### PR TITLE
Make it so that app name generation will work on OSX as well as Linux

### DIFF
--- a/c_common/front_end_common_lib/Makefile.SpiNNFrontEndCommon
+++ b/c_common/front_end_common_lib/Makefile.SpiNNFrontEndCommon
@@ -39,7 +39,7 @@ LIBRARIES += -lspinn_frontend_common -lspinn_common -lm
 FEC_DEBUG := PRODUCTION_CODE
 # Run md5sum on application name and extract first 8 bytes
 SHELL = bash
-APPLICATION_NAME_HASH = $(shell echo -n "$(APP)" | md5sum | cut -c 1-8)
+APPLICATION_NAME_HASH = $(shell echo -n "$(APP)" | (md5sum 2>/dev/null || md5) | cut -c 1-8)
 
 CFLAGS += -Wall -Wextra -D$(FEC_DEBUG) $(OTIME) -DAPPLICATION_NAME_HASH=0x$(APPLICATION_NAME_HASH)
 


### PR DESCRIPTION
This tries to use `md5sum` to generate a name, but falls back to `md5` if it is missing. This makes builds work on Linux _and_ OSX.