### PR TITLE
fixes for remote spinnaker

### DIFF
--- a/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
@@ -1394,6 +1394,7 @@
             <param_type>BootPortNum</param_type>
             <param_type>MaxSDRAMSize</param_type>
             <param_type>MachineAllocationController</param_type>
+            <param_type>DownedLinksDetails</param_type>
         </outputs>
     </algorithm>
     <algorithm name="SpallocMaxMachineGenerator">

--- a/spinn_front_end_common/interface/interface_functions/hbp_allocator.py
+++ b/spinn_front_end_common/interface/interface_functions/hbp_allocator.py
@@ -97,7 +97,7 @@ class HBPAllocator(object):
         return (
             machine["machineName"], int(machine["version"]), None, None,
             bmp_details, False, False, None, None, None,
-            hbp_job_controller
+            hbp_job_controller, None
         )
 
     def _get_machine(self, url, n_chips, total_run_time):

--- a/spinn_front_end_common/interface/interface_functions/hbp_max_machine_generator.py
+++ b/spinn_front_end_common/interface/interface_functions/hbp_max_machine_generator.py
@@ -17,7 +17,7 @@ class HBPMaxMachineGenerator(object):
         :param total_run_time: The total run time to request
         """
 
-        max_machine = self._max_machine(hbp_server_url, total_run_time)
+        max_machine = self._max_machine_request(hbp_server_url, total_run_time)
 
         # Return the width and height and assume that it has wrap arounds
         return max_machine["width"], max_machine["height"], True


### PR DESCRIPTION
without this, the remote spinnaker logic flow crashes before it begins, as the machine generator needs dead links and doesn't get it from the HBP allocater.  

found by Christian and his evil bug discovery instinct. 