### PR TITLE
Fix error recovery

### DIFF
--- a/spinn_front_end_common/interface/interface_functions/front_end_common_application_runner.py
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_application_runner.py
@@ -95,7 +95,7 @@ class FrontEndCommonApplicationRunner(object):
         if runtime is None:
             logger.info("Application is set to run forever - exiting")
         else:
-            time_to_wait = (runtime / 1000.0) + 0.1
+            time_to_wait = ((runtime * time_scale_factor) / 1000.0) + 0.1
             logger.info(
                 "Application started - waiting {} seconds for it to stop"
                 .format(time_to_wait))

--- a/spinn_front_end_common/interface/interface_functions/front_end_common_router_provenance_gatherer.py
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_router_provenance_gatherer.py
@@ -7,6 +7,10 @@ from spinn_front_end_common.utilities.utility_objs.provenance_data_item \
     import ProvenanceDataItem
 from spinn_front_end_common.utilities import exceptions
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class FrontEndCommonRouterProvenanceGatherer(object):
     """
@@ -99,13 +103,18 @@ class FrontEndCommonRouterProvenanceGatherer(object):
             x = router_table.x
             y = router_table.y
             if not machine.get_chip_at(x, y).virtual:
-                router_diagnostic = txrx.get_router_diagnostics(x, y)
-                seen_chips.add((x, y))
-                reinjector_status = txrx.get_reinjection_status(x, y)
-                items.extend(self._write_router_diagnostics(
-                    x, y, router_diagnostic, reinjector_status, True,
-                    router_table))
-                self._add_totals(router_diagnostic, reinjector_status)
+                try:
+                    router_diagnostic = txrx.get_router_diagnostics(x, y)
+                    seen_chips.add((x, y))
+                    reinjector_status = txrx.get_reinjection_status(x, y)
+                    items.extend(self._write_router_diagnostics(
+                        x, y, router_diagnostic, reinjector_status, True,
+                        router_table))
+                    self._add_totals(router_diagnostic, reinjector_status)
+                except Exception as e:
+                    logger.warn(
+                        "Could not read routing diagnostics from {}, {}: {}"
+                        .format(x, y, e))
             progress.update()
 
         for chip in sorted(machine.chips, key=lambda c: (c.x, c.y)):

--- a/spinn_front_end_common/interface/spinnaker_main_interface.py
+++ b/spinn_front_end_common/interface/spinnaker_main_interface.py
@@ -1445,14 +1445,16 @@ class SpinnakerMainInterface(object):
                 self._executable_start_type ==
                 ExecutableStartType.USES_SIMULATION_INTERFACE):
             placements = Placements()
+            non_rte_core_subsets = CoreSubsets()
             for (x, y, p) in non_rte_cores:
                 vertex = self._placements.get_vertex_on_processor(x, y, p)
                 placements.add_placement(
                     self._placements.get_placement_of_vertex(vertex))
+                non_rte_core_subsets.add_processor(x, y, p)
 
             # Attempt to force the cores to write provenance and exit
             updater = FrontEndCommonChipProvenanceUpdater()
-            updater(self._txrx, self._app_id, placements, self._graph_mapper)
+            updater(self._txrx, self._app_id, non_rte_core_subsets)
 
             # Extract any written provenance data
             extracter = FrontEndCommonPlacementsProvenanceGatherer()

--- a/spinn_front_end_common/interface/spinnaker_main_interface.py
+++ b/spinn_front_end_common/interface/spinnaker_main_interface.py
@@ -1437,7 +1437,8 @@ class SpinnakerMainInterface(object):
         non_rte_cores = [
             (x, y, p)
             for (x, y, p), core_info in unsuccessful_cores.iteritems()
-            if core_info.state != CPUState.RUN_TIME_EXCEPTION
+            if (core_info.state != CPUState.RUN_TIME_EXCEPTION and
+                core_info.state != CPUState.WATCHDOG)
         ]
 
         # If there are any cores that are not in RTE, extract data from them

--- a/spinn_front_end_common/utilities/connections/live_event_connection.py
+++ b/spinn_front_end_common/utilities/connections/live_event_connection.py
@@ -185,9 +185,9 @@ class LiveEventConnection(DatabaseConnection):
                         listener.start()
                         self._receivers[port] = receiver
                         self._listeners[port] = listener
-#                     logger.info(
-#                         "Listening for traffic from {} on {}:{}".format(
-#                             receive_label, host, port))
+                    logger.info(
+                        "Listening for traffic from {} on {}:{}".format(
+                            receive_label, host, port))
                 else:
                     raise Exception("Currently, only ip tags which strip the"
                                     " SDP headers are supported")

--- a/spinn_front_end_common/utilities/connections/live_event_connection.py
+++ b/spinn_front_end_common/utilities/connections/live_event_connection.py
@@ -185,9 +185,9 @@ class LiveEventConnection(DatabaseConnection):
                         listener.start()
                         self._receivers[port] = receiver
                         self._listeners[port] = listener
-                    logger.info(
-                        "Listening for traffic from {} on {}:{}".format(
-                            receive_label, host, port))
+#                     logger.info(
+#                         "Listening for traffic from {} on {}:{}".format(
+#                             receive_label, host, port))
                 else:
                     raise Exception("Currently, only ip tags which strip the"
                                     " SDP headers are supported")


### PR DESCRIPTION
Fixes a couple of issues:
 - The error recovery was calling functions with the wrong arguments
 - Made the application runner wait for the correct amount of time when there is a timescale_factor
 - Allow router provenance to fail on some chips but continue