### PR TITLE
adds the ability to not autodetect the bmp if needed by the end user

### DIFF
--- a/spinn_front_end_common/interface/front_end_common_interface_functions.py
+++ b/spinn_front_end_common/interface/front_end_common_interface_functions.py
@@ -86,7 +86,7 @@ class FrontEndCommonInterfaceFunctions(object):
     def setup_interfaces(
             self, hostname, bmp_details, downed_chips, downed_cores,
             board_version, number_of_boards, width, height,
-            is_virtual, virtual_has_wrap_arounds):
+            is_virtual, virtual_has_wrap_arounds, auto_detect_bmp=True):
         """
         Set up the interfaces for communicating with the SpiNNaker board
         :param hostname: the hostname or ip address of the spinnaker machine
@@ -104,6 +104,8 @@ class FrontEndCommonInterfaceFunctions(object):
                 True, the width and height are used as the machine dimensions
         :param virtual_has_wrap_arounds: True if the machine is virtual and\
                 should be created with wrap_arounds
+        :param auto_detect_bmp: boolean which determines if the bmp should
+               be automatically determined
         :return: None
         """
 
@@ -118,7 +120,8 @@ class FrontEndCommonInterfaceFunctions(object):
             self._txrx = create_transceiver_from_hostname(
                 hostname=hostname, bmp_connection_data=bmp_connection_data,
                 version=board_version, ignore_chips=ignored_chips,
-                ignore_cores=ignored_cores, number_of_boards=number_of_boards)
+                ignore_cores=ignored_cores, number_of_boards=number_of_boards,
+                auto_detect_bmp=auto_detect_bmp)
 
             # update number of boards from machine
             if number_of_boards is None:
@@ -137,7 +140,7 @@ class FrontEndCommonInterfaceFunctions(object):
                 self._reload_script = ReloadScript(
                     self._app_data_folder, hostname, board_version,
                     bmp_details, downed_chips, downed_cores, number_of_boards,
-                    height, width)
+                    height, width, auto_detect_bmp)
         else:
             self._machine = VirtualMachine(
                 width=width, height=height,

--- a/spinn_front_end_common/utilities/reload/reload.py
+++ b/spinn_front_end_common/utilities/reload/reload.py
@@ -19,12 +19,13 @@ class Reload(object):
 
     def __init__(self, machine_name, version, reports_states, bmp_details,
                  down_chips, down_cores, number_of_boards, height, width,
-                 app_id=30):
+                 auto_detect_bmp, app_id=30):
         self._spinnaker_interface = \
             FrontEndCommonInterfaceFunctions(reports_states, None, None)
         self._spinnaker_interface.setup_interfaces(
             machine_name, bmp_details, down_chips, down_cores,
-            version, number_of_boards, width, height, False, False)
+            version, number_of_boards, width, height, False, False,
+            auto_detect_bmp)
         self._app_id = app_id
         self._reports_states = reports_states
         self._total_processors = 0

--- a/spinn_front_end_common/utilities/reload/reload_script.py
+++ b/spinn_front_end_common/utilities/reload/reload_script.py
@@ -20,12 +20,13 @@ class ReloadScript(object):
 
     def __init__(self, binary_directory, hostname, board_version,
                  bmp_details, down_chips, down_cores, number_of_boards,
-                 height, width):
+                 height, width, auto_detect_bmp):
         self._binary_directory = binary_directory
         self._wait_on_confiramtion = None
         self._runtime = None
         self._time_scale_factor = None
         self._buffer_vertex_file_names = dict()
+        self._auto_detect_bmp = auto_detect_bmp
         if not self._binary_directory.endswith(os.sep):
             self._binary_directory += os.sep
 
@@ -241,7 +242,8 @@ class ReloadScript(object):
         self._println("")
         self._println("reloader = Reload(machine_name, machine_version, "
                       "reports_states, bmp_details, down_chips, down_cores, "
-                      "number_of_boards, height, width)")
+                      "number_of_boards, height, width, {})"
+                      .format(self._auto_detect_bmp))
         self._println("if len(socket_addresses) > 0:")
         # note that this needs to be added into the script, as it needs to
         # be able to find its database no matter where it is or where its

--- a/spinn_front_end_common/utilities/reload/reload_script.py
+++ b/spinn_front_end_common/utilities/reload/reload_script.py
@@ -25,7 +25,6 @@ class ReloadScript(object):
         self._wait_on_confiramtion = None
         self._runtime = None
         self._time_scale_factor = None
-        self._auto_detect_bmp = auto_detect_bmp
         if not self._binary_directory.endswith(os.sep):
             self._binary_directory += os.sep
 
@@ -49,6 +48,7 @@ class ReloadScript(object):
         self._println("number_of_boards = {}".format(number_of_boards))
         self._println("height = {}".format(height))
         self._println("width = {}".format(width))
+        self._println("auto_detect_bmp = {}".format(auto_detect_bmp))
 
     @property
     def wait_on_confirmation(self):
@@ -240,8 +240,7 @@ class ReloadScript(object):
         self._println("")
         self._println("reloader = Reload(machine_name, machine_version, "
                       "reports_states, bmp_details, down_chips, down_cores, "
-                      "number_of_boards, height, width, {})"
-                      .format(self._auto_detect_bmp))
+                      "number_of_boards, height, width, auto_detect_bmp)")
         self._println("if len(socket_addresses) > 0:")
         # note that this needs to be added into the script, as it needs to
         # be able to find its database no matter where it is or where its


### PR DESCRIPTION
fix to allow spinn-4 / spinn-5 boards with no bmp to work