### PR TITLE
removed default wrap around False

### DIFF
--- a/spinn_front_end_common/interface/interface_functions/front_end_common_virtual_machine_generator.py
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_virtual_machine_generator.py
@@ -7,7 +7,7 @@ class FrontEndCommonVirtualMachineGenerator(object):
     __slots__ = []
 
     def __call__(
-            self, width=None, height=None, virtual_has_wrap_arounds=False,
+            self, width=None, height=None, virtual_has_wrap_arounds=None,
             version=None, n_cpus_per_chip=18, with_monitors=True,
             down_chips=None, down_cores=None, down_links=None):
         """


### PR DESCRIPTION
new virtual machine fails with incorrect size and wrap around pair

This allow the virtual machine to set the wrap around and therefor not fail.

Required for SpiNNakerManchester/SpiNNMachine#31 but appears not to fail on current master

Tested with one run but not fully tests as I don't know how to yet