### PR TITLE
Fix iobuf extraction

### DIFF
--- a/spinn_front_end_common/interface/interface_functions/front_end_common_application_finisher.py
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_application_finisher.py
@@ -1,6 +1,8 @@
 from spinn_front_end_common.utilities import helpful_functions
 from spinn_front_end_common.utilities import constants
 from spinn_front_end_common.utilities import exceptions
+from spinn_front_end_common.abstract_models\
+    .abstract_binary_uses_simulation_run import AbstractBinaryUsesSimulationRun
 
 from spinnman.messages.sdp.sdp_flag import SDPFlag
 from spinnman.messages.sdp.sdp_header import SDPHeader
@@ -16,14 +18,22 @@ class FrontEndCommonApplicationFinisher(object):
 
     __slots__ = []
 
-    def __call__(self, app_id, txrx, executable_targets, has_ran):
+    def __call__(
+            self, app_id, txrx, executable_targets, has_ran, placements,
+            graph_mapper=None):
 
         if not has_ran:
             raise exceptions.ConfigurationException(
                 "The ran token is not set correctly, please fix and try again")
 
-        total_processors = executable_targets.total_processors
-        all_core_subsets = executable_targets.all_core_subsets
+        # Only deal with binaries that *can* be shut down i.e. those that
+        # have been compiled with simulation runner
+        filtered_targets, _ = helpful_functions.get_executables_by_run_type(
+            executable_targets, placements, graph_mapper,
+            AbstractBinaryUsesSimulationRun)
+
+        total_processors = filtered_targets.total_processors
+        all_core_subsets = filtered_targets.all_core_subsets
 
         progress_bar = ProgressBar(
             total_processors,
@@ -64,8 +74,8 @@ class FrontEndCommonApplicationFinisher(object):
                 for processor in core_subset.processor_ids:
                     byte_data = struct.pack(
                         "<I",
-                        constants.SDP_RUNNING_MESSAGE_CODES.SDP_STOP_ID_CODE
-                        .value)
+                        constants.SDP_RUNNING_MESSAGE_CODES
+                        .SDP_UPDATE_PROVENCE_REGION_AND_EXIT.value)
 
                     txrx.send_sdp_message(SDPMessage(
                         sdp_header=SDPHeader(

--- a/spinn_front_end_common/interface/interface_functions/front_end_common_application_finisher.py
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_application_finisher.py
@@ -47,17 +47,11 @@ class FrontEndCommonApplicationFinisher(object):
                 app_id, CPUState.WATCHDOG)
 
             if processors_rte > 0 or processors_watchdogged > 0:
-                error_cores = helpful_functions.get_cores_in_state(
-                    all_core_subsets,
-                    {CPUState.RUN_TIME_EXCEPTION, CPUState.WATCHDOG}, txrx)
-                fail_message = helpful_functions.get_core_status_string(
-                    error_cores)
                 raise exceptions.ExecutableFailedToStopException(
                     "{} of {} processors went into an error state when"
                     " shutting down: {}".format(
                         processors_rte + processors_watchdogged,
-                        total_processors, fail_message),
-                    helpful_functions.get_core_subsets(error_cores), True)
+                        total_processors))
 
             successful_cores_finished = set(
                 helpful_functions.get_cores_in_state(

--- a/spinn_front_end_common/interface/interface_functions/front_end_common_chip_iobuf_clearer.py
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_chip_iobuf_clearer.py
@@ -1,7 +1,10 @@
 from spinn_front_end_common.utilities.scp.clear_iobuf_process import \
     ClearIOBUFProcess
+from spinn_front_end_common.abstract_models\
+    .abstract_binary_uses_simulation_run import AbstractBinaryUsesSimulationRun
 
 from spinn_front_end_common.utilities import exceptions
+from spinn_front_end_common.utilities import helpful_functions
 
 
 class FrontEndCommonChipIOBufClearer(object):
@@ -10,13 +13,19 @@ class FrontEndCommonChipIOBufClearer(object):
 
     __slots__ = []
 
-    def __call__(self, transceiver, executable_targets, ran_token):
+    def __call__(
+            self, transceiver, executable_targets, ran_token, placements,
+            graph_mapper=None):
 
         if not ran_token:
             raise exceptions.ConfigurationException(
                 "The simulation has to have ran before running this system")
 
+        clearable_targets, _ = helpful_functions.get_executables_by_run_type(
+            executable_targets, placements, graph_mapper,
+            AbstractBinaryUsesSimulationRun)
+
         process = ClearIOBUFProcess(transceiver._scamp_connection_selector)
-        process.clear_iobuf(executable_targets.all_core_subsets,
-                            len(executable_targets.all_core_subsets))
+        process.clear_iobuf(clearable_targets.all_core_subsets,
+                            len(clearable_targets.all_core_subsets))
         return True

--- a/spinn_front_end_common/interface/interface_functions/front_end_common_chip_provenance_updater.py
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_chip_provenance_updater.py
@@ -7,6 +7,8 @@ from spinnman.model.cpu_state import CPUState
 
 from spinn_front_end_common.utilities import helpful_functions
 from spinn_front_end_common.utilities import constants
+from spinn_front_end_common.abstract_models\
+    .abstract_binary_uses_simulation_run import AbstractBinaryUsesSimulationRun
 
 import struct
 
@@ -17,12 +19,19 @@ class FrontEndCommonChipProvenanceUpdater(object):
 
     __slots__ = []
 
-    def __call__(self, txrx, app_id, all_core_subsets):
+    def __call__(
+            self, txrx, app_id, placements, graph_mapper=None):
 
-        # check that the right number of processors are in sync
+        # Get the placements that are compatible with provenance updating
+        matching_placements, _ = helpful_functions.get_placements_by_run_type(
+            placements, graph_mapper, AbstractBinaryUsesSimulationRun)
+        matching_subsets = helpful_functions.get_placement_core_subsets(
+            matching_placements)
+
+        # check that the right number of processors are finished
         processors_completed = txrx.get_core_state_count(
             app_id, CPUState.FINISHED)
-        total_processors = len(all_core_subsets)
+        total_processors = len(matching_subsets)
         left_to_do_cores = total_processors - processors_completed
 
         progress_bar = ProgressBar(
@@ -33,7 +42,7 @@ class FrontEndCommonChipProvenanceUpdater(object):
         # the core has received the message and done provenance updating
         while processors_completed != total_processors:
             unsuccessful_cores = helpful_functions.get_cores_not_in_state(
-                all_core_subsets, CPUState.FINISHED, txrx)
+                matching_subsets, CPUState.FINISHED, txrx)
 
             for (x, y, p) in unsuccessful_cores:
                 data = struct.pack(

--- a/spinn_front_end_common/interface/interface_functions/front_end_common_chip_provenance_updater.py
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_chip_provenance_updater.py
@@ -29,7 +29,7 @@ class FrontEndCommonChipProvenanceUpdater(object):
             left_to_do_cores,
             "Forcing error cores to generate provenance data")
 
-        # check that all cores are in the state CPU_STATE_12 which shows that
+        # check that all cores are in the state FINISHED which shows that
         # the core has received the message and done provenance updating
         while processors_completed != total_processors:
             unsuccessful_cores = helpful_functions.get_cores_not_in_state(

--- a/spinn_front_end_common/interface/interface_functions/front_end_common_chip_runtime_updater.py
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_chip_runtime_updater.py
@@ -42,7 +42,7 @@ class FrontEndCommonChipRuntimeUpdater(object):
             process = UpdateRuntimeProcess(txrx._scamp_connection_selector)
             process.update_runtime(
                 no_machine_timesteps, infinite_run,
-                executable_targets.all_core_subsets,
-                executable_targets.total_processors)
+                updatable_binaries.all_core_subsets,
+                updatable_binaries.total_processors)
 
         return True

--- a/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
@@ -1147,15 +1147,22 @@
                 <param_type>APPID</param_type>
             </parameter>
             <parameter>
-                <param_name>all_core_subsets</param_name>
-                <param_type>FailedCoresSubsets</param_type>
+                <param_name>placements</param_name>
+                <param_type>MemoryPlacements</param_type>
+            </parameter>
+            <parameter>
+                <param_name>graph_mapper</param_name>
+                <param_type>MemoryGraphMapper</param_type>
             </parameter>
         </input_definitions>
         <required_inputs>
             <param_name>txrx</param_name>
             <param_name>app_id</param_name>
-            <param_name>all_core_subsets</param_name>
+            <param_name>placements</param_name>
         </required_inputs>
+        <optional_inputs>
+            <param_name>graph_mapper</param_name>
+        </optional_inputs>
     </algorithm>
     <algorithm name="FrontEndCommonChipIOBufClearer">
         <python_module>spinn_front_end_common.interface.interface_functions.front_end_common_chip_iobuf_clearer</python_module>

--- a/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
@@ -1180,13 +1180,23 @@
                 <param_name>executable_targets</param_name>
                 <param_type>ExecutableTargets</param_type>
             </parameter>
+            <parameter>
+                <param_name>placements</param_name>
+                <param_type>MemoryPlacements</param_type>
+            </parameter>
+            <parameter>
+                <param_name>graph_mapper</param_name>
+                <param_type>MemoryGraphMapper</param_type>
+            </parameter>
         </input_definitions>
         <required_inputs>
             <param_name>transceiver</param_name>
             <param_name>executable_targets</param_name>
             <param_name>ran_token</param_name>
+            <param_name>placements</param_name>
         </required_inputs>
         <optional_inputs>
+            <param_name>graph_mapper</param_name>
         </optional_inputs>
         <outputs>
             <param_type>ClearedIOBufToken</param_type>

--- a/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
@@ -1066,13 +1066,25 @@
                 <param_name>has_ran</param_name>
                 <param_type>RanToken</param_type>
             </parameter>
+            <parameter>
+                <param_name>placements</param_name>
+                <param_type>MemoryPlacements</param_type>
+            </parameter>
+            <parameter>
+                <param_name>graph_mapper</param_name>
+                <param_type>MemoryGraphMapper</param_type>
+            </parameter>
         </input_definitions>
         <required_inputs>
             <param_name>app_id</param_name>
             <param_name>txrx</param_name>
             <param_name>executable_targets</param_name>
             <param_name>has_ran</param_name>
+            <param_name>placements</param_name>
         </required_inputs>
+        <optional_inputs>
+            <param_name>graph_mapper</param_name>
+        </optional_inputs>
     </algorithm>
     <algorithm name="FrontEndCommonChipRuntimeUpdater">
         <python_module>spinn_front_end_common.interface.interface_functions.front_end_common_chip_runtime_updater</python_module>

--- a/spinn_front_end_common/interface/provenance/pacman_provenance_extractor.py
+++ b/spinn_front_end_common/interface/provenance/pacman_provenance_extractor.py
@@ -17,3 +17,6 @@ class PacmanProvenanceExtractor(object):
     @property
     def data_items(self):
         return self._data_items
+
+    def clear(self):
+        self._data_items = list()

--- a/spinn_front_end_common/interface/spinnaker_main_interface.py
+++ b/spinn_front_end_common/interface/spinnaker_main_interface.py
@@ -4,6 +4,7 @@ main interface for the spinnaker tools
 
 # pacman imports
 from pacman.model.graphs.abstract_virtual_vertex import AbstractVirtualVertex
+from pacman.model.placements.placements import Placements
 from pacman.model.graphs.application.impl.application_graph \
     import ApplicationGraph
 from pacman.model.graphs.machine.impl.machine_graph import MachineGraph
@@ -1425,17 +1426,19 @@ class SpinnakerMainInterface(object):
 
         # If there are any cores, extract data from them
         if len(non_rte_cores) > 0:
-            non_rte_coresubsets = CoreSubsets()
+            placements = Placements()
             for (x, y, p) in non_rte_cores:
-                non_rte_coresubsets.add_processor(x, y, p)
+                vertex = self._placements.get_vertex_on_processor(x, y, p)
+                placements.add_placement(
+                    self._placements.get_placement_of_vertex(vertex))
 
             # Attempt to force the cores to write provenance and exit
             updater = FrontEndCommonChipProvenanceUpdater()
-            updater(self._txrx, self._app_id, non_rte_coresubsets)
+            updater(self._txrx, self._app_id, placements, self._graph_mapper)
 
             # Extract any written provenance data
             extracter = FrontEndCommonPlacementsProvenanceGatherer()
-            extracter(self._txrx, self._placements, True, prov_items)
+            extracter(self._txrx, placements, True, prov_items)
 
         # Finish getting the provenance
         prov_items.extend(self._pacman_provenance.data_items)

--- a/spinn_front_end_common/utilities/exceptions.py
+++ b/spinn_front_end_common/utilities/exceptions.py
@@ -20,37 +20,14 @@ class ExecutableFailedToStartException(SpinnFrontEndException):
     """ Raised when an executable has not entered the expected state during\
         start up
     """
-    def __init__(self, output_string, failed_core_subsets):
-        SpinnFrontEndException.__init__(self, output_string)
-        self._failed_core_subsets = failed_core_subsets
-
-    @property
-    def failed_core_subsets(self):
-        """ The subset of cores in the incorrect state
-        """
-        return self._failed_core_subsets
+    pass
 
 
 class ExecutableFailedToStopException(SpinnFrontEndException):
     """ Raised when an executable has not entered the expected state during\
         execution
     """
-    def __init__(self, output_string, failed_core_subsets, is_rte):
-        SpinnFrontEndException.__init__(self, output_string)
-        self._failed_core_subsets = failed_core_subsets
-        self._is_rte = is_rte
-
-    @property
-    def failed_core_subsets(self):
-        """ The failed cores
-        """
-        return self._failed_core_subsets
-
-    @property
-    def is_rte(self):
-        """ True if the failure was an RTE
-        """
-        return self._is_rte
+    pass
 
 
 class ExecutableNotFoundException(SpinnFrontEndException):

--- a/spinn_front_end_common/utilities/helpful_functions.py
+++ b/spinn_front_end_common/utilities/helpful_functions.py
@@ -360,6 +360,15 @@ def get_core_subsets(core_infos):
     return core_subsets
 
 
+def get_placement_core_subsets(placements):
+    """ Converts placements into core_subset objects
+    """
+    core_subsets = CoreSubsets()
+    for placement in placements:
+        core_subsets.add_processor(placement.x, placement.y, placement.p)
+    return core_subsets
+
+
 def convert_string_info_chip_and_core_subsets(downed_chips, downed_cores):
     """ Translate the down cores and down chips string into a form that \
         spinnman can understand
@@ -518,6 +527,27 @@ def get_executables_by_run_type(
                     other_executables.add_processor(
                         binary, core_subset.x, core_subset.y, p)
     return matching_executables, other_executables
+
+
+def get_placements_by_run_type(placements, graph_mapper, type_to_find):
+    """ Get placements by the type of the vertex
+    """
+    matching_placements = list()
+    other_placements = list()
+    for placement in placements.placements:
+        is_of_type = False
+        vertex = placement.vertex
+        if isinstance(vertex, type_to_find):
+            matching_placements.append(placement)
+            is_of_type = True
+        elif graph_mapper is not None:
+            assoc_vertex = graph_mapper.get_application_vertex(vertex)
+            if isinstance(assoc_vertex, type_to_find):
+                matching_placements.append(placement)
+                is_of_type = True
+        if not is_of_type:
+            other_placements.append(placement)
+    return matching_placements, other_placements
 
 
 def read_config(config, section, item):

--- a/spinn_front_end_common/utilities/helpful_functions.py
+++ b/spinn_front_end_common/utilities/helpful_functions.py
@@ -476,19 +476,17 @@ def wait_for_cores_to_be_ready(executable_targets, app_id, txrx, sync_state):
     processors_ready = txrx.get_core_state_count(
         app_id, sync_state)
     if processors_ready != total_processors:
+
+        # check that the count given is actually correct
         unsuccessful_cores = get_cores_not_in_state(
             all_core_subsets, sync_state, txrx)
 
         # last chance to slip out of error check
         if len(unsuccessful_cores) != 0:
-            break_down = get_core_status_string(
-                unsuccessful_cores)
             raise exceptions.ExecutableFailedToStartException(
-                "Only {} processors out of {} have successfully reached "
-                "{}:{}".format(
-                    processors_ready, total_processors, sync_state.name,
-                    break_down),
-                get_core_subsets(unsuccessful_cores))
+                "Only {} processors out of {} have successfully reached {}"
+                .format(
+                    processors_ready, total_processors, sync_state.name))
 
 
 def get_executables_by_run_type(


### PR DESCRIPTION
Though the title suggests this branch fixes the iobuf extraction, it also fixes a number of other issues:
 - Fixes the extraction of buffers on second and subsequent runs
 - Adds IOBUF clearing on second and subsequent runs rather than clearing post-run
 - Simplifies the IOBUF and Provenance extraction to be done directly after run, or on stop if the run is infinite
 - Fixes to the error handling system that make it more smooth
 - Fixes to some of the algorithms so that they check each binary uses simulation.h/c before trying to talk to it