### PR TITLE
Fix board addresses

### DIFF
--- a/c_common/front_end_common_lib/src/recording.c
+++ b/c_common/front_end_common_lib/src/recording.c
@@ -17,6 +17,7 @@
 enum recording_data_e {
     N_REGIONS,
     TAG,
+    TAG_DESTINATION,
     SDP_PORT,
     BUFFER_SIZE_BEFORE_REQUEST,
     TIME_BETWEEN_TRIGGERS,
@@ -453,6 +454,7 @@ bool recording_initialize(
     // Read in the parameters
     n_recording_regions = recording_data_address[N_REGIONS];
     uint8_t buffering_output_tag = recording_data_address[TAG];
+    uint32_t buffering_destination = recording_data_address[TAG_DESTINATION];
     sdp_port = recording_data_address[SDP_PORT];
     buffer_size_before_trigger =
         recording_data_address[BUFFER_SIZE_BEFORE_REQUEST];
@@ -531,7 +533,7 @@ bool recording_initialize(
     msg.tag = buffering_output_tag;
     msg.dest_port = 0xFF;
     msg.srce_port = (sdp_port << 5) | spin1_get_core_id();
-    msg.dest_addr = 0;
+    msg.dest_addr = buffering_destination;
     msg.srce_addr = spin1_get_chip_id();
 
     return true;

--- a/c_common/models/live_packet_gather/live_packet_gather.c
+++ b/c_common/models/live_packet_gather/live_packet_gather.c
@@ -64,6 +64,7 @@ static uint32_t payload_prefix;
 // Right payload shift (for the sender)
 static uint32_t payload_right_shift;
 static uint32_t sdp_tag;
+static uint32_t sdp_dest;
 static uint32_t packets_per_timestamp;
 
 //! human readable definitions of each region in SDRAM
@@ -86,6 +87,7 @@ typedef enum configuration_region_components_e {
     PAYLOAD_PREFIX,
     PAYLOAD_RIGHT_SHIFT,
     SDP_TAG,
+    SDP_DEST,
     PACKETS_PER_TIMESTEP
 } configuration_region_components_e;
 
@@ -371,6 +373,7 @@ void read_parameters(address_t region_address) {
     // Right payload shift (for the sender)
     payload_right_shift = region_address[PAYLOAD_RIGHT_SHIFT];
     sdp_tag = region_address[SDP_TAG];
+    sdp_dest = region_address[SDP_DEST];
     packets_per_timestamp = region_address[PACKETS_PER_TIMESTEP];
 
     log_info("apply_prefix: %d\n", apply_prefix);
@@ -383,6 +386,7 @@ void read_parameters(address_t region_address) {
     log_info("payload_prefix: %08x\n", payload_prefix);
     log_info("payload_right_shift: %d\n", payload_right_shift);
     log_info("sdp_tag: %d\n", sdp_tag);
+    log_info("sdp_dest: 0x%08x\n", sdp_dest);
     log_info("packets_per_timestamp: %d\n", packets_per_timestamp);
 }
 
@@ -432,7 +436,7 @@ bool configure_sdp_msg(void) {
     g_event_message.flags = 0x07;
 
     // Chip 0,0
-    g_event_message.dest_addr = 0;
+    g_event_message.dest_addr = sdp_dest;
 
     // Dump through Ethernet
     g_event_message.dest_port = PORT_ETH;

--- a/c_common/models/reverse_iptag_multicast_source/reverse_iptag_multicast_source.c
+++ b/c_common/models/reverse_iptag_multicast_source/reverse_iptag_multicast_source.c
@@ -32,7 +32,7 @@ typedef enum eieio_prefix_types {
 typedef enum read_in_parameters{
     APPLY_PREFIX, PREFIX, PREFIX_TYPE, CHECK_KEYS, HAS_KEY, KEY_SPACE, MASK,
     BUFFER_REGION_SIZE, SPACE_BEFORE_DATA_REQUEST, RETURN_TAG_ID,
-    BUFFERED_IN_SDP_PORT
+    RETURN_TAG_DEST, BUFFERED_IN_SDP_PORT
 } read_in_parameters;
 
 //! The memory regions
@@ -110,6 +110,7 @@ static uint8_t pkt_last_sequence_seen;
 static bool send_packet_reqs;
 static bool last_buffer_operation;
 static uint8_t return_tag_id;
+static uint32_t return_tag_dest;
 static uint32_t buffered_in_sdp_port;
 static uint32_t last_space;
 static uint32_t last_request_tick;
@@ -851,6 +852,7 @@ bool read_parameters(address_t region_address) {
     buffer_region_size = region_address[BUFFER_REGION_SIZE];
     space_before_data_request = region_address[SPACE_BEFORE_DATA_REQUEST];
     return_tag_id = region_address[RETURN_TAG_ID];
+    return_tag_dest = region_address[RETURN_TAG_DEST];
     buffered_in_sdp_port = region_address[BUFFERED_IN_SDP_PORT];
 
     // There is no point in sending requests until there is space for
@@ -882,7 +884,7 @@ bool read_parameters(address_t region_address) {
     req.tag = return_tag_id;
     req.dest_port = 0xFF;
     req.srce_port = (1 << 5) | spin1_get_core_id();
-    req.dest_addr = 0;
+    req.dest_addr = return_tag_dest;
     req.srce_addr = spin1_get_chip_id();
     req_ptr = (req_packet_sdp_t*) &(req.cmd_rc);
     req_ptr->eieio_header_command = 1 << 14 | SPINNAKER_REQUEST_BUFFERS;
@@ -899,6 +901,7 @@ bool read_parameters(address_t region_address) {
     log_info("mask: 0x%08x", mask);
     log_info("space_before_read_request: %d", space_before_data_request);
     log_info("return_tag_id: %d", return_tag_id);
+    log_info("return_tag_dest: 0x%08x", return_tag_dest);
 
     return true;
 }

--- a/spinn_front_end_common/interface/buffer_management/recording_utilities.py
+++ b/spinn_front_end_common/interface/buffer_management/recording_utilities.py
@@ -11,10 +11,10 @@ import sys
 import math
 
 # The offset of the last sequence number field in bytes
-_LAST_SEQUENCE_NUMBER_OFFSET = 4 * 5
+_LAST_SEQUENCE_NUMBER_OFFSET = 4 * 6
 
 # The offset of the memory addresses in bytes
-_FIRST_REGION_ADDRESS_OFFSET = 4 * 6
+_FIRST_REGION_ADDRESS_OFFSET = 4 * 7
 
 # The Buffer traffic type
 TRAFFIC_IDENTIFIER = "BufferTraffic"
@@ -27,7 +27,7 @@ def get_recording_header_size(n_recorded_regions):
     """
 
     # See recording.h/recording_initialise for data included in the header
-    return (6 + (2 * n_recorded_regions)) * 4
+    return (7 + (2 * n_recorded_regions)) * 4
 
 
 def get_recording_data_size(recorded_region_sizes):
@@ -215,6 +215,8 @@ def get_recording_header_array(
 
     # Find the tag if required
     buffering_output_tag = 0
+    buffering_output_dest_x = 0
+    buffering_output_dest_y = 0
     if buffering_tag is not None:
         buffering_output_tag = buffering_tag
     elif ip_tags is not None and len(ip_tags) > 0:
@@ -222,6 +224,8 @@ def get_recording_header_array(
         for tag in ip_tags:
             if tag.traffic_identifier == TRAFFIC_IDENTIFIER:
                 buffering_output_tag = tag.tag
+                buffering_output_dest_x = tag.destination_x
+                buffering_output_dest_y = tag.destination_y
                 break
         if buffering_output_tag is None:
             raise Exception("Buffering tag not found")
@@ -232,6 +236,8 @@ def get_recording_header_array(
     # The parameters
     data.append(len(recorded_region_sizes))
     data.append(buffering_output_tag)
+    data.append(struct.pack(
+        "<HH", buffering_output_dest_y, buffering_output_dest_x))
     data.append(constants.SDP_PORTS.OUTPUT_BUFFERING_SDP_PORT.value)
     if buffer_size_before_request is not None:
         data.append(buffer_size_before_request)

--- a/spinn_front_end_common/interface/buffer_management/recording_utilities.py
+++ b/spinn_front_end_common/interface/buffer_management/recording_utilities.py
@@ -16,6 +16,10 @@ _LAST_SEQUENCE_NUMBER_OFFSET = 4 * 6
 # The offset of the memory addresses in bytes
 _FIRST_REGION_ADDRESS_OFFSET = 4 * 7
 
+# the number of data elements inside the recording region before
+# recording regions iszes are stored.
+_RECORDING_ELEMENTS_BEFORE_REGION_SIZES = 7
+
 # The Buffer traffic type
 TRAFFIC_IDENTIFIER = "BufferTraffic"
 
@@ -27,7 +31,8 @@ def get_recording_header_size(n_recorded_regions):
     """
 
     # See recording.h/recording_initialise for data included in the header
-    return (7 + (2 * n_recorded_regions)) * 4
+    return (_RECORDING_ELEMENTS_BEFORE_REGION_SIZES +
+            (2 * n_recorded_regions)) * 4
 
 
 def get_recording_data_size(recorded_region_sizes):

--- a/spinn_front_end_common/interface/buffer_management/recording_utilities.py
+++ b/spinn_front_end_common/interface/buffer_management/recording_utilities.py
@@ -236,8 +236,8 @@ def get_recording_header_array(
     # The parameters
     data.append(len(recorded_region_sizes))
     data.append(buffering_output_tag)
-    data.append(struct.pack(
-        "<HH", buffering_output_dest_y, buffering_output_dest_x))
+    data.append(struct.unpack("<I", struct.pack(
+        "<HH", buffering_output_dest_y, buffering_output_dest_x))[0])
     data.append(constants.SDP_PORTS.OUTPUT_BUFFERING_SDP_PORT.value)
     if buffer_size_before_request is not None:
         data.append(buffer_size_before_request)

--- a/spinn_front_end_common/utilities/reload/reload_script.py
+++ b/spinn_front_end_common/utilities/reload/reload_script.py
@@ -202,9 +202,9 @@ class ReloadScript(object):
         else:
             board_address = "\"{}\"".format(iptag.board_address)
         self._println("iptags.append(")
-        self._println("    IPTag({}, {}, \"{}\", {}, {})) ".format(
-            board_address, iptag.tag, iptag.ip_address, iptag.port,
-            iptag.strip_sdp))
+        self._println("    IPTag(\"{}\", {}, {}, {}, \"{}\", {}, {})) ".format(
+            board_address, iptag.destination_x, iptag.destination_y, iptag.tag,
+            iptag.ip_address, iptag.port, iptag.strip_sdp))
 
     def add_reverse_ip_tag(self, reverse_ip_tag):
         """ Add a reverse ip tag to be reloaded
@@ -218,7 +218,7 @@ class ReloadScript(object):
         else:
             board_address = "\"{}\"".format(reverse_ip_tag.board_address)
         self._println("reverse_iptags.append(")
-        self._println("    ReverseIPTag({}, {}, {}, {}, {}, {}))".format(
+        self._println("    ReverseIPTag(\"{}\", {}, {}, {}, {}, {}))".format(
             board_address, reverse_ip_tag.tag,
             reverse_ip_tag.port, reverse_ip_tag.destination_x,
             reverse_ip_tag.destination_y, reverse_ip_tag.destination_p,
@@ -250,9 +250,10 @@ class ReloadScript(object):
         self._println("    Placement(vertex, {}, {}, {}))".format(
             placement.x, placement.y, placement.p))
         self._println("buffered_tags.add_ip_tag(")
-        self._println("    IPTag(\"{}\", {}, \"{}\", {}, {}), vertex)".format(
-            iptag.board_address, iptag.tag, iptag.ip_address,
-            iptag.port, iptag.strip_sdp))
+        self._println(
+            "    IPTag(\"{}\", {}, {}, {}, \"{}\", {}, {}), vertex)".format(
+                iptag.board_address, iptag.destination_x, iptag.destination_y,
+                iptag.tag, iptag.ip_address, iptag.port, iptag.strip_sdp))
 
     def add_dsg_target(self, x, y, p, file_path):
         """ Add a Data Specification Generated file to be reloaded

--- a/spinn_front_end_common/utility_models/live_packet_gather_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/live_packet_gather_machine_vertex.py
@@ -22,9 +22,9 @@ from spinn_front_end_common.interface.simulation import simulation_utilities
 from spinn_front_end_common.abstract_models\
     .abstract_generates_data_specification \
     import AbstractGeneratesDataSpecification
-from spinn_front_end_common.abstract_models\
-    .abstract_binary_uses_simulation_run import AbstractBinaryUsesSimulationRun
-import struct
+from spinn_front_end_common.abstract_models \
+    .abstract_binary_uses_simulation_run import \
+    AbstractBinaryUsesSimulationRun
 from spinn_front_end_common.abstract_models.abstract_has_associated_binary \
     import AbstractHasAssociatedBinary
 from spinn_front_end_common.utilities.utility_objs.provenance_data_item \
@@ -34,6 +34,7 @@ from spinn_front_end_common.utilities import constants
 from spinnman.messages.eieio.eieio_type import EIEIOType
 
 from enum import Enum
+import struct
 
 
 class LivePacketGatherMachineVertex(

--- a/spinn_front_end_common/utility_models/live_packet_gather_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/live_packet_gather_machine_vertex.py
@@ -24,6 +24,7 @@ from spinn_front_end_common.abstract_models\
     import AbstractGeneratesDataSpecification
 from spinn_front_end_common.abstract_models\
     .abstract_binary_uses_simulation_run import AbstractBinaryUsesSimulationRun
+import struct
 from spinn_front_end_common.abstract_models.abstract_has_associated_binary \
     import AbstractHasAssociatedBinary
 from spinn_front_end_common.utilities.utility_objs.provenance_data_item \
@@ -47,7 +48,7 @@ class LivePacketGatherMachineVertex(
                ('PROVENANCE', 2)])
 
     N_ADDITIONAL_PROVENANCE_ITEMS = 2
-    _CONFIG_SIZE = 44
+    _CONFIG_SIZE = 48
     _PROVENANCE_REGION_SIZE = 8
 
     def __init__(
@@ -258,6 +259,8 @@ class LivePacketGatherMachineVertex(
         # SDP tag
         iptag = iter(iptags).next()
         spec.write_value(data=iptag.tag)
+        spec.write_value(struct.pack(
+            "<HH", iptag.destination_chip_y, iptag.destination_chip_x))
 
         # number of packets to send per time stamp
         spec.write_value(data=self._number_of_packets_sent_per_time_step)

--- a/spinn_front_end_common/utility_models/live_packet_gather_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/live_packet_gather_machine_vertex.py
@@ -259,8 +259,8 @@ class LivePacketGatherMachineVertex(
         # SDP tag
         iptag = iter(iptags).next()
         spec.write_value(data=iptag.tag)
-        spec.write_value(struct.pack(
-            "<HH", iptag.destination_chip_y, iptag.destination_chip_x))
+        spec.write_value(struct.unpack("<I", struct.pack(
+            "<HH", iptag.destination_y, iptag.destination_x))[0])
 
         # number of packets to send per time stamp
         spec.write_value(data=self._number_of_packets_sent_per_time_step)

--- a/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
@@ -552,9 +552,8 @@ class ReverseIPTagMulticastSourceMachineVertex(
             spec.write_value(data=buffer_space)
             spec.write_value(data=self._send_buffer_space_before_notify)
             spec.write_value(data=this_tag.tag)
-            spec.write_value(struct.pack(
-                "<HH", this_tag.destination_chip_y,
-                this_tag.destination_chip_x))
+            spec.write_value(struct.unpack("<I", struct.pack(
+                "<HH", this_tag.destination_y, this_tag.destination_x))[0])
         else:
             spec.write_value(data=0)
             spec.write_value(data=0)

--- a/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
@@ -14,6 +14,7 @@ from pacman.model.decorators.delegates_to import delegates_to
 from pacman.model.resources.resource_container import ResourceContainer
 from pacman.model.resources.dtcm_resource import DTCMResource
 from pacman.model.resources.sdram_resource import SDRAMResource
+import struct
 from pacman.model.resources.cpu_cycles_per_tick_resource \
     import CPUCyclesPerTickResource
 from pacman.model.abstract_classes.impl.constrained_object \
@@ -84,11 +85,11 @@ class ReverseIPTagMulticastSourceMachineVertex(
                ('SEND_BUFFER', 3),
                ('PROVENANCE_REGION', 4)])
 
-    # 11 ints (1, has prefix, 2, prefix, 3, prefix type, 4, check key flag,
-    #          5, has key, 6, key, 7, mask, 8, buffer space,
-    #          9, send buffer flag before notify, 10, tag,
-    #          11. receive SDP port)
-    _CONFIGURATION_REGION_SIZE = 11 * 4
+    # 12 ints (1. has prefix, 2. prefix, 3. prefix type, 4. check key flag,
+    #          5. has key, 6. key, 7. mask, 8. buffer space,
+    #          9. send buffer flag before notify, 10. tag,
+    #          11. tag destination (y, x), 12. receive SDP port)
+    _CONFIGURATION_REGION_SIZE = 12 * 4
 
     def __init__(
             self, n_keys, label, constraints=None,
@@ -551,7 +552,11 @@ class ReverseIPTagMulticastSourceMachineVertex(
             spec.write_value(data=buffer_space)
             spec.write_value(data=self._send_buffer_space_before_notify)
             spec.write_value(data=this_tag.tag)
+            spec.write_value(struct.pack(
+                "<HH", this_tag.destination_chip_y,
+                this_tag.destination_chip_x))
         else:
+            spec.write_value(data=0)
             spec.write_value(data=0)
             spec.write_value(data=0)
             spec.write_value(data=0)

--- a/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
@@ -14,7 +14,6 @@ from pacman.model.decorators.delegates_to import delegates_to
 from pacman.model.resources.resource_container import ResourceContainer
 from pacman.model.resources.dtcm_resource import DTCMResource
 from pacman.model.resources.sdram_resource import SDRAMResource
-import struct
 from pacman.model.resources.cpu_cycles_per_tick_resource \
     import CPUCyclesPerTickResource
 from pacman.model.abstract_classes.impl.constrained_object \
@@ -60,6 +59,7 @@ from spinnman.messages.eieio.eieio_prefix import EIEIOPrefix
 from enum import Enum
 import math
 import sys
+import struct
 
 _DEFAULT_MALLOC_REGIONS = 2
 
@@ -430,15 +430,6 @@ class ReverseIPTagMulticastSourceMachineVertex(
             time_between_triggers=0):
         """ Enable recording of the keys sent
 
-        :param buffering_ip_address:\
-            The ip address to receive buffer notification messages on
-        :type buffering_ip_address: str
-        :param buffering_port:\
-            The port to receive buffer notification messages on
-        :type buffering_port: int
-        :param notification_tag:\
-            The tag to send buffer notification messages to
-        :type notification_tag: int
         :param record_buffer_size:\
             The size of the recording buffer in bytes.  Note that when using\
             automatic pause and resume, this will be used as the minimum size\


### PR DESCRIPTION
Use the chip coordinates from the IP Tag to direct SDP packets at the appropriate Ethernet chip in multi-board systems.

- [x] Wait for merge of SpiNNakerManchester/PACMAN#65