### PR TITLE
Allow installation from branches other than master as a coordinated set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,18 @@ before_install:
   - pip install --upgrade pip setuptools wheel
   - pip install --only-binary=numpy,scipy numpy scipy
   # SpiNNakerManchester internal dependencies; development mode
-  - pip install --upgrade git+git://github.com/SpiNNakerManchester/SpiNNMachine.git@master
-  - pip install --upgrade git+git://github.com/SpiNNakerManchester/SpiNNMan.git@master
-  - pip install --upgrade git+git://github.com/SpiNNakerManchester/SpiNNStorageHandlers.git@master
-  - pip install --upgrade git+git://github.com/SpiNNakerManchester/PACMAN.git@master
-  - pip install --upgrade git+git://github.com/SpiNNakerManchester/DataSpecification.git@master
+  - pip install -q --upgrade git+git://github.com/SpiNNakerManchester/SpiNNMachine.git@$TRAVIS_BRANCH || pip install -q --upgrade git+git://github.com/SpiNNakerManchester/SpiNNMachine.git@master
+  - pip install -q --upgrade git+git://github.com/SpiNNakerManchester/SpiNNMan.git@$TRAVIS_BRANCH || pip install -q --upgrade git+git://github.com/SpiNNakerManchester/SpiNNMan.git@master
+  - pip install -q --upgrade git+git://github.com/SpiNNakerManchester/SpiNNStorageHandlers.git@$TRAVIS_BRANCH || pip install -q --upgrade git+git://github.com/SpiNNakerManchester/SpiNNStorageHandlers.git@master
+  - pip install -q --upgrade git+git://github.com/SpiNNakerManchester/PACMAN.git@$TRAVIS_BRANCH || pip install -q --upgrade git+git://github.com/SpiNNakerManchester/PACMAN.git@master
+  - pip install -q --upgrade git+git://github.com/SpiNNakerManchester/DataSpecification.git@TRAVIS_BRANCH || pip install -q --upgrade git+git://github.com/SpiNNakerManchester/DataSpecification.git@master
+
 install:
   # These things ought to be enough
   - pip install -r requirements-test.txt
   - pip install -r doc/doc_requirements.txt
   - python ./setup.py install
+
 script:
   - py.test unittests
   - py.test integration_tests
@@ -32,4 +34,3 @@ script:
   - sphinx-build -T -E -b html -d _build/doctrees-readthedocsdirhtml -D language=en . _build/html
   - sphinx-build -T -b json -d _build/doctrees-json -D language=en . _build/json
   - sphinx-build -T -b singlehtml -d _build/doctrees-readthedocssinglehtmllocalmedia -D language=en . _build/localmedia
-


### PR DESCRIPTION
If you've got several branches that work together on a problem, this makes it easy to build them together. The magic is based on the `TRAVIS_BRANCH` environment variable and some shell fallbacks.