### PR TITLE
Reverse ip tag partitioned fixes

### DIFF
--- a/c_common/front_end_common_lib/Makefile.SpiNNFrontEndCommon
+++ b/c_common/front_end_common_lib/Makefile.SpiNNFrontEndCommon
@@ -28,14 +28,12 @@ $(foreach dir, $(SOURCE_DIRS), $(eval $(call define-build-code,$(dir))))
 OBJECTS += $(OBJS)
 
 LIBRARIES += -lspinn_frontend_common -lspinn_common -lm
-ifndef DEBUG
-    DEBUG = PRODUCTION_CODE
-endif
+FEC_DEBUG := PRODUCTION_CODE
 # Run md5sum on application name and extract first 8 bytes
 SHELL = bash
 APPLICATION_NAME_HASH = $(shell echo -n "$(APP)" | md5sum | cut -c 1-8)
 
-CFLAGS += -Wall -Wextra -D$(DEBUG) $(OTIME) -DAPPLICATION_NAME_HASH=0x$(APPLICATION_NAME_HASH)
+CFLAGS += -Wall -Wextra -D$(FEC_DEBUG) $(OTIME) -DAPPLICATION_NAME_HASH=0x$(APPLICATION_NAME_HASH)
 
 include $(SPINN_DIRS)/make/Makefile.common
 

--- a/c_common/models/reverse_iptag_multicast_source/reverse_iptag_multicast_source.c
+++ b/c_common/models/reverse_iptag_multicast_source/reverse_iptag_multicast_source.c
@@ -108,6 +108,7 @@ static uint8_t return_tag_id;
 static uint32_t last_space;
 static uint32_t last_request_tick;
 
+static bool stopped = false;
 
 static inline uint16_t calculate_eieio_packet_command_size(
         eieio_msg_t eieio_msg_ptr) {
@@ -433,12 +434,12 @@ static inline void process_16_bit_packets(
         if (has_key) {
             if (!check || (check && ((key & mask) == key_space))) {
                 if (pkt_has_payload && !pkt_payload_is_timestamp) {
-                    log_debug("mc packet 16-bit key=%d", key);
+                    log_info("mc packet 16-bit key=%d", key);
                     while (!spin1_send_mc_packet(key, payload, WITH_PAYLOAD)) {
                         spin1_delay_us(1);
                     }
                 } else {
-                    log_debug(
+                    log_info(
                         "mc packet 16-bit key=%d, payload=%d", key, payload);
                     while (!spin1_send_mc_packet(key, 0, NO_PAYLOAD)) {
                         spin1_delay_us(1);
@@ -483,12 +484,12 @@ static inline void process_32_bit_packets(
         if (has_key) {
             if (!check || (check && ((key & mask) == key_space))) {
                 if (pkt_has_payload && !pkt_payload_is_timestamp) {
-                    log_debug("mc packet 32-bit key=0x%08x", key);
+                    log_info("mc packet 32-bit key=0x%08x", key);
                     while (!spin1_send_mc_packet(key, payload, WITH_PAYLOAD)) {
                         spin1_delay_us(1);
                     }
                 } else {
-                    log_debug("mc packet 32-bit key=0x%08x, payload=0x%08x",
+                    log_info("mc packet 32-bit key=0x%08x, payload=0x%08x",
                               key, payload);
                     while (!spin1_send_mc_packet(key, 0, NO_PAYLOAD)) {
                         spin1_delay_us(1);
@@ -696,7 +697,7 @@ static inline bool eieio_commmand_parse_packet(eieio_msg_t eieio_msg_ptr,
 
     case EVENT_STOP_COMMANDS:
         log_debug("command: EVENT_STOP");
-        time = simulation_ticks + 1;
+        stopped = true;
         write_pointer = read_pointer;
         break;
 
@@ -985,6 +986,8 @@ void resume_callback() {
     if(!initialise_recording()){
         log_error("Could not reset recording regions");
     }
+
+    stopped = false;
 }
 
 void timer_callback(uint unused0, uint unused1) {
@@ -992,11 +995,11 @@ void timer_callback(uint unused0, uint unused1) {
     use(unused1);
     time++;
 
-    log_debug("timer_callback, final time: %d, current time: %d,"
+    log_info("timer_callback, final time: %d, current time: %d,"
               "next packet buffer time: %d", simulation_ticks, time,
               next_buffer_time);
 
-    if ((infinite_run != TRUE) && (time >= simulation_ticks + 1)) {
+    if (stopped || ((infinite_run != TRUE) && (time >= simulation_ticks))) {
 
         // Enter pause and resume state to avoid another tick
         simulation_handle_pause_resume(resume_callback);

--- a/c_common/models/reverse_iptag_multicast_source/reverse_iptag_multicast_source.c
+++ b/c_common/models/reverse_iptag_multicast_source/reverse_iptag_multicast_source.c
@@ -434,13 +434,14 @@ static inline void process_16_bit_packets(
         if (has_key) {
             if (!check || (check && ((key & mask) == key_space))) {
                 if (pkt_has_payload && !pkt_payload_is_timestamp) {
-                    log_info("mc packet 16-bit key=%d", key);
+                    log_debug(
+                        "mc packet 16-bit key=%d, payload=%d", key, payload);
                     while (!spin1_send_mc_packet(key, payload, WITH_PAYLOAD)) {
                         spin1_delay_us(1);
                     }
                 } else {
-                    log_info(
-                        "mc packet 16-bit key=%d, payload=%d", key, payload);
+                    log_debug(
+                        "mc packet 16-bit key=%d", key);
                     while (!spin1_send_mc_packet(key, 0, NO_PAYLOAD)) {
                         spin1_delay_us(1);
                     }
@@ -484,13 +485,14 @@ static inline void process_32_bit_packets(
         if (has_key) {
             if (!check || (check && ((key & mask) == key_space))) {
                 if (pkt_has_payload && !pkt_payload_is_timestamp) {
-                    log_info("mc packet 32-bit key=0x%08x", key);
+                    log_debug(
+                        "mc packet 32-bit key=0x%08x , payload=0x%08x",
+                        key, payload);
                     while (!spin1_send_mc_packet(key, payload, WITH_PAYLOAD)) {
                         spin1_delay_us(1);
                     }
                 } else {
-                    log_info("mc packet 32-bit key=0x%08x, payload=0x%08x",
-                              key, payload);
+                    log_debug("mc packet 32-bit key=0x%08x", key);
                     while (!spin1_send_mc_packet(key, 0, NO_PAYLOAD)) {
                         spin1_delay_us(1);
                     }
@@ -995,7 +997,7 @@ void timer_callback(uint unused0, uint unused1) {
     use(unused1);
     time++;
 
-    log_info("timer_callback, final time: %d, current time: %d,"
+    log_debug("timer_callback, final time: %d, current time: %d,"
               "next packet buffer time: %d", simulation_ticks, time,
               next_buffer_time);
 

--- a/spinn_front_end_common/interface/interface_functions/front_end_common_partitioned_graph_data_specification_writer.py
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_partitioned_graph_data_specification_writer.py
@@ -79,10 +79,7 @@ class FrontEndCommonPartitionedGraphDataSpecificationWriter(object):
                     app_data_runtime_folder)
 
                 # link dsg file to subvertex
-                mapping_key = \
-                    placement.x, placement.y, placement.p, \
-                    placement.subvertex.label
-                dsg_targets[mapping_key] = file_path
+                dsg_targets[placement.x, placement.y, placement.p] = file_path
 
                 progress_bar.update()
 

--- a/spinn_front_end_common/utility_models/reverse_ip_tag_multi_cast_source.py
+++ b/spinn_front_end_common/utility_models/reverse_ip_tag_multi_cast_source.py
@@ -183,32 +183,10 @@ class ReverseIpTagMultiCastSource(
             get_outgoing_partition_constraints(partition, graph_mapper)
 
     def get_sdram_usage_for_atoms(self, vertex_slice, graph):
-        send_buffer_size = 0
-        if self._send_buffer_times is not None:
-            send_buffer_size = self._send_buffer_max_space
-
-        recording_size = (ReverseIPTagMulticastSourcePartitionedVertex
-                          .get_recording_data_size(1))
-        if self._recording_enabled:
-            if self._using_auto_pause_and_resume:
-                recording_size += self._minimum_sdram_for_buffering
-            else:
-                recording_size += self._record_buffer_size
-                recording_size += (
-                    ReverseIPTagMulticastSourcePartitionedVertex.
-                    get_buffer_state_region_size(1))
-        mallocs = \
-            ReverseIPTagMulticastSourcePartitionedVertex.n_regions_to_allocate(
-                self._send_buffer_times is not None, self._recording_enabled)
-        allocation_size = mallocs * constants.SARK_PER_MALLOC_SDRAM_USAGE
-
-        return (
-            (constants.DATA_SPECABLE_BASIC_SETUP_INFO_N_WORDS * 4) +
-            (ReverseIPTagMulticastSourcePartitionedVertex.
-                _CONFIGURATION_REGION_SIZE) +
-            send_buffer_size + recording_size + allocation_size +
-            (ReverseIPTagMulticastSourcePartitionedVertex.
-                get_provenance_data_size(0)))
+        return ReverseIPTagMulticastSourcePartitionedVertex.get_sdram_usage(
+            self._send_buffer_times, self._send_buffer_max_space,
+            self._recording_enabled, self._using_auto_pause_and_resume,
+            self._minimum_sdram_for_buffering, self._record_buffer_size)
 
     @property
     def model_name(self):
@@ -245,7 +223,7 @@ class ReverseIpTagMultiCastSource(
                 send_buffer_times = self._send_buffer_times[
                     vertex_slice.lo_atom:vertex_slice.hi_atom + 1]
         subvertex = ReverseIPTagMulticastSourcePartitionedVertex(
-            n_keys=vertex_slice.n_atoms, resources_required=resources_required,
+            n_keys=vertex_slice.n_atoms,
             machine_time_step=self._machine_time_step,
             timescale_factor=self._timescale_factor, label=label,
             constraints=constraints,

--- a/spinn_front_end_common/utility_models/reverse_ip_tag_multi_cast_source.py
+++ b/spinn_front_end_common/utility_models/reverse_ip_tag_multi_cast_source.py
@@ -210,8 +210,8 @@ class ReverseIpTagMultiCastSource(
             write_text_specs, application_run_time_folder):
 
         return subvertex.generate_data_spec(
-            subvertex, placement, sub_graph, graph, routing_info,
-            hostname, graph_mapper, report_folder, ip_tags, reverse_ip_tags,
+            placement, sub_graph, routing_info,
+            hostname, report_folder, ip_tags, reverse_ip_tags,
             write_text_specs, application_run_time_folder)
 
     def create_subvertex(self, vertex_slice, resources_required, label=None,

--- a/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_partitioned_vertex.py
+++ b/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_partitioned_vertex.py
@@ -311,7 +311,7 @@ class ReverseIPTagMulticastSourcePartitionedVertex(
     def _is_in_range(self, time_stamp_in_ticks):
         return (
             (self._no_machine_time_steps is None) or (
-                self._first_machine_time_step <= time_stamp_in_ticks <=
+                self._first_machine_time_step <= time_stamp_in_ticks <
                 self._no_machine_time_steps))
 
     def _fill_send_buffer(self):

--- a/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_partitioned_vertex.py
+++ b/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_partitioned_vertex.py
@@ -141,7 +141,7 @@ class ReverseIPTagMulticastSourcePartitionedVertex(
 
         # Set up super types
         PartitionedVertex.__init__(
-            self, None,
+            self, self.generate_resources_required(),
             label, constraints)
         AbstractPartitionedDataSpecableVertex.__init__(
             self, machine_time_step, timescale_factor)
@@ -239,7 +239,7 @@ class ReverseIPTagMulticastSourcePartitionedVertex(
                 self._prefix = self._virtual_key
 
     @property
-    def resources_required(self):
+    def generate_resources_required(self):
         return ResourceContainer(
             DTCMResource(1),
             SDRAMResource(self.get_sdram_usage(

--- a/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_partitioned_vertex.py
+++ b/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_partitioned_vertex.py
@@ -30,8 +30,9 @@ from spinn_front_end_common.abstract_models\
     import AbstractProvidesOutgoingPartitionConstraints
 from spinn_front_end_common.abstract_models.abstract_recordable \
     import AbstractRecordable
-from spinn_front_end_common.abstract_models.abstract_data_specable_vertex \
-    import AbstractDataSpecableVertex
+from spinn_front_end_common.abstract_models\
+    .abstract_partitioned_data_specable_vertex \
+    import AbstractPartitionedDataSpecableVertex
 from spinn_front_end_common.interface.provenance\
     .provides_provenance_data_from_machine_impl import \
     ProvidesProvenanceDataFromMachineImpl
@@ -49,7 +50,8 @@ _DEFAULT_MALLOC_REGIONS = 2
 
 class ReverseIPTagMulticastSourcePartitionedVertex(
         PartitionedVertex,
-        AbstractDataSpecableVertex, ProvidesProvenanceDataFromMachineImpl,
+        AbstractPartitionedDataSpecableVertex,
+        ProvidesProvenanceDataFromMachineImpl,
         AbstractProvidesOutgoingPartitionConstraints,
         SendsBuffersFromHostPreBufferedImpl,
         ReceiveBuffersToHostBasicImpl,
@@ -141,7 +143,7 @@ class ReverseIPTagMulticastSourcePartitionedVertex(
         PartitionedVertex.__init__(
             self, None,
             label, constraints)
-        AbstractDataSpecableVertex.__init__(
+        AbstractPartitionedDataSpecableVertex.__init__(
             self, machine_time_step, timescale_factor)
         ProvidesProvenanceDataFromMachineImpl.__init__(
             self, self._REGIONS.PROVENANCE_REGION.value, 0)
@@ -238,14 +240,14 @@ class ReverseIPTagMulticastSourcePartitionedVertex(
 
     @property
     def resources_required(self):
-        ResourceContainer(
+        return ResourceContainer(
             DTCMResource(1),
             SDRAMResource(self.get_sdram_usage(
                 self._send_buffer_times, self._send_buffer_max_space,
                 self._record_buffer_size > 0,
                 self._buffered_sdram_per_timestep > 0,
                 self._minimum_sdram_for_buffering, self._record_buffer_size)),
-            CPUCyclesPerTickResource(1)),
+            CPUCyclesPerTickResource(1))
 
     @staticmethod
     def get_sdram_usage(
@@ -476,9 +478,9 @@ class ReverseIPTagMulticastSourcePartitionedVertex(
             spec.write_value(data=0)
 
     def generate_data_spec(
-            self, subvertex, placement, sub_graph, graph, routing_info,
-            hostname, graph_subgraph_mapper, report_folder, ip_tags,
-            reverse_ip_tags, write_text_specs, application_run_time_folder):
+            self, placement, sub_graph, routing_info,
+            hostname, report_folder, ip_tags, reverse_ip_tags,
+            write_text_specs, application_run_time_folder):
 
         # Create new DataSpec for this processor:
         data_writer, report_writer = \
@@ -519,7 +521,7 @@ class ReverseIPTagMulticastSourcePartitionedVertex(
                 [BaseKeyAndMask(self._virtual_key, self._mask)])])
         return list()
 
-    def is_data_specable(self):
+    def is_partitioned_data_specable(self):
         return True
 
     @property


### PR DESCRIPTION
Allows reverse ip tag multicast source to work as a partitioned vertex more smoothly.
 - [x] Wait for merge of #51