### PR TITLE
Enforce all boards to use the same buffer manager listener port

### DIFF
--- a/integration_tests/test_buffer_manager_listener_creation.py
+++ b/integration_tests/test_buffer_manager_listener_creation.py
@@ -25,10 +25,10 @@ class TestBufferManagerListenerCreation(unittest.TestCase):
         v2 = TestVertex(10, "v2", 256)
 
         # Create two tags - important thing is port=None
-        t1 = IPTag(board_address='127.0.0.1', destination_x=0, destination_y=1,
+        t1 = IPTag(board_address='130.88.193.148', destination_x=0, destination_y=1,
                    tag=1, port=None, ip_address=None, strip_sdp=True,
                    traffic_identifier='BufferTraffic')
-        t2 = IPTag(board_address='127.0.0.2', destination_x=0, destination_y=2,
+        t2 = IPTag(board_address='130.88.193.148', destination_x=0, destination_y=2,
                    tag=1, port=None, ip_address=None, strip_sdp=True,
                    traffic_identifier='BufferTraffic')
 
@@ -57,7 +57,7 @@ class TestBufferManagerListenerCreation(unittest.TestCase):
         # Create buffer manager
         bm = BufferManager(pl, t, trnx, False, None)
 
-        # Register two listeners, and check the second listener is uses the
+        # Register two listeners, and check the second listener uses the
         # first rather than creating a new one
         bm._add_buffer_listeners(vertex=v1)
         bm._add_buffer_listeners(vertex=v2)

--- a/integration_tests/test_buffer_manager_listener_creation.py
+++ b/integration_tests/test_buffer_manager_listener_creation.py
@@ -73,6 +73,7 @@ class TestBufferManagerListenerCreation(unittest.TestCase):
                 number_of_listeners += 1
             print i
         self.assertEqual(number_of_listeners, 1)
+        self.assertTrue(Flase, "for testing purposes")
 
 
 class TestVertex(ApplicationVertex):

--- a/integration_tests/test_buffer_manager_listener_creation.py
+++ b/integration_tests/test_buffer_manager_listener_creation.py
@@ -29,7 +29,7 @@ class TestBufferManagerListenerCreation(unittest.TestCase):
         t1 = IPTag(board_address='127.0.0.1', destination_x=0,
                    destination_y=1, tag=1, port=None, ip_address=None,
                    strip_sdp=True, traffic_identifier='BufferTraffic')
-        t2 = IPTag(board_address='127.0.0.2', destination_x=0,
+        t2 = IPTag(board_address='127.0.0.1', destination_x=0,
                    destination_y=2, tag=1, port=None, ip_address=None,
                    strip_sdp=True, traffic_identifier='BufferTraffic')
 
@@ -73,7 +73,7 @@ class TestBufferManagerListenerCreation(unittest.TestCase):
                 number_of_listeners += 1
             print i
         self.assertEqual(number_of_listeners, 1)
-        self.assertTrue(Flase, "for testing purposes")
+        #self.assertTrue(False, "for testing purposes")
 
 
 class TestVertex(ApplicationVertex):

--- a/integration_tests/test_buffer_manager_listener_creation.py
+++ b/integration_tests/test_buffer_manager_listener_creation.py
@@ -1,0 +1,104 @@
+import unittest
+from spinn_front_end_common.interface.buffer_management.buffer_manager \
+    import BufferManager
+from pacman.model.placements import Placement, Placements
+from pacman.model.tags.tags import Tags
+from pacman.model.graphs.application import ApplicationVertex
+from pacman.model.decorators.overrides import overrides
+from spinnman.transceiver import Transceiver
+from spinnman.connections.udp_packet_connections.udp_scamp_connection \
+    import UDPSCAMPConnection
+from spinnman.connections.udp_packet_connections.udp_eieio_connection \
+    import UDPEIEIOConnection
+from spinn_machine.tags.iptag import IPTag
+
+class TestBufferManagerListenerCreation(unittest.TestCase):
+
+    def test_listener_creation(self):
+        # Test of buffer manager listener creation problem, where multiple
+        # listeners were being created for the buffer manager traffic from
+        #individual boards, where it's preferred all traffic is received by
+        # a single listener
+
+        # Create two vertices
+        v1 = TestVertex(10, "v1", 256)
+        v2 = TestVertex(10, "v2", 256)
+
+        # Create two tags - important thing is port=None
+        t1 = IPTag(board_address='127.0.0.1', destination_x=0, destination_y=1,
+                   tag=1, port=None, ip_address=None, strip_sdp=True,
+                   traffic_identifier='BufferTraffic')
+        t2 = IPTag(board_address='127.0.0.2', destination_x=0, destination_y=2,
+                   tag=1, port=None, ip_address=None, strip_sdp=True,
+                   traffic_identifier='BufferTraffic')
+
+        # Create 'Tags' object and add tags
+        t = Tags()
+        t.add_ip_tag(t1, v1)
+        t.add_ip_tag(t2, v2)
+
+        # Create board connections
+        connections=[]
+        connections.append(UDPSCAMPConnection(
+                    remote_host=None))
+        connections.append(UDPEIEIOConnection())
+
+        # Create two placements and 'Placements' object
+        pl1 = Placement(v1, 0, 1, 1)
+        pl2 = Placement(v2, 0, 2, 1)
+        pl = Placements([pl1, pl2])
+
+        # Create transceiver
+        trnx = Transceiver(version=5, connections=connections)
+        # Alternatively, one can register a udp listener for testing via:
+        # trnx.register_udp_listener(callback=None,
+        #        connection_class=UDPEIEIOConnection)
+
+        # Create buffer manager
+        bm = BufferManager(pl, t, trnx, False, None)
+
+        # Register two listeners, and check the second listener is uses the
+        # first rather than creating a new one
+        bm._add_buffer_listeners(vertex=v1)
+        bm._add_buffer_listeners(vertex=v2)
+
+        number_of_listeners = 0
+        for i in bm._transceiver._udp_listenable_connections_by_class[
+                UDPEIEIOConnection]:
+            # Check if listener is registered on connection - we only expect
+            # one listener to be registered, as all connections can use the
+            # same listener for the buffer manager
+            if not i[1] == None:
+                number_of_listeners += 1
+            print i
+        self.assertEqual(number_of_listeners, 1)
+
+class TestVertex(ApplicationVertex):
+    """
+    taken skeleton test vertex definition from PACMAN.uinit_test_objects
+    """
+    _model_based_max_atoms_per_core = None
+
+    def __init__(self, n_atoms, label=None, max_atoms_per_core=256):
+        ApplicationVertex.__init__(self, label=label,
+                                   max_atoms_per_core=max_atoms_per_core)
+        self._model_based_max_atoms_per_core = max_atoms_per_core
+        self._n_atoms = n_atoms
+
+    @overrides
+    def get_resources_used_by_atoms(self, vertex_slice):
+        pass
+
+    @overrides(ApplicationVertex.create_machine_vertex)
+    def create_machine_vertex(
+            self, vertex_slice, resources_required, label=None,
+            constraints=None):
+        pass
+
+    @property
+    @overrides(ApplicationVertex.n_atoms)
+    def n_atoms(self):
+       return self._n_atoms
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integration_tests/test_buffer_manager_listener_creation.py
+++ b/integration_tests/test_buffer_manager_listener_creation.py
@@ -73,7 +73,6 @@ class TestBufferManagerListenerCreation(unittest.TestCase):
                 number_of_listeners += 1
             print i
         self.assertEqual(number_of_listeners, 1)
-        #self.assertTrue(False, "for testing purposes")
 
 
 class TestVertex(ApplicationVertex):

--- a/integration_tests/test_buffer_manager_listener_creation.py
+++ b/integration_tests/test_buffer_manager_listener_creation.py
@@ -29,7 +29,7 @@ class TestBufferManagerListenerCreation(unittest.TestCase):
         t1 = IPTag(board_address='127.0.0.1', destination_x=0,
                    destination_y=1, tag=1, port=None, ip_address=None,
                    strip_sdp=True, traffic_identifier='BufferTraffic')
-        t2 = IPTag(board_address='127.0.0.1', destination_x=0,
+        t2 = IPTag(board_address='127.0.0.2', destination_x=0,
                    destination_y=2, tag=1, port=None, ip_address=None,
                    strip_sdp=True, traffic_identifier='BufferTraffic')
 
@@ -60,8 +60,8 @@ class TestBufferManagerListenerCreation(unittest.TestCase):
 
         # Register two listeners, and check the second listener uses the
         # first rather than creating a new one
-        l1 = bm._add_buffer_listeners(vertex=v1)
-        l2 = bm._add_buffer_listeners(vertex=v2)
+        bm._add_buffer_listeners(vertex=v1)
+        bm._add_buffer_listeners(vertex=v2)
 
         number_of_listeners = 0
         for i in bm._transceiver._udp_listenable_connections_by_class[

--- a/integration_tests/test_buffer_manager_listener_creation.py
+++ b/integration_tests/test_buffer_manager_listener_creation.py
@@ -41,7 +41,7 @@ class TestBufferManagerListenerCreation(unittest.TestCase):
         # Create board connections
         connections = []
         connections.append(UDPSCAMPConnection(
-                    remote_host=None))
+            remote_host=None))
         connections.append(UDPEIEIOConnection())
 
         # Create two placements and 'Placements' object

--- a/integration_tests/test_buffer_manager_listener_creation.py
+++ b/integration_tests/test_buffer_manager_listener_creation.py
@@ -12,12 +12,13 @@ from spinnman.connections.udp_packet_connections.udp_eieio_connection \
     import UDPEIEIOConnection
 from spinn_machine.tags.iptag import IPTag
 
+
 class TestBufferManagerListenerCreation(unittest.TestCase):
 
     def test_listener_creation(self):
         # Test of buffer manager listener creation problem, where multiple
         # listeners were being created for the buffer manager traffic from
-        #individual boards, where it's preferred all traffic is received by
+        # individual boards, where it's preferred all traffic is received by
         # a single listener
 
         # Create two vertices
@@ -25,12 +26,12 @@ class TestBufferManagerListenerCreation(unittest.TestCase):
         v2 = TestVertex(10, "v2", 256)
 
         # Create two tags - important thing is port=None
-        t1 = IPTag(board_address='130.88.193.148', destination_x=0, destination_y=1,
-                   tag=1, port=None, ip_address=None, strip_sdp=True,
-                   traffic_identifier='BufferTraffic')
-        t2 = IPTag(board_address='130.88.193.148', destination_x=0, destination_y=2,
-                   tag=1, port=None, ip_address=None, strip_sdp=True,
-                   traffic_identifier='BufferTraffic')
+        t1 = IPTag(board_address='0.0.0.0', destination_x=0,
+                   destination_y=1, tag=1, port=None, ip_address=None,
+                   strip_sdp=True, traffic_identifier='BufferTraffic')
+        t2 = IPTag(board_address='0.0.0.0', destination_x=0,
+                   destination_y=2, tag=1, port=None, ip_address=None,
+                   strip_sdp=True, traffic_identifier='BufferTraffic')
 
         # Create 'Tags' object and add tags
         t = Tags()
@@ -38,7 +39,7 @@ class TestBufferManagerListenerCreation(unittest.TestCase):
         t.add_ip_tag(t2, v2)
 
         # Create board connections
-        connections=[]
+        connections = []
         connections.append(UDPSCAMPConnection(
                     remote_host=None))
         connections.append(UDPEIEIOConnection())
@@ -68,10 +69,11 @@ class TestBufferManagerListenerCreation(unittest.TestCase):
             # Check if listener is registered on connection - we only expect
             # one listener to be registered, as all connections can use the
             # same listener for the buffer manager
-            if not i[1] == None:
+            if not i[1] is None:
                 number_of_listeners += 1
             print i
         self.assertEqual(number_of_listeners, 1)
+
 
 class TestVertex(ApplicationVertex):
     """
@@ -98,7 +100,8 @@ class TestVertex(ApplicationVertex):
     @property
     @overrides(ApplicationVertex.n_atoms)
     def n_atoms(self):
-       return self._n_atoms
+        return self._n_atoms
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/integration_tests/test_buffer_manager_listener_creation.py
+++ b/integration_tests/test_buffer_manager_listener_creation.py
@@ -26,10 +26,10 @@ class TestBufferManagerListenerCreation(unittest.TestCase):
         v2 = TestVertex(10, "v2", 256)
 
         # Create two tags - important thing is port=None
-        t1 = IPTag(board_address='0.0.0.0', destination_x=0,
+        t1 = IPTag(board_address='127.0.0.1', destination_x=0,
                    destination_y=1, tag=1, port=None, ip_address=None,
                    strip_sdp=True, traffic_identifier='BufferTraffic')
-        t2 = IPTag(board_address='0.0.0.0', destination_x=0,
+        t2 = IPTag(board_address='127.0.0.1', destination_x=0,
                    destination_y=2, tag=1, port=None, ip_address=None,
                    strip_sdp=True, traffic_identifier='BufferTraffic')
 
@@ -60,8 +60,8 @@ class TestBufferManagerListenerCreation(unittest.TestCase):
 
         # Register two listeners, and check the second listener uses the
         # first rather than creating a new one
-        bm._add_buffer_listeners(vertex=v1)
-        bm._add_buffer_listeners(vertex=v2)
+        l1 = bm._add_buffer_listeners(vertex=v1)
+        l2 = bm._add_buffer_listeners(vertex=v2)
 
         number_of_listeners = 0
         for i in bm._transceiver._udp_listenable_connections_by_class[

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -236,7 +236,6 @@ class BufferManager(object):
 
         # If using virtual board, no listeners can be set up
         if self._transceiver is None:
-            print "no transceiver"
             return
 
         # Find a tag for receiving buffer data
@@ -245,7 +244,6 @@ class BufferManager(object):
         if tags is not None:
             # locate tag associated with the buffer manager traffic
             for tag in tags:
-                print tag
                 if tag.traffic_identifier == self.TRAFFIC_IDENTIFIER:
                     # If the tag port is not assigned create a connection\
                     # and assign the port.  Note that this *should* \
@@ -254,11 +252,8 @@ class BufferManager(object):
                         # If connection already setup, ensure subsequent
                         # boards use same listener port in their tag
                         if self._listener_port is None:
-                            print "going to create a listener"
                             connection = self._create_connection(tag)
                             tag.port = connection.local_port
-                            print "connection local port = {}".\
-                                format(connection.local_port)
                             self._listener_port = connection.local_port
                         else:
                             tag.port = self._listener_port

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -253,8 +253,8 @@ class BufferManager(object):
                     if tag.port is None:
                         # If connection already setup, ensure subsequent
                         # boards use same listener port in their tag
-                        print "going to create a listener"
                         if self._listener_port is None:
+                            print "going to create a listener"
                             connection = self._create_connection(tag)
                             tag.port = connection.local_port
                             self._listener_port = connection.local_port

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -235,30 +235,34 @@ class BufferManager(object):
         """ Add listeners for buffered data for the given vertex
         """
 
+        # If using virtual board, no listeners can be set up
+        if self._transceiver is None:
+            return
+
         # Find a tag for receiving buffer data
         tags = self._tags.get_ip_tags_for_vertex(vertex)
 
         if tags is not None:
-                # locate tag associated with the buffer manage traffic
-                for tag in tags:
-                    if tag.traffic_identifier == self.TRAFFIC_IDENTIFIER:
-                        # If the tag port is not assigned create a connection\
-                        # and assign the port.  Note that this *should* \
-                        # update the port number in any tags being shared
-                        if tag.port is None:
-                            # If connection already setup, ensure subsequent
-                            # boards use same listener port in their tag
-                            if self._listener_port is None:
-                                connection = self._create_connection(tag)
-                                tag.port = connection.local_port
-                                self._listener_port = connection.local_port
-                            else:
-                                tag.port = self._listener_port
+            # locate tag associated with the buffer manager traffic
+            for tag in tags:
+                if tag.traffic_identifier == self.TRAFFIC_IDENTIFIER:
+                    # If the tag port is not assigned create a connection\
+                    # and assign the port.  Note that this *should* \
+                    # update the port number in any tags being shared
+                    if tag.port is None:
+                        # If connection already setup, ensure subsequent
+                        # boards use same listener port in their tag
+                        if self._listener_port is None:
+                            connection = self._create_connection(tag)
+                            tag.port = connection.local_port
+                            self._listener_port = connection.local_port
+                        else:
+                            tag.port = self._listener_port
 
-                        # In case we have tags with different specified ports,\
-                        # also allow the tag to be created here
-                        elif (tag.ip_address, tag.port) not in self._seen_tags:
-                            self._create_connection(tag)
+                    # In case we have tags with different specified ports,\
+                    # also allow the tag to be created here
+                    elif (tag.ip_address, tag.port) not in self._seen_tags:
+                        self._create_connection(tag)
 
     def add_receiving_vertex(self, vertex):
         """ Add a vertex into the managed list for vertices\
@@ -334,6 +338,18 @@ class BufferManager(object):
 
         # update the received data items
         self._received_data.resume()
+
+    def clear_recorded_data(self, x, y, p, recording_region_id):
+        """ Removes the recorded data stored in memory.
+
+        :param x: placement x coord
+        :param y: placement y coord
+        :param p: placement p coord
+        :param recording_region_id: the recording region id
+
+        :return:
+        """
+        self._received_data.clear(x, y, p, recording_region_id)
 
     def _generate_end_buffering_state_from_machine(
             self, placement, state_region_base_address):

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -222,7 +222,6 @@ class BufferManager(object):
                 self.receive_buffer_command_message, UDPEIEIOConnection,
                 local_port=tag.port, local_host=tag.ip_address)
 
-
             self._seen_tags.add((tag.ip_address, connection.local_port))
             utility_functions.send_port_trigger_message(
                 connection, tag.board_address)
@@ -243,21 +242,21 @@ class BufferManager(object):
                 # locate tag associated with the buffer manage traffic
                 for tag in tags:
                     if tag.traffic_identifier == self.TRAFFIC_IDENTIFIER:
-                        # If the tag port is not assigned, create a connection and
-                        # assign the port.  Note that this *should* update the port
-                        # number in any tags being shared
+                        # If the tag port is not assigned create a connection\
+                        # and assign the port.  Note that this *should* \
+                        # update the port number in any tags being shared
                         if tag.port is None:
                             # If connection already setup, ensure subsequent
                             # boards use same listener port in their tag
-                            if self._listener_port is  None:
+                            if self._listener_port is None:
                                 connection = self._create_connection(tag)
                                 tag.port = connection.local_port
                                 self._listener_port = connection.local_port
                             else:
                                 tag.port = self._listener_port
 
-                        # In case we have tags with different specified ports, also
-                        # allow the tag to be created here
+                        # In case we have tags with different specified ports,\
+                        # also allow the tag to be created here
                         elif (tag.ip_address, tag.port) not in self._seen_tags:
                             self._create_connection(tag)
 

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -236,12 +236,14 @@ class BufferManager(object):
 
         # If using virtual board, no listeners can be set up
         if self._transceiver is None:
+            print "no transceiver"
             return
 
         # Find a tag for receiving buffer data
         tags = self._tags.get_ip_tags_for_vertex(vertex)
 
         if tags is not None:
+            print "tags are not none"
             # locate tag associated with the buffer manager traffic
             for tag in tags:
                 if tag.traffic_identifier == self.TRAFFIC_IDENTIFIER:
@@ -251,6 +253,7 @@ class BufferManager(object):
                     if tag.port is None:
                         # If connection already setup, ensure subsequent
                         # boards use same listener port in their tag
+                        print "going to create a listener"
                         if self._listener_port is None:
                             connection = self._create_connection(tag)
                             tag.port = connection.local_port

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -257,7 +257,8 @@ class BufferManager(object):
                             print "going to create a listener"
                             connection = self._create_connection(tag)
                             tag.port = connection.local_port
-                            print "connection local port = {}".format(connection.local_port)
+                            print "connection local port = {}".\
+                                format(connection.local_port)
                             self._listener_port = connection.local_port
                         else:
                             tag.port = self._listener_port

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -221,7 +221,6 @@ class BufferManager(object):
             connection = self._transceiver.register_udp_listener(
                 self.receive_buffer_command_message, UDPEIEIOConnection,
                 local_port=tag.port, local_host=tag.ip_address)
-
             self._seen_tags.add((tag.ip_address, connection.local_port))
             utility_functions.send_port_trigger_message(
                 connection, tag.board_address)

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -257,6 +257,7 @@ class BufferManager(object):
                             print "going to create a listener"
                             connection = self._create_connection(tag)
                             tag.port = connection.local_port
+                            print "connection local port = {}".format(connection.local_port)
                             self._listener_port = connection.local_port
                         else:
                             tag.port = self._listener_port

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -243,9 +243,9 @@ class BufferManager(object):
         tags = self._tags.get_ip_tags_for_vertex(vertex)
 
         if tags is not None:
-            print "tags are not none"
             # locate tag associated with the buffer manager traffic
             for tag in tags:
+                print tag
                 if tag.traffic_identifier == self.TRAFFIC_IDENTIFIER:
                     # If the tag port is not assigned create a connection\
                     # and assign the port.  Note that this *should* \

--- a/spinn_front_end_common/interface/interface_functions/front_end_common_spalloc_max_machine_generator.py
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_spalloc_max_machine_generator.py
@@ -8,7 +8,8 @@ class FrontEndCommonSpallocMaxMachineGenerator(object):
 
     __slots__ = []
 
-    def __call__(self, spalloc_server, spalloc_port=22244):
+    def __call__(
+            self, spalloc_server, spalloc_port=22244, spalloc_machine=None):
 
         client = ProtocolClient(spalloc_server, spalloc_port)
         client.connect()
@@ -18,12 +19,28 @@ class FrontEndCommonSpallocMaxMachineGenerator(object):
         max_height = None
 
         for machine in machines:
-            if "default" in machine["tags"]:
-                if ((max_width is None and max_height is None) or
-                        ((machine["width"] * machine["height"]) >
-                            (max_width * max_height))):
-                    max_width = machine["width"]
-                    max_height = machine["height"]
+            if ((spalloc_machine is None and "default" in machine["tags"]) or
+                    machine["name"] == spalloc_machine):
 
-        # Return the width and height, and assume it has wrap arounds
-        return max_width * 12, max_height * 12, True
+                # Get the width and height in chips
+                width = machine["width"] * 12
+                height = machine["height"] * 12
+
+                # A specific exception is the 1-board machine, which is
+                # represented as a 3 board machine with 2 dead boards.
+                # In this case the width and height is 8
+                if (machine["width"] == 1 and
+                        machine["height"] == 1 and
+                        len(machine["dead_boards"]) == 2):
+                    width = 8
+                    height = 8
+
+                # The "biggest" board is the one with the most chips
+                if ((max_width is None and max_height is None) or
+                        ((width * height) > (max_width * max_height))):
+                    max_width = width
+                    max_height = height
+
+        # Return the width and height, and make no assumption about
+        # wrap arounds or version
+        return max_width, max_height, None, None


### PR DESCRIPTION
Together with the changes in SpiNNMan under the branch of the same name (additional_listeners_removal), this should fix the issues around the buffer manager creating multiple listeners on the same connection.