### PR TITLE
Recording dma fix

### DIFF
--- a/c_common/front_end_common_lib/include/recording.h
+++ b/c_common/front_end_common_lib/include/recording.h
@@ -14,6 +14,9 @@
 
 #define RECORDING_DMA_COMPLETE_TAG_ID 15
 
+//! \brief Callback for recording completion.
+typedef void (*recording_complete_callback_t) ();
+
 typedef struct {
     uint16_t eieio_header_command;
     uint16_t chip_id;
@@ -58,6 +61,18 @@ inline bool recording_is_channel_enabled(
 //!         False otherwise.
 bool recording_record(
     uint8_t channel, void *data, uint32_t size_bytes);
+
+//! \brief records some data into a specific recording channel, calling a
+//!        callback function once complete
+//! \param[in] channel the channel to store the data into.
+//! \param[in] data the data to store into the channel.
+//! \param[in] size_bytes the number of bytes that this data will take up.
+//! \param[in] callback callback to call when the recording has completed
+//! \return boolean which is True if the data has been stored in the channel,
+//!         False otherwise.
+bool recording_record_and_notify(
+    uint8_t channel, void *data, uint32_t size_bytes,
+    recording_complete_callback_t callback);
 
 //! \brief Finishes recording - should only be called if recording_flags is
 //!        not 0

--- a/c_common/front_end_common_lib/src/recording.c
+++ b/c_common/front_end_common_lib/src/recording.c
@@ -438,7 +438,15 @@ bool recording_record_and_notify(
 }
 
 bool recording_record(uint8_t channel, void *data, uint32_t size_bytes) {
-    recording_record_and_notify(channel, data, size_bytes, NULL);
+    if (!recording_record_and_notify(channel, data, size_bytes, NULL)) {
+        return false;
+    }
+
+    // wait till all DMA's have been finished
+    while (circular_buffer_size(dma_complete_buffer) != 0) {
+        spin1_wfi();
+    }
+    return true;
 }
 
 //! brief this writes the state data to the regions

--- a/c_common/models/reverse_iptag_multicast_source/reverse_iptag_multicast_source.c
+++ b/c_common/models/reverse_iptag_multicast_source/reverse_iptag_multicast_source.c
@@ -524,6 +524,18 @@ static inline void process_32_bit_packets(
     }
 }
 
+static inline void record_packet(eieio_msg_t eieio_msg_ptr, uint32_t length) {
+    if (recording_flags > 0) {
+        uint32_t recording_length = 4 * ((length + 3) / 4);
+        log_debug(
+            "recording a eieio message with length %u", recording_length);
+        recording_record(
+            SPIKE_HISTORY_CHANNEL, &recording_length, 4);
+        recording_record(
+            SPIKE_HISTORY_CHANNEL, eieio_msg_ptr, recording_length);
+    }
+}
+
 static inline bool eieio_data_parse_packet(
         eieio_msg_t eieio_msg_ptr, uint32_t length) {
     log_debug("eieio_data_process_data_packet");
@@ -623,19 +635,13 @@ static inline bool eieio_data_parse_packet(
         process_16_bit_packets(
             event_pointer, pkt_prefix_upper, pkt_count, pkt_key_prefix,
             pkt_payload_prefix, pkt_has_payload, pkt_payload_is_timestamp);
-        if (recording_flags > 0) {
-            log_debug("recording a eieio message with length %u", length);
-            recording_record(SPIKE_HISTORY_CHANNEL, eieio_msg_ptr, length);
-        }
+        record_packet(eieio_msg_ptr, length);
         return true;
     } else {
         process_32_bit_packets(
             event_pointer, pkt_count, pkt_key_prefix,
             pkt_payload_prefix, pkt_has_payload, pkt_payload_is_timestamp);
-        if (recording_flags > 0) {
-            log_debug("recording a eieio message with length %u", length);
-            recording_record(SPIKE_HISTORY_CHANNEL, eieio_msg_ptr, length);
-        }
+        record_packet(eieio_msg_ptr, length);
         return false;
     }
 }

--- a/c_common/models/reverse_iptag_multicast_source/reverse_iptag_multicast_source.c
+++ b/c_common/models/reverse_iptag_multicast_source/reverse_iptag_multicast_source.c
@@ -539,12 +539,19 @@ static inline void record_packet(eieio_msg_t eieio_msg_ptr, uint32_t length) {
             spin1_wfi();
         }
 
+        // Ensure that the recorded data size is a multiple of 4
         uint32_t recording_length = 4 * ((length + 3) / 4);
         log_debug(
             "recording a eieio message with length %u", recording_length);
         recording_in_progress = true;
         recording_record(
             SPIKE_HISTORY_CHANNEL, &recording_length, 4);
+
+        // NOTE: recording_length could be bigger than the length of the valid
+        // data in eieio_msg_ptr.  This is OK as the data pointed to by
+        // eieio_msg_ptr is always big enough to have extra space in it.  The
+        // bytes in this data will be random, but are also ignored by
+        // whatever reads the data.
         recording_record_and_notify(
             SPIKE_HISTORY_CHANNEL, eieio_msg_ptr, recording_length,
             recording_done_callback);


### PR DESCRIPTION
Fixes DMA-based recording.  In particular:
 - DMA recording is now explicitly requested by the API user; if they don't request it, they get "normal" (i.e. using spin1_memcpy) recording.
 - DMA recording accepts a callback (if this is provided as NULL, you get normal recording).
 - The callback priority for recording with DMA needs to be 0 or less if a "wait" is going to be done for the recording (this is up to the API user of course).