### PR TITLE
Rewrite of database access layer

### DIFF
--- a/spinn_front_end_common/interface/interface_functions/database_interface.py
+++ b/spinn_front_end_common/interface/interface_functions/database_interface.py
@@ -34,54 +34,50 @@ class DatabaseInterface(object):
 
         self._writer = DatabaseWriter(database_directory)
         self._user_create_database = user_create_database
-
         # add database generation if requested
-        self._needs_database = \
-            self._writer.auto_detect_database(machine_graph)
-        if ((self._user_create_database == "None" and self._needs_database) or
-                self._user_create_database == "True"):
+        self._needs_database = self._writer.auto_detect_database(
+            machine_graph)
 
-            if application_graph is not None and application_graph.n_vertices:
-                database_progress = ProgressBar(11, "Creating database")
-            else:
-                database_progress = ProgressBar(10, "Creating database")
-
-            self._writer.add_system_params(
-                time_scale_factor, machine_time_step, runtime)
-            database_progress.update()
-            self._writer.add_machine_objects(machine)
-            database_progress.update()
-            if application_graph is not None and application_graph.n_vertices:
-                self._writer.add_application_vertices(application_graph)
-                database_progress.update()
-            self._writer.add_vertices(
-                machine_graph, graph_mapper, application_graph)
-            database_progress.update()
-            self._writer.add_placements(placements, machine_graph)
-            database_progress.update()
-            self._writer.add_routing_infos(
-                routing_infos, machine_graph)
-            database_progress.update()
-            self._writer.add_routing_tables(router_tables)
-            database_progress.update()
-            self._writer.add_tags(machine_graph, tags)
-            database_progress.update()
-            if (graph_mapper is not None and
-                    application_graph is not None and
-                    create_atom_to_event_id_mapping):
-                self._writer.create_atom_to_event_id_mapping(
-                    graph_mapper=graph_mapper,
-                    application_graph=application_graph,
-                    machine_graph=machine_graph,
-                    routing_infos=routing_infos)
-            database_progress.update()
-            database_progress.update()
-            database_progress.end()
+        if self.needs_database:
+            with self._writer as w, ProgressBar(9, "Creating database") as p:
+                w.add_system_params(
+                    time_scale_factor, machine_time_step, runtime)
+                p.update()
+                w.add_machine_objects(machine)
+                p.update()
+                if application_graph is not None \
+                        and application_graph.n_vertices:
+                    w.add_application_vertices(application_graph)
+                p.update()
+                w.add_vertices(machine_graph, graph_mapper, application_graph)
+                p.update()
+                w.add_placements(placements)
+                p.update()
+                w.add_routing_infos( routing_infos, machine_graph)
+                p.update()
+                w.add_routing_tables(router_tables)
+                p.update()
+                w.add_tags(machine_graph, tags)
+                p.update()
+                if (graph_mapper is not None
+                        and application_graph is not None
+                        and create_atom_to_event_id_mapping):
+                    w.create_atom_to_event_id_mapping(
+                        graph_mapper=graph_mapper,
+                        application_graph=application_graph,
+                        machine_graph=machine_graph,
+                        routing_infos=routing_infos)
+                p.update()
 
         return self, self.database_file_path
 
     @property
+    def needs_database(self):
+        return ((self._user_create_database == "None" and self._needs_database)
+                or self._user_create_database == "True")
+
+    @property
     def database_file_path(self):
-        if ((self._user_create_database == "None" and self._needs_database) or
-                self._user_create_database == "True"):
+        if self.needs_database:
             return self._writer.database_path
+        return None

--- a/spinn_front_end_common/interface/interface_functions/database_interface.py
+++ b/spinn_front_end_common/interface/interface_functions/database_interface.py
@@ -53,7 +53,7 @@ class DatabaseInterface(object):
                 p.update()
                 w.add_placements(placements)
                 p.update()
-                w.add_routing_infos( routing_infos, machine_graph)
+                w.add_routing_infos(routing_infos, machine_graph)
                 p.update()
                 w.add_routing_tables(router_tables)
                 p.update()

--- a/spinn_front_end_common/utilities/database/database_reader.py
+++ b/spinn_front_end_common/utilities/database/database_reader.py
@@ -41,10 +41,10 @@ class DatabaseReader(object):
         """
         event_id_to_atom_id_mapping = dict()
         for row in self._cursor.execute(
-            "SELECT n.atom_id as a_id, n.event_id as event"
-            " FROM event_to_atom_mapping as n"
-            " JOIN Application_vertices as p ON n.vertex_id = p.vertex_id"
-                " WHERE p.vertex_label=\"{}\"".format(label)):
+                "SELECT n.atom_id AS a_id, n.event_id AS event"
+                " FROM event_to_atom_mapping AS n"
+                " JOIN Application_vertices AS p ON n.vertex_id = p.vertex_id"
+                " WHERE p.vertex_label = ?", (label, )):
             event_id_to_atom_id_mapping[row["event"]] = row["a_id"]
         return event_id_to_atom_id_mapping
 
@@ -57,10 +57,11 @@ class DatabaseReader(object):
         """
         atom_to_event_id_mapping = dict()
         for row in self._cursor.execute(
-            "SELECT n.atom_id as a_id, n.event_id as event"
-            " FROM event_to_atom_mapping as n"
-            " JOIN Application_vertices as p ON n.vertex_id = p.vertex_id"
-                " WHERE p.vertex_label=\"{}\"".format(label)):
+                "SELECT n.atom_id AS a_id, n.event_id AS event"
+                " FROM event_to_atom_mapping AS n"
+                " JOIN Application_vertices AS p"
+                "   ON n.vertex_id = p.vertex_id"
+                " WHERE p.vertex_label = ?", (label, )):
             atom_to_event_id_mapping[row["a_id"]] = row["event"]
         return atom_to_event_id_mapping
 
@@ -74,18 +75,18 @@ class DatabaseReader(object):
         :rtype: (str, int, bool)
         """
         self._cursor.execute(
-            "SELECT * FROM IP_tags as tag"
-            " JOIN graph_mapper_vertex as mapper"
-            " ON tag.vertex_id = mapper.machine_vertex_id"
-            " JOIN Application_vertices as post_vertices"
-            " ON mapper.application_vertex_id = post_vertices.vertex_id"
-            " JOIN Application_edges as edges"
-            " ON mapper.application_vertex_id == edges.post_vertex"
-            " JOIN Application_vertices as pre_vertices"
-            " ON edges.pre_vertex == pre_vertices.vertex_id"
-            " WHERE pre_vertices.vertex_label == \"{}\""
-            " AND post_vertices.vertex_label == \"{}\""
-            .format(label, receiver_label))
+            "SELECT * FROM IP_tags AS tag"
+            " JOIN graph_mapper_vertex AS mapper"
+            "   ON tag.vertex_id = mapper.machine_vertex_id"
+            " JOIN Application_vertices AS post_vertices"
+            "   ON mapper.application_vertex_id = post_vertices.vertex_id"
+            " JOIN Application_edges AS edges"
+            "   ON mapper.application_vertex_id = edges.post_vertex"
+            " JOIN Application_vertices AS pre_vertices"
+            "   ON edges.pre_vertex = pre_vertices.vertex_id"
+            " WHERE pre_vertices.vertex_label = ?"
+            "   AND post_vertices.vertex_label = ?"
+            " LIMIT 1", (label, receiver_label))
         row = self._cursor.fetchone()
         return (
             row["ip_address"], row["port"], row["strip_sdp"],
@@ -101,13 +102,14 @@ class DatabaseReader(object):
         :rtype: (str, int)
         """
         self._cursor.execute(
-            "SELECT tag.board_address, tag.port as port"
-            " FROM Reverse_IP_tags as tag"
-            " JOIN graph_mapper_vertex as mapper"
-            " ON tag.vertex_id = mapper.machine_vertex_id"
-            " JOIN Application_vertices as application"
-            " ON mapper.application_vertex_id = application.vertex_id"
-            " WHERE application.vertex_label=\"{}\"".format(label))
+            "SELECT tag.board_address, tag.port AS port"
+            " FROM Reverse_IP_tags AS tag"
+            " JOIN graph_mapper_vertex AS mapper"
+            "   ON tag.vertex_id = mapper.machine_vertex_id"
+            " JOIN Application_vertices AS application"
+            "   ON mapper.application_vertex_id = application.vertex_id"
+            " WHERE application.vertex_label = ?"
+            " LIMIT 1", (label, ))
         row = self._cursor.fetchone()
         return row["board_address"], row["port"]
 
@@ -121,16 +123,16 @@ class DatabaseReader(object):
         :rtype: (str, int, bool)
         """
         self._cursor.execute(
-            "SELECT * FROM IP_tags as tag"
-            " JOIN Machine_vertices as post_vertices"
-            " ON tag.vertex_id == post_vertices.vertex_id"
-            " JOIN Machine_edges as edges"
-            " ON post_vertices.vertex_id == edges.post_vertex"
-            " JOIN Machine_vertices as pre_vertices"
-            " ON edges.pre_vertex == pre_vertices.vertex_id"
-            " WHERE pre_vertices.label == \"{}\""
-            " AND post_vertices.label == \"{}\""
-            .format(label, receiver_label))
+            "SELECT * FROM IP_tags AS tag"
+            " JOIN Machine_vertices AS post_vertices"
+            "   ON tag.vertex_id = post_vertices.vertex_id"
+            " JOIN Machine_edges AS edges"
+            "   ON post_vertices.vertex_id = edges.post_vertex"
+            " JOIN Machine_vertices AS pre_vertices"
+            "   ON edges.pre_vertex = pre_vertices.vertex_id"
+            " WHERE pre_vertices.label = ?"
+            "   AND post_vertices.label = ?"
+            " LIMIT 1", (label, receiver_label))
         row = self._cursor.fetchone()
         return (
             row["ip_address"], row["port"], row["strip_sdp"],
@@ -146,38 +148,39 @@ class DatabaseReader(object):
         :rtype: (str, int)
         """
         self._cursor.execute(
-            "SELECT tag.board_address, tag.port as port"
-            " FROM Reverse_IP_tags as tag"
-            " JOIN Machine_vertices as post_vertices"
-            " ON tag.vertex_id = post_vertices.vertex_id"
-            " WHERE post_vertices.label=\"{}\"".format(label))
+            "SELECT tag.board_address, tag.port AS port"
+            " FROM Reverse_IP_tags AS tag"
+            " JOIN Machine_vertices AS post_vertices"
+            "   ON tag.vertex_id = post_vertices.vertex_id"
+            " WHERE post_vertices.label = ?"
+            " LIMIT 1", (label, ))
         row = self._cursor.fetchone()
         return row["board_address"], row["port"]
 
     def get_machine_live_output_key(self, label, receiver_label):
         self._cursor.execute(
-            "SELECT * FROM Routing_info as r_info"
-            " JOIN Machine_edges as edges"
-            " ON edges.edge_id == r_info.edge_id"
-            " JOIN Machine_vertices as post_vertices"
-            " ON post_vertices.vertex_id == edges.post_vertex"
-            " JOIN Machine_vertices as pre_vertices"
-            " ON pre_vertices.vertex_id == edges.pre_vertex"
-            " WHERE pre_vertices.label == \"{}\""
-            " AND post_vertices.label == \"{}\""
-            .format(label, receiver_label))
+            "SELECT * FROM Routing_info AS r_info"
+            " JOIN Machine_edges AS edges"
+            "   ON edges.edge_id = r_info.edge_id"
+            " JOIN Machine_vertices AS post_vertices"
+            "   ON post_vertices.vertex_id = edges.post_vertex"
+            " JOIN Machine_vertices AS pre_vertices"
+            "   ON pre_vertices.vertex_id = edges.pre_vertex"
+            " WHERE pre_vertices.label = ?"
+            "   AND post_vertices.label = ?"
+            " LIMIT 1", (label, receiver_label))
         row = self._cursor.fetchone()
         return (row["key"], row["mask"])
 
     def get_machine_live_input_key(self, label):
         self._cursor.execute(
-            "SELECT * FROM Routing_info as r_info"
-            " JOIN Machine_edges as edges"
-            " ON edges.edge_id == r_info.edge_id"
-            " JOIN Machine_vertices as pre_vertices"
-            " ON pre_vertices.vertex_id == edges.pre_vertex"
-            " WHERE pre_vertices.label == \"{}\""
-            .format(label))
+            "SELECT * FROM Routing_info AS r_info"
+            " JOIN Machine_edges AS edges"
+            "   ON edges.edge_id = r_info.edge_id"
+            " JOIN Machine_vertices AS pre_vertices"
+            "   ON pre_vertices.vertex_id = edges.pre_vertex"
+            " WHERE pre_vertices.label = ?"
+            " LIMIT 1", (label, ))
         row = self._cursor.fetchone()
         return (row["key"], row["mask"])
 
@@ -191,7 +194,8 @@ class DatabaseReader(object):
         """
         self._cursor.execute(
             "SELECT no_atoms FROM Application_vertices "
-            "WHERE vertex_label = \"{}\"".format(label))
+            "WHERE vertex_label = ?"
+            " LIMIT 1", (label, ))
         return self._cursor.fetchone()["no_atoms"]
 
     def get_configuration_parameter_value(self, parameter_name):
@@ -204,8 +208,16 @@ class DatabaseReader(object):
         """
         self._cursor.execute(
             "SELECT value FROM configuration_parameters"
-            " WHERE parameter_id = \"{}\"".format(parameter_name))
+            " WHERE parameter_id = ?"
+            " LIMIT 1", (parameter_name, ))
         return float(self._cursor.fetchone()["value"])
 
     def close(self):
         self._connection.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):  # @UnusedVariable
+        self._connection.close()
+        return False

--- a/spinn_front_end_common/utilities/database/database_reader.py
+++ b/spinn_front_end_common/utilities/database/database_reader.py
@@ -1,4 +1,4 @@
-import sqlite3 as sqlite
+import sqlite3
 
 
 class DatabaseReader(object):
@@ -19,8 +19,8 @@ class DatabaseReader(object):
         :param database_path: The path to the database
         :type database_path: str
         """
-        self._connection = sqlite.connect(database_path)
-        self._connection.row_factory = sqlite.Row
+        self._connection = sqlite3.connect(database_path)
+        self._connection.row_factory = sqlite3.Row
         self._cursor = self._connection.cursor()
 
     @property

--- a/spinn_front_end_common/utilities/database/database_writer.py
+++ b/spinn_front_end_common/utilities/database/database_writer.py
@@ -1,12 +1,12 @@
 # spinn front end common
 from pacman.model.abstract_classes import AbstractHasGlobalMaxAtoms
+from pandas.util.doctools import idx
 from spinn_front_end_common.abstract_models \
     import AbstractProvidesKeyToAtomMapping, AbstractRecordable, \
     AbstractSupportsDatabaseInjection
 
 # general imports
 import logging
-import traceback
 import os
 import sys
 
@@ -31,7 +31,13 @@ class DatabaseWriter(object):
         "_database_path",
 
         # the identifier for the SpiNNaker machine
-        "_machine_id"
+        "_machine_id",
+
+        # the database connection itself
+        "_connection",
+
+        # Mappings used to accelerate inserts
+        "_machine_to_id", "_vertex_to_id", "_edge_to_id"
     ]
 
     def __init__(self, database_directory):
@@ -40,6 +46,10 @@ class DatabaseWriter(object):
         self._database_directory = database_directory
         self._database_path = os.path.join(
             self._database_directory, "input_output_database.db")
+        self._connection = None
+        self._machine_to_id = dict()
+        self._vertex_to_id = dict()
+        self._edge_to_id = dict()
 
         # delete any old database
         if os.path.isfile(self._database_path):
@@ -47,6 +57,17 @@ class DatabaseWriter(object):
 
         # set up checks
         self._machine_id = 0
+
+    def __enter__(self):
+        import sqlite3 as sqlite
+        self._connection = sqlite.connect(self._database_path)
+        self.create_schema()
+        return self
+         
+    def __exit__(self, exc_type, exc_val, exc_tb):  # @UnusedVariable
+        self._connection.close()
+        self._connection = None
+        return False
 
     @staticmethod
     def auto_detect_database(machine_graph):
@@ -67,64 +88,168 @@ class DatabaseWriter(object):
     def database_path(self):
         return self._database_path
 
+    @property
+    def _cursor(self):
+        return self._connection.cursor()
+
+    def create_schema(self):
+        with self._connection as c:
+            c.execute(
+                "CREATE TABLE IF NOT EXISTS Machine_layout("
+                "  machine_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                "  x_dimension INT, y_dimension INT)")
+            c.execute(
+                "CREATE TABLE IF NOT EXISTS Machine_chip("
+                "  no_processors INT, chip_x INTEGER, chip_y INTEGER, "
+                "  machine_id INTEGER, avilableSDRAM INT, "
+                "PRIMARY KEY(chip_x, chip_y, machine_id), "
+                "FOREIGN KEY (machine_id) "
+                "  REFERENCES Machine_layout(machine_id))")
+            c.execute(
+                "CREATE TABLE IF NOT EXISTS Processor("
+                "  chip_x INTEGER, chip_y INTEGER, machine_id INTEGER, "
+                "  available_DTCM INT, available_CPU INT, "
+                "  physical_id INTEGER, "
+                "PRIMARY KEY(chip_x, chip_y, machine_id, physical_id), "
+                "FOREIGN KEY (chip_x, chip_y, machine_id) "
+                "  REFERENCES Machine_chip(chip_x, chip_y, machine_id))")
+            c.execute(
+                "CREATE TABLE IF NOT EXISTS Application_vertices("
+                "  vertex_id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                "  vertex_label TEXT, no_atoms INT, max_atom_constrant INT,"
+                "  recorded INT)")
+            c.execute(
+                "CREATE TABLE IF NOT EXISTS Application_edges("
+                "  edge_id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                "  pre_vertex INTEGER, post_vertex INTEGER, edge_label TEXT, "
+                "FOREIGN KEY (pre_vertex)"
+                "  REFERENCES Application_vertices(vertex_id), "
+                "FOREIGN KEY (post_vertex)"
+                "  REFERENCES Application_vertices(vertex_id))")
+            c.execute(
+                "CREATE TABLE IF NOT EXISTS Application_graph("
+                "  vertex_id INTEGER, edge_id INTEGER, "
+                "FOREIGN KEY (vertex_id) "
+                "  REFERENCES Application_vertices(vertex_id), "
+                "FOREIGN KEY (edge_id) "
+                "  REFERENCES Application_edges(edge_id), "
+                "PRIMARY KEY (vertex_id, edge_id))")
+            c.execute(
+                "CREATE TABLE IF NOT EXISTS configuration_parameters("
+                "  parameter_id TEXT, value REAL, "
+                "PRIMARY KEY (parameter_id))")
+            c.execute(
+                "CREATE TABLE IF NOT EXISTS Machine_vertices("
+                "  vertex_id INTEGER PRIMARY KEY AUTOINCREMENT, label TEXT, "
+                "  cpu_used INT, sdram_used INT, dtcm_used INT)")
+            c.execute(
+                "CREATE TABLE IF NOT EXISTS Machine_edges("
+                "  edge_id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                "  pre_vertex INTEGER, post_vertex INTEGER, label TEXT, "
+                "FOREIGN KEY (pre_vertex)"
+                "  REFERENCES Machine_vertices(vertex_id), "
+                "FOREIGN KEY (post_vertex)"
+                "  REFERENCES Machine_vertices(vertex_id))")
+            c.execute(
+                "CREATE TABLE IF NOT EXISTS Machine_graph("
+                "  vertex_id INTEGER, edge_id INTEGER, "
+                "PRIMARY KEY(vertex_id, edge_id), "
+                "FOREIGN KEY (vertex_id)"
+                "  REFERENCES Machine_vertices(vertex_id), "
+                "FOREIGN KEY (edge_id)"
+                "  REFERENCES Machine_edges(edge_id))")
+            c.execute(
+                "CREATE TABLE IF NOT EXISTS graph_mapper_vertex("
+                "  application_vertex_id INTEGER, "
+                "  machine_vertex_id INTEGER, lo_atom INT, hi_atom INT, "
+                "PRIMARY KEY(application_vertex_id, machine_vertex_id), "
+                "FOREIGN KEY (machine_vertex_id)"
+                "  REFERENCES Machine_vertices(vertex_id), "
+                "FOREIGN KEY (application_vertex_id)"
+                "  REFERENCES Application_vertices(vertex_id))")
+            c.execute(
+                "CREATE TABLE IF NOT EXISTS graph_mapper_edges("
+                "  application_edge_id INTEGER,"
+                "  machine_edge_id INTEGER, "
+                "PRIMARY KEY(application_edge_id, machine_edge_id), "
+                "FOREIGN KEY (machine_edge_id)"
+                "  REFERENCES Machine_edges(edge_id), "
+                "FOREIGN KEY (application_edge_id)"
+                "  REFERENCES Application_edges(edge_id))")
+            c.execute(
+                "CREATE TABLE IF NOT EXISTS Placements("
+                "  vertex_id INTEGER PRIMARY KEY, machine_id INTEGER, "
+                "  chip_x INT, chip_y INT, chip_p INT, "
+                "FOREIGN KEY (vertex_id) "
+                "  REFERENCES Machine_vertices(vertex_id), "
+                "FOREIGN KEY (chip_x, chip_y, chip_p, machine_id) "
+                "  REFERENCES Processor(chip_x, chip_y, physical_id, "
+                "    machine_id))")
+            c.execute(
+                "CREATE TABLE IF NOT EXISTS Routing_info("
+                "  edge_id INTEGER, key INT, mask INT, "
+                "PRIMARY KEY (edge_id, key, mask), "
+                "FOREIGN KEY (edge_id)"
+                "  REFERENCES Machine_edges(edge_id))")
+            c.execute(
+                "CREATE TABLE IF NOT EXISTS Routing_table("
+                "  chip_x INTEGER, chip_y INTEGER, position INTEGER, "
+                "  key_combo INT, mask INT, route INT, "
+                "PRIMARY KEY (chip_x, chip_y, position))")
+            c.execute(
+                "CREATE TABLE IF NOT EXISTS IP_tags("
+                "  vertex_id INTEGER, tag INTEGER, "
+                "  board_address TEXT, ip_address TEXT, port INTEGER, "
+                "  strip_sdp BOOLEAN,"
+                "PRIMARY KEY ("
+                "  vertex_id, tag, board_address, ip_address, port,"
+                "  strip_sdp),"
+                "FOREIGN KEY (vertex_id)"
+                "  REFERENCES Machine_vertices(vertex_id))")
+            c.execute(
+                "CREATE TABLE IF NOT EXISTS Reverse_IP_tags("
+                "  vertex_id INTEGER PRIMARY KEY, tag INTEGER, "
+                "  board_address TEXT, port INTEGER, "
+                "FOREIGN KEY (vertex_id)"
+                "  REFERENCES Machine_vertices(vertex_id))")
+            c.execute(
+                "CREATE TABLE IF NOT EXISTS event_to_atom_mapping("
+                "  vertex_id INTEGER, atom_id INTEGER, "
+                "  event_id INTEGER PRIMARY KEY, "
+                "FOREIGN KEY (vertex_id)"
+                "  REFERENCES Machine_vertices(vertex_id))")
+
     def add_machine_objects(self, machine):
         """ Store the machine object into the database
 
         :param machine: the machine object.
         :rtype: None
         """
-
-        # noinspection PyBroadException
-        try:
-            import sqlite3 as sqlite
-            connection = sqlite.connect(self._database_path)
-            cur = connection.cursor()
-            cur.execute(
-                "CREATE TABLE Machine_layout("
-                "machine_id INTEGER PRIMARY KEY AUTOINCREMENT,"
-                " x_dimension INT, y_dimension INT)")
-            cur.execute(
-                "CREATE TABLE Machine_chip("
-                "no_processors INT, chip_x INTEGER, chip_y INTEGER, "
-                "machine_id INTEGER, avilableSDRAM INT, "
-                "PRIMARY KEY(chip_x, chip_y, machine_id), "
-                "FOREIGN KEY (machine_id) "
-                "REFERENCES Machine_layout(machine_id))")
-            cur.execute(
-                "CREATE TABLE Processor("
-                "chip_x INTEGER, chip_y INTEGER, machine_id INTEGER, "
-                "available_DTCM INT, available_CPU INT, physical_id INTEGER, "
-                "PRIMARY KEY(chip_x, chip_y, machine_id, physical_id), "
-                "FOREIGN KEY (chip_x, chip_y, machine_id) "
-                "REFERENCES Machine_chip(chip_x, chip_y, machine_id))")
-
+        with self._connection as c:
             x_di = machine.max_chip_x + 1
             y_di = machine.max_chip_y + 1
-            cur.execute("INSERT INTO Machine_layout("
-                        "x_dimension, y_dimension)"
-                        " VALUES({}, {})".format(x_di, y_di))
+            c.execute("INSERT INTO Machine_layout("
+                      "  x_dimension, y_dimension) "
+                      "VALUES(?, ?)", (x_di, y_di))
             self._machine_id += 1
+            self._machine_to_id[machine] = self._machine_id
             for chip in machine.chips:
-                cur.execute(
+                c.execute(
                     "INSERT INTO Machine_chip("
-                    "no_processors, chip_x, chip_y, machine_id) "
-                    "VALUES ({}, {}, {}, {})"
-                    .format(len(list(chip.processors)), chip.x, chip.y,
-                            self._machine_id))
+                    "  no_processors, chip_x, chip_y, machine_id) "
+                    "VALUES (?, ?, ?, ?)", (
+                        len(list(chip.processors)), chip.x, chip.y,
+                        self._machine_id))
                 for processor in chip.processors:
-                    cur.execute(
+                    c.execute(
                         "INSERT INTO Processor("
-                        "chip_x, chip_y, machine_id, available_DTCM, "
-                        "available_CPU, physical_id)"
-                        "VALUES({}, {}, {}, {}, {}, {})"
-                        .format(chip.x, chip.y, self._machine_id,
-                                processor.dtcm_available,
-                                processor.cpu_cycles_available,
-                                processor.processor_id))
-            connection.commit()
-            connection.close()
-        except Exception:
-            traceback.print_exc()
+                        "  chip_x, chip_y, machine_id, available_DTCM, "
+                        "  available_CPU, physical_id) "
+                        "VALUES(?, ?, ?, ?, ?, ?)", (
+                            chip.x, chip.y, self._machine_id,
+                            processor.dtcm_available,
+                            processor.cpu_cycles_available,
+                            processor.processor_id))
 
     def add_application_vertices(self, application_graph):
         """
@@ -132,87 +257,53 @@ class DatabaseWriter(object):
         :param application_graph:
         :rtype: None
         """
-
-        try:
-            import sqlite3 as sqlite
-            connection = sqlite.connect(self._database_path)
-            cur = connection.cursor()
-            cur.execute(
-                "CREATE TABLE Application_vertices("
-                "vertex_id INTEGER PRIMARY KEY AUTOINCREMENT, "
-                "vertex_label TEXT, no_atoms INT, max_atom_constrant INT,"
-                "recorded INT)")
-            cur.execute(
-                "CREATE TABLE Application_edges("
-                "edge_id INTEGER PRIMARY KEY AUTOINCREMENT, "
-                "pre_vertex INTEGER, post_vertex INTEGER, edge_label TEXT, "
-                "FOREIGN KEY (pre_vertex)"
-                " REFERENCES Application_vertices(vertex_id), "
-                "FOREIGN KEY (post_vertex)"
-                " REFERENCES Application_vertices(vertex_id))")
-            cur.execute(
-                "CREATE TABLE Application_graph("
-                "vertex_id INTEGER, edge_id INTEGER, "
-                "FOREIGN KEY (vertex_id) "
-                "REFERENCES Application_vertices(vertex_id), "
-                "FOREIGN KEY (edge_id) "
-                "REFERENCES Application_edges(edge_id), "
-                "PRIMARY KEY (vertex_id, edge_id))")
-
+        with self._connection as c:
             # add vertices
-            for vertex in application_graph.vertices:
+            for idx, vertex in enumerate(application_graph.vertices, start=1):
                 if isinstance(vertex, AbstractRecordable):
-                    cur.execute(
-                        "INSERT INTO Application_vertices("
-                        "vertex_label, no_atoms, max_atom_constrant, recorded)"
-                        " VALUES('{}', {}, {}, {});"
-                        .format(vertex.label, vertex.n_atoms,
-                                vertex.get_max_atoms_per_core(),
-                                int(vertex.is_recording_spikes())))
+                    self._insert_app_vertex(
+                        c, vertex, vertex.get_max_atoms_per_core(),
+                        vertex.is_recording_spikes())
+                elif isinstance(vertex, AbstractHasGlobalMaxAtoms):
+                    self._insert_app_vertex(
+                        c, vertex, vertex.get_max_atoms_per_core(), 0)
                 else:
-                    if isinstance(vertex, AbstractHasGlobalMaxAtoms):
-                        cur.execute(
-                            "INSERT INTO Application_vertices("
-                            "vertex_label, no_atoms, max_atom_constrant, "
-                            "recorded) VALUES('{}', {}, {}, 0);"
-                            .format(vertex.label, vertex.n_atoms,
-                                    vertex.get_max_atoms_per_core()))
-                    else:
-                        cur.execute(
-                            "INSERT INTO Application_vertices("
-                            "vertex_label, no_atoms, max_atom_constrant, "
-                            "recorded) VALUES('{}', {}, {}, 0);"
-                            .format(vertex.label, vertex.n_atoms, sys.maxint))
+                    self._insert_app_vertex(c, vertex, sys.maxint, 0)
+                self._vertex_to_id[vertex] = idx
 
             # add edges
-            vertices = list(application_graph.vertices)
-            edges = list(application_graph.edges)
+            idx = 1
             for vertex in application_graph.vertices:
                 for edge in application_graph.\
                         get_edges_starting_at_vertex(vertex):
-                    cur.execute(
+                    c.execute(
                         "INSERT INTO Application_edges ("
-                        "pre_vertex, post_vertex, edge_label) "
-                        "VALUES({}, {}, '{}');"
-                        .format(vertices.index(edge.pre_vertex) + 1,
-                                vertices.index(edge.post_vertex) + 1,
-                                edge.label))
+                        "  pre_vertex, post_vertex, edge_label) "
+                        "VALUES(?, ?, ?)", (
+                            self._vertex_to_id[edge.pre_vertex],
+                            self._vertex_to_id[edge.post_vertex],
+                            edge.label))
+                    self._edge_to_id[edge] = idx
+                    idx += 1
 
             # update graph
-            edge_id_offset = 0
             for vertex in application_graph.vertices:
                 for edge in application_graph.\
                         get_edges_starting_at_vertex(vertex):
-                    cur.execute(
+                    c.execute(
                         "INSERT INTO Application_graph ("
-                        "vertex_id, edge_id)"
-                        " VALUES({}, {})"
-                        .format(vertices.index(vertex) + 1,
-                                edges.index(edge) + edge_id_offset))
-            connection.commit()
-            connection.close()
-        except Exception:
-            traceback.print_exc()
+                        "  vertex_id, edge_id) "
+                        "VALUES(?, ?)", (
+                            self._vertex_to_id[vertex],
+                            self._edge_to_id[edge]))
+
+    @staticmethod
+    def _insert_app_vertex(c, vertex, max_atoms, is_recording):
+        c.execute(
+            "INSERT INTO Application_vertices("
+            "  vertex_label, no_atoms, max_atom_constrant, recorded) "
+            "VALUES(?, ?, ?, ?)", (
+                vertex.label, vertex.n_atoms, max_atoms, int(is_recording)))
 
     def add_system_params(self, time_scale_factor, machine_time_step, runtime):
         """ Write system params into the database
@@ -221,52 +312,22 @@ class DatabaseWriter(object):
         :param machine_time_step: the machine time step used in timing
         :param runtime: the amount of time the application is to run for
         """
-
-        # noinspection PyBroadException
-        try:
-            import sqlite3 as sqlite
-            connection = sqlite.connect(self._database_path)
-            cur = connection.cursor()
-            # create table
-            cur.execute(
-                "CREATE TABLE configuration_parameters("
-                "parameter_id TEXT, value REAL, "
-                "PRIMARY KEY (parameter_id))")
-
-            # Done in 3 statements, as Windows seems to not support
-            # multiple value sets in a single statement
-            cur.execute(
-                "INSERT INTO configuration_parameters (parameter_id, value)"
-                " VALUES ('machine_time_step', {})".format(machine_time_step)
-            )
-            cur.execute(
-                "INSERT INTO configuration_parameters (parameter_id, value)"
-                " VALUES ('time_scale_factor', {})".format(time_scale_factor)
-            )
+        with self._connection as c:
+            self._insert_cfg(c, "machine_time_step", machine_time_step)
+            self._insert_cfg(c, "time_scale_factor", time_scale_factor)
             if runtime is not None:
-                cur.execute(
-                    "INSERT INTO configuration_parameters"
-                    " (parameter_id, value) VALUES ('infinite_run', 'False')"
-                )
-                cur.execute(
-                    "INSERT INTO configuration_parameters"
-                    " (parameter_id, value) VALUES ('runtime', {})".format(
-                        runtime)
-                )
+                self._insert_cfg(c, "infinite_run", "False")
+                self._insert_cfg(c, "runtime", runtime)
             else:
-                cur.execute(
-                    "INSERT INTO configuration_parameters"
-                    " (parameter_id, value) VALUES ('infinite_run', 'True')"
-                )
-                cur.execute(
-                    "INSERT INTO configuration_parameters"
-                    " (parameter_id, value) VALUES ('runtime', {})".format(-1)
-                )
+                self._insert_cfg(c, "infinite_run", "True")
+                self._insert_cfg(c, "runtime", -1)
 
-            connection.commit()
-            connection.close()
-        except Exception:
-            traceback.print_exc()
+    @staticmethod
+    def _insert_cfg(c, parameter_id, value):
+        c.execute(
+            "INSERT INTO configuration_parameters ("
+            "  parameter_id, value) "
+            "VALUES (?, ?)", (parameter_id, value))
 
     def add_vertices(self, machine_graph, graph_mapper, application_graph):
         """ Add the machine graph, graph mapper and application graph \
@@ -277,159 +338,79 @@ class DatabaseWriter(object):
         :param application_graph: the application graph object
         :rtype: None
         """
-
-        # noinspection PyBroadException
-        try:
-            import sqlite3 as sqlite
-            connection = sqlite.connect(self._database_path)
-            cur = connection.cursor()
-            cur.execute(
-                "CREATE TABLE Machine_vertices("
-                "vertex_id INTEGER PRIMARY KEY AUTOINCREMENT, label TEXT, "
-                "cpu_used INT, sdram_used INT, dtcm_used INT)")
-            cur.execute(
-                "CREATE TABLE Machine_edges("
-                "edge_id INTEGER PRIMARY KEY AUTOINCREMENT, "
-                "pre_vertex INTEGER, post_vertex INTEGER, label TEXT, "
-                "FOREIGN KEY (pre_vertex)"
-                " REFERENCES Machine_vertices(vertex_id), "
-                "FOREIGN KEY (post_vertex)"
-                " REFERENCES Machine_vertices(vertex_id))")
-            cur.execute(
-                "CREATE TABLE Machine_graph("
-                "vertex_id INTEGER, edge_id INTEGER, "
-                "PRIMARY KEY(vertex_id, edge_id), "
-                "FOREIGN KEY (vertex_id)"
-                " REFERENCES Machine_vertices(vertex_id), "
-                "FOREIGN KEY (edge_id)"
-                " REFERENCES Machine_edges(edge_id))")
-
-            # add machine vertex
-            for vertex in machine_graph.vertices:
-                cur.execute(
+        with self._connection as c:
+            for idx, vertex in enumerate(machine_graph.vertices, start=1):
+                c.execute(
                     "INSERT INTO Machine_vertices ("
-                    "label, cpu_used, sdram_used, dtcm_used) "
-                    "VALUES('{}', {}, {}, {});"
-                    .format(vertex.label,
-                            vertex.resources_required.cpu_cycles.get_value(),
-                            vertex.resources_required.sdram.get_value(),
-                            vertex.resources_required.dtcm.get_value()))
+                    "  label, cpu_used, sdram_used, dtcm_used) "
+                    "VALUES(?, ?, ?, ?)", (
+                        vertex.label,
+                        vertex.resources_required.cpu_cycles.get_value(),
+                        vertex.resources_required.sdram.get_value(),
+                        vertex.resources_required.dtcm.get_value()))
+                self._vertex_to_id[vertex] = idx
 
             # add machine edges
-            machine_vertices = list(machine_graph.vertices)
-            machine_edges = list(machine_graph.edges)
-            for edge in machine_edges:
-                cur.execute(
+            for idx, edge in enumerate(machine_graph.edges, start=1):
+                c.execute(
                     "INSERT INTO Machine_edges ("
-                    "pre_vertex, post_vertex, label) "
-                    "VALUES({}, {}, '{}');"
-                    .format(machine_vertices.index(edge.pre_vertex) + 1,
-                            machine_vertices.index(edge.post_vertex) + 1,
-                            edge.label))
+                    "  pre_vertex, post_vertex, label) "
+                    "VALUES(?, ?, ?)", (
+                        self._vertex_to_id[edge.pre_vertex],
+                        self._vertex_to_id[edge.post_vertex],
+                        edge.label))
 
             # add to machine graph
             for vertex in machine_graph.vertices:
                 for edge in machine_graph.get_edges_starting_at_vertex(vertex):
-                    cur.execute(
+                    c.execute(
                         "INSERT INTO Machine_graph ("
-                        "vertex_id, edge_id)"
-                        " VALUES({}, {});"
-                        .format(machine_vertices.index(vertex) + 1,
-                                machine_edges.index(edge) + 1))
+                        "  vertex_id, edge_id) "
+                        "VALUES(?, ?)", (
+                            self._vertex_to_id[vertex],
+                            self._edge_to_id[edge]))
 
             if application_graph is not None:
-
-                # create mapper tables
-                cur.execute(
-                    "CREATE TABLE graph_mapper_vertex("
-                    "application_vertex_id INTEGER, "
-                    "machine_vertex_id INTEGER, lo_atom INT, hi_atom INT, "
-                    "PRIMARY KEY(application_vertex_id, "
-                    "machine_vertex_id), "
-                    "FOREIGN KEY (machine_vertex_id)"
-                    " REFERENCES Machine_vertices(vertex_id), "
-                    "FOREIGN KEY (application_vertex_id)"
-                    " REFERENCES Application_vertices(vertex_id))")
-                cur.execute(
-                    "CREATE TABLE graph_mapper_edges("
-                    "application_edge_id INTEGER,"
-                    " machine_edge_id INTEGER, "
-                    "PRIMARY KEY(application_edge_id, machine_edge_id), "
-                    "FOREIGN KEY (machine_edge_id)"
-                    " REFERENCES Machine_edges(edge_id), "
-                    "FOREIGN KEY (application_edge_id)"
-                    " REFERENCES Application_edges(edge_id))")
-
-                # add mapper for vertex
-                app_vertices = list(application_graph.vertices)
-                for machine_vertex in machine_vertices:
+                for machine_vertex in machine_graph.vertices:
                     app_vertex = graph_mapper.get_application_vertex(
                         machine_vertex)
                     vertex_slice = graph_mapper.get_slice(machine_vertex)
-                    cur.execute(
+                    c.execute(
                         "INSERT INTO graph_mapper_vertex ("
-                        "application_vertex_id, machine_vertex_id, "
-                        "lo_atom, hi_atom) "
-                        "VALUES({}, {}, {}, {});"
-                        .format(app_vertices.index(app_vertex) + 1,
-                                machine_vertices.index(machine_vertex) + 1,
-                                vertex_slice.lo_atom, vertex_slice.hi_atom))
+                        "  application_vertex_id, machine_vertex_id, "
+                        "  lo_atom, hi_atom) "
+                        "VALUES(?, ?, ?, ?)", (
+                            self._vertex_to_id[app_vertex],
+                            self._vertex_to_id[machine_vertex],
+                            vertex_slice.lo_atom, vertex_slice.hi_atom))
 
                 # add graph_mapper edges
-                app_edges = list(application_graph.edges)
-                for edge in machine_edges:
+                for edge in machine_graph.edges:
                     app_edge = graph_mapper.get_application_edge(edge)
-                    cur.execute(
+                    c.execute(
                         "INSERT INTO graph_mapper_edges ("
-                        "application_edge_id, machine_edge_id) "
-                        "VALUES({}, {})"
-                        .format(machine_edges.index(edge) + 1,
-                                app_edges.index(app_edge) + 1))
+                        "  application_edge_id, machine_edge_id) "
+                        "VALUES(?, ?)", (
+                            self._edge_to_id[edge],
+                            self._edge_to_id[app_edge]))
 
-            connection.commit()
-            connection.close()
-        except Exception:
-            traceback.print_exc()
-
-    def add_placements(self, placements, machine_graph):
+    def add_placements(self, placements):
         """ Adds the placements objects into the database
 
         :param placements: the placements object
         :param machine_graph: the machine graph object
         :rtype: None
         """
-
-        # noinspection PyBroadException
-        try:
-            import sqlite3 as sqlite
-            connection = sqlite.connect(self._database_path)
-            cur = connection.cursor()
-
-            # create tables
-            cur.execute(
-                "CREATE TABLE Placements("
-                "vertex_id INTEGER PRIMARY KEY, machine_id INTEGER, "
-                "chip_x INT, chip_y INT, chip_p INT, "
-                "FOREIGN KEY (vertex_id) "
-                "REFERENCES Machine_vertices(vertex_id), "
-                "FOREIGN KEY (chip_x, chip_y, chip_p, machine_id) "
-                "REFERENCES Processor(chip_x, chip_y, physical_id, "
-                "machine_id))")
-
+        with self._connection as c:
             # add records
-            machine_vertices = list(machine_graph.vertices)
             for placement in placements.placements:
-                cur.execute(
+                c.execute(
                     "INSERT INTO Placements("
-                    "vertex_id, chip_x, chip_y, chip_p, machine_id) "
-                    "VALUES({}, {}, {}, {}, {})"
-                    .format(machine_vertices.index(placement.vertex) + 1,
-                            placement.x, placement.y, placement.p,
-                            self._machine_id))
-            connection.commit()
-            connection.close()
-        except Exception:
-            traceback.print_exc()
+                    "  vertex_id, chip_x, chip_y, chip_p, machine_id) "
+                    "VALUES(?, ?, ?, ?, ?)", (
+                        self._vertex_to_id[placement.vertex],
+                        placement.x, placement.y, placement.p,
+                        self._machine_id))
 
     def add_routing_infos(self, routing_infos, machine_graph):
         """ Adds the routing information (key masks etc) into the database
@@ -438,35 +419,18 @@ class DatabaseWriter(object):
         :param machine_graph: the machine graph object
         :rtype: None:
         """
-
-        # noinspection PyBroadException
-        try:
-            import sqlite3 as sqlite
-            connection = sqlite.connect(self._database_path)
-            cur = connection.cursor()
-            cur.execute(
-                "CREATE TABLE Routing_info("
-                "edge_id INTEGER, key INT, mask INT, "
-                "PRIMARY KEY (edge_id, key, mask), "
-                "FOREIGN KEY (edge_id) REFERENCES Machine_edges(edge_id))")
-
-            all_edges = list(machine_graph.edges)
-
+        with self._connection as c:
             for partition in machine_graph.outgoing_edge_partitions:
                 rinfo = routing_infos.get_routing_info_from_partition(
                     partition)
                 for edge in partition.edges:
                     for key_mask in rinfo.keys_and_masks:
-                        cur.execute(
+                        c.execute(
                             "INSERT INTO Routing_info("
-                            "edge_id, key, mask) "
-                            "VALUES({}, {}, {})"
-                            .format(all_edges.index(edge) + 1,
-                                    key_mask.key, key_mask.mask))
-            connection.commit()
-            connection.close()
-        except Exception:
-            traceback.print_exc()
+                            "  edge_id, key, mask) "
+                            "VALUES(?, ?, ?)", (
+                                self._edge_to_id[edge],
+                                key_mask.key, key_mask.mask))
 
     def add_routing_tables(self, routing_tables):
         """ Adds the routing tables into the database
@@ -474,39 +438,21 @@ class DatabaseWriter(object):
         :param routing_tables: the routing tables object
         :rtype: None
         """
-
-        # noinspection PyBroadException
-        try:
-            import sqlite3 as sqlite
-            connection = sqlite.connect(self._database_path)
-            cur = connection.cursor()
-
-            cur.execute(
-                "CREATE TABLE Routing_table("
-                "chip_x INTEGER, chip_y INTEGER, position INTEGER, "
-                "key_combo INT, mask INT, route INT, "
-                "PRIMARY KEY (chip_x, chip_y, position))")
-
+        with self._connection as c:
             for routing_table in routing_tables.routing_tables:
-                counter = 0
-                for entry in routing_table.multicast_routing_entries:
+                for counter, entry in \
+                        enumerate(routing_table.multicast_routing_entries):
                     route_entry = 0
                     for processor_id in entry.processor_ids:
-                        route_entry |= (1 << (6 + processor_id))
+                        route_entry |= 1 << (6 + processor_id)
                     for link_id in entry.link_ids:
-                        route_entry |= (1 << link_id)
-                    cur.execute(
+                        route_entry |= 1 << link_id
+                    c.execute(
                         "INSERT INTO Routing_table("
-                        "chip_x, chip_y, position, key_combo, mask, route) "
-                        "VALUES({}, {}, {}, {}, {}, {})"
-                        .format(routing_table.x, routing_table.y, counter,
-                                entry.routing_entry_key, entry.mask,
-                                route_entry))
-                    counter += 1
-            connection.commit()
-            connection.close()
-        except Exception:
-            traceback.print_exc()
+                        "  chip_x, chip_y, position, key_combo, mask, route) "
+                        "VALUES(?, ?, ?, ?, ?, ?)", (
+                            routing_table.x, routing_table.y, counter,
+                            entry.routing_entry_key, entry.mask, route_entry))
 
     def add_tags(self, machine_graph, tags):
         """ Adds the tags into the database
@@ -515,56 +461,31 @@ class DatabaseWriter(object):
         :param tags: the tags object
         :rtype: None
         """
-
-        # noinspection PyBroadException
-        try:
-            import sqlite3 as sqlite
-            connection = sqlite.connect(self._database_path)
-            cur = connection.cursor()
-            cur.execute(
-                "CREATE TABLE IP_tags("
-                "vertex_id INTEGER, tag INTEGER, "
-                "board_address TEXT, ip_address TEXT, port INTEGER, "
-                "strip_sdp BOOLEAN,"
-                "PRIMARY KEY ("
-                "vertex_id, tag, board_address, ip_address, port, strip_sdp),"
-                "FOREIGN KEY (vertex_id) REFERENCES "
-                "Machine_vertices(vertex_id))")
-            cur.execute(
-                "CREATE TABLE Reverse_IP_tags("
-                "vertex_id INTEGER PRIMARY KEY, tag INTEGER, "
-                "board_address TEXT, port INTEGER, "
-                "FOREIGN KEY (vertex_id) REFERENCES "
-                "Machine_vertices(vertex_id))")
-
-            vertices = list(machine_graph.vertices)
+        with self._connection as c:
             for vertex in machine_graph.vertices:
                 ip_tags = tags.get_ip_tags_for_vertex(vertex)
-                index = vertices.index(vertex) + 1
+                index = self._vertex_to_id[vertex]
                 if ip_tags is not None:
                     for ip_tag in ip_tags:
-                        cur.execute(
-                            "INSERT INTO IP_tags(vertex_id, tag,"
-                            " board_address, ip_address, port, strip_sdp)"
-                            " VALUES ({}, {}, '{}', '{}', {}, {})"
-                            .format(index, ip_tag.tag, ip_tag.board_address,
-                                    ip_tag.ip_address, ip_tag.port,
-                                    "1" if ip_tag.strip_sdp else "0"))
+                        c.execute(
+                            "INSERT INTO IP_tags("
+                            "  vertex_id, tag, board_address, ip_address,"
+                            "  port, strip_sdp) "
+                            "VALUES (?, ?, ?, ?, ?, ?)", (
+                                index, ip_tag.tag, ip_tag.board_address,
+                                ip_tag.ip_address, ip_tag.port,
+                                1 if ip_tag.strip_sdp else 0))
                 reverse_ip_tags = tags.get_reverse_ip_tags_for_vertex(
                     vertex)
                 if reverse_ip_tags is not None:
                     for reverse_ip_tag in reverse_ip_tags:
-                        cur.execute(
-                            "INSERT INTO Reverse_IP_tags(vertex_id, tag,"
-                            " board_address, port)"
-                            " VALUES ({}, {}, '{}', {})"
-                            .format(index, reverse_ip_tag.tag,
-                                    reverse_ip_tag.board_address,
-                                    reverse_ip_tag.port))
-            connection.commit()
-            connection.close()
-        except Exception:
-            traceback.print_exc()
+                        c.execute(
+                            "INSERT INTO Reverse_IP_tags("
+                            "  vertex_id, tag, board_address, port) "
+                            "VALUES (?, ?, ?, ?)", (
+                                index, reverse_ip_tag.tag,
+                                reverse_ip_tag.board_address,
+                                reverse_ip_tag.port))
 
     def create_atom_to_event_id_mapping(
             self, application_graph, machine_graph, routing_infos,
@@ -577,75 +498,39 @@ class DatabaseWriter(object):
         :param graph_mapper:
         :rtype: None
         """
-
-        # noinspection PyBroadException
-        try:
-            import sqlite3 as sqlite
-            connection = sqlite.connect(self._database_path)
-            cur = connection.cursor()
-
-            # create table
-            cur.execute(
-                "CREATE TABLE event_to_atom_mapping("
-                "vertex_id INTEGER, atom_id INTEGER, "
-                "event_id INTEGER PRIMARY KEY, "
-                "FOREIGN KEY (vertex_id)"
-                " REFERENCES Machine_vertices(vertex_id))")
-
-            if (application_graph is not None and
-                    application_graph.n_vertices != 0):
-
-                # insert into table
-                vertices = list(application_graph.vertices)
-                for vertex in machine_graph.vertices:
-                    partitions = machine_graph.\
+        have_app_graph = (application_graph is not None and
+                          application_graph.n_vertices != 0)
+        with self._connection as c:
+            for vertex in machine_graph.vertices:
+                for partition in machine_graph.\
                         get_outgoing_edge_partitions_starting_at_vertex(
-                            vertex)
-                    for partition in partitions:
-                        routing_info = routing_infos.\
-                            get_routing_info_from_partition(partition)
-                        app_vertex = graph_mapper.get_application_vertex(
-                            vertex)
-                        vertex_id = vertices.index(app_vertex) + 1
+                            vertex):
+                    if have_app_graph:
                         self._insert_vertex_atom_to_key_map(
-                            app_vertex, partition, vertex_id, routing_info,
-                            cur)
-            else:
-                # insert into table
-                vertices = list(machine_graph.vertices)
-                for vertex in machine_graph.vertices:
-                    out_going_partitions = machine_graph.\
-                        get_outgoing_edge_partitions_starting_at_vertex(
-                            vertex)
-                    for partition in out_going_partitions:
-                        routing_info = routing_infos.\
-                            get_routing_info_from_partition(partition)
-                        vertex_id = vertices.index(vertex) + 1
+                            graph_mapper.get_application_vertex(vertex),
+                            partition, routing_infos, c)
+                    else:
                         self._insert_vertex_atom_to_key_map(
-                            vertex, partition, vertex_id, routing_info, cur)
+                            vertex, partition, routing_infos, c)
 
-            connection.commit()
-            connection.close()
-        except Exception:
-            traceback.print_exc()
-
-    @staticmethod
     def _insert_vertex_atom_to_key_map(
-            vertex, partition, vertex_id, routing_info, cur):
+            self, vertex, partition, routing_infos, cur):
         """
 
         :param vertex:
         :param partition:
-        :param vertex_id:
-        :param routing_info:
+        :param routing_infos:
         :param cur:
         :rtype: None
         """
         if isinstance(vertex, AbstractProvidesKeyToAtomMapping):
-            mapping = vertex.routing_key_partition_atom_mapping(
-                routing_info, partition)
-            for (atom_id, key) in mapping:
+            vertex_id = self._vertex_to_id[vertex]
+            routing_info = routing_infos.get_routing_info_from_partition(
+                partition)
+            for atom_id, key in vertex.routing_key_partition_atom_mapping(
+                    routing_info, partition):
                 cur.execute(
                     "INSERT INTO event_to_atom_mapping("
-                    "vertex_id, event_id, atom_id) "
-                    "VALUES ({}, {}, {})".format(vertex_id, key, atom_id))
+                    "  vertex_id, event_id, atom_id) "
+                    "VALUES (?, ?, ?)", (
+                        vertex_id, key, atom_id))

--- a/spinn_front_end_common/utilities/database/database_writer.py
+++ b/spinn_front_end_common/utilities/database/database_writer.py
@@ -7,6 +7,7 @@ from spinn_front_end_common.abstract_models \
 # general imports
 import logging
 import os
+import sqlite3
 import sys
 
 logger = logging.getLogger(__name__)
@@ -61,8 +62,7 @@ class DatabaseWriter(object):
         self._machine_id = 0
 
     def __enter__(self):
-        import sqlite3 as sqlite
-        self._connection = sqlite.connect(self._database_path)
+        self._connection = sqlite3.connect(self._database_path)
         self.create_schema()
         return self
          

--- a/spinn_front_end_common/utilities/database/database_writer.py
+++ b/spinn_front_end_common/utilities/database/database_writer.py
@@ -65,7 +65,7 @@ class DatabaseWriter(object):
         self._connection = sqlite3.connect(self._database_path)
         self.create_schema()
         return self
-         
+
     def __exit__(self, exc_type, exc_val, exc_tb):  # @UnusedVariable
         self._connection.close()
         self._connection = None

--- a/spinn_front_end_common/utilities/database/database_writer.py
+++ b/spinn_front_end_common/utilities/database/database_writer.py
@@ -1,6 +1,5 @@
 # spinn front end common
 from pacman.model.abstract_classes import AbstractHasGlobalMaxAtoms
-from pandas.util.doctools import idx
 from spinn_front_end_common.abstract_models \
     import AbstractProvidesKeyToAtomMapping, AbstractRecordable, \
     AbstractSupportsDatabaseInjection
@@ -91,14 +90,15 @@ class DatabaseWriter(object):
     def database_path(self):
         return self._database_path
 
-    @property
-    def _cursor(self):
-        return self._connection.cursor()
+    def _ins(self, sql, *args):
+        c = self._connection.cursor()
+        c.execute(sql, args)
+        return c.lastrowid
 
     def create_schema(self):
-        with self._connection as c, open(self._init_sql_path) as f:
+        with self._connection, open(self._init_sql_path) as f:
             sql = f.read()
-            c.execute(sql)
+            self._connection.executescript(sql)
 
     def add_machine_objects(self, machine):
         """ Store the machine object into the database
@@ -106,31 +106,31 @@ class DatabaseWriter(object):
         :param machine: the machine object.
         :rtype: None
         """
-        with self._connection as c:
+        with self._connection:
             x_di = machine.max_chip_x + 1
             y_di = machine.max_chip_y + 1
-            c.execute("INSERT INTO Machine_layout("
-                      "  x_dimension, y_dimension) "
-                      "VALUES(?, ?)", (x_di, y_di))
+            self._machine_to_id[machine] = self._ins(
+                "INSERT INTO Machine_layout("
+                "  x_dimension, y_dimension) "
+                "VALUES(?, ?)", x_di, y_di)
             self._machine_id += 1
-            self._machine_to_id[machine] = self._machine_id
             for chip in machine.chips:
-                c.execute(
+                self._ins(
                     "INSERT INTO Machine_chip("
                     "  no_processors, chip_x, chip_y, machine_id) "
-                    "VALUES (?, ?, ?, ?)", (
-                        len(list(chip.processors)), chip.x, chip.y,
-                        self._machine_id))
+                    "VALUES (?, ?, ?, ?)",
+                    len(list(chip.processors)), chip.x, chip.y,
+                    self._machine_id)
                 for processor in chip.processors:
-                    c.execute(
+                    self._ins(
                         "INSERT INTO Processor("
                         "  chip_x, chip_y, machine_id, available_DTCM, "
                         "  available_CPU, physical_id) "
-                        "VALUES(?, ?, ?, ?, ?, ?)", (
-                            chip.x, chip.y, self._machine_id,
-                            processor.dtcm_available,
-                            processor.cpu_cycles_available,
-                            processor.processor_id))
+                        "VALUES(?, ?, ?, ?, ?, ?)",
+                        chip.x, chip.y, self._machine_id,
+                        processor.dtcm_available,
+                        processor.cpu_cycles_available,
+                        processor.processor_id)
 
     def add_application_vertices(self, application_graph):
         """
@@ -138,53 +138,49 @@ class DatabaseWriter(object):
         :param application_graph:
         :rtype: None
         """
-        with self._connection as c:
+        with self._connection:
             # add vertices
-            for idx, vertex in enumerate(application_graph.vertices, start=1):
+            for vertex in application_graph.vertices:
                 if isinstance(vertex, AbstractRecordable):
-                    self._insert_app_vertex(
-                        c, vertex, vertex.get_max_atoms_per_core(),
+                    self._vertex_to_id[vertex] = self._insert_app_vertex(
+                        vertex, vertex.get_max_atoms_per_core(),
                         vertex.is_recording_spikes())
                 elif isinstance(vertex, AbstractHasGlobalMaxAtoms):
-                    self._insert_app_vertex(
-                        c, vertex, vertex.get_max_atoms_per_core(), 0)
+                    self._vertex_to_id[vertex] = self._insert_app_vertex(
+                        vertex, vertex.get_max_atoms_per_core(), 0)
                 else:
-                    self._insert_app_vertex(c, vertex, sys.maxint, 0)
-                self._vertex_to_id[vertex] = idx
+                    self._vertex_to_id[vertex] = self._insert_app_vertex(
+                        vertex, sys.maxint, 0)
 
             # add edges
-            idx = 1
             for vertex in application_graph.vertices:
                 for edge in application_graph.\
                         get_edges_starting_at_vertex(vertex):
-                    c.execute(
+                    self._edge_to_id[edge] = self._ins(
                         "INSERT INTO Application_edges ("
                         "  pre_vertex, post_vertex, edge_label) "
-                        "VALUES(?, ?, ?)", (
-                            self._vertex_to_id[edge.pre_vertex],
-                            self._vertex_to_id[edge.post_vertex],
-                            edge.label))
-                    self._edge_to_id[edge] = idx
-                    idx += 1
+                        "VALUES(?, ?, ?)",
+                        self._vertex_to_id[edge.pre_vertex],
+                        self._vertex_to_id[edge.post_vertex],
+                        edge.label)
 
             # update graph
             for vertex in application_graph.vertices:
                 for edge in application_graph.\
                         get_edges_starting_at_vertex(vertex):
-                    c.execute(
+                    self._ins(
                         "INSERT INTO Application_graph ("
                         "  vertex_id, edge_id) "
-                        "VALUES(?, ?)", (
-                            self._vertex_to_id[vertex],
-                            self._edge_to_id[edge]))
+                        "VALUES(?, ?)",
+                        self._vertex_to_id[vertex],
+                        self._edge_to_id[edge])
 
-    @staticmethod
-    def _insert_app_vertex(c, vertex, max_atoms, is_recording):
-        c.execute(
+    def _insert_app_vertex(self, vertex, max_atoms, is_recording):
+        return self._ins(
             "INSERT INTO Application_vertices("
             "  vertex_label, no_atoms, max_atom_constrant, recorded) "
-            "VALUES(?, ?, ?, ?)", (
-                vertex.label, vertex.n_atoms, max_atoms, int(is_recording)))
+            "VALUES(?, ?, ?, ?)",
+            vertex.label, vertex.n_atoms, max_atoms, int(is_recording))
 
     def add_system_params(self, time_scale_factor, machine_time_step, runtime):
         """ Write system params into the database
@@ -193,22 +189,22 @@ class DatabaseWriter(object):
         :param machine_time_step: the machine time step used in timing
         :param runtime: the amount of time the application is to run for
         """
-        with self._connection as c:
-            self._insert_cfg(c, "machine_time_step", machine_time_step)
-            self._insert_cfg(c, "time_scale_factor", time_scale_factor)
+        with self._connection:
+            self._insert_cfg("machine_time_step", machine_time_step)
+            self._insert_cfg("time_scale_factor", time_scale_factor)
             if runtime is not None:
-                self._insert_cfg(c, "infinite_run", "False")
-                self._insert_cfg(c, "runtime", runtime)
+                self._insert_cfg("infinite_run", "False")
+                self._insert_cfg("runtime", runtime)
             else:
-                self._insert_cfg(c, "infinite_run", "True")
-                self._insert_cfg(c, "runtime", -1)
+                self._insert_cfg("infinite_run", "True")
+                self._insert_cfg("runtime", -1)
 
-    @staticmethod
-    def _insert_cfg(c, parameter_id, value):
-        c.execute(
+    def _insert_cfg(self, parameter_id, value):
+        self._ins(
             "INSERT INTO configuration_parameters ("
             "  parameter_id, value) "
-            "VALUES (?, ?)", (parameter_id, value))
+            "VALUES (?, ?)",
+            parameter_id, value)
 
     def add_vertices(self, machine_graph, graph_mapper, application_graph):
         """ Add the machine graph, graph mapper and application graph \
@@ -219,61 +215,57 @@ class DatabaseWriter(object):
         :param application_graph: the application graph object
         :rtype: None
         """
-        with self._connection as c:
-            for idx, vertex in enumerate(machine_graph.vertices, start=1):
-                c.execute(
+        with self._connection:
+            for vertex in machine_graph.vertices:
+                self._vertex_to_id[vertex] = self._ins(
                     "INSERT INTO Machine_vertices ("
                     "  label, cpu_used, sdram_used, dtcm_used) "
-                    "VALUES(?, ?, ?, ?)", (
-                        vertex.label,
-                        vertex.resources_required.cpu_cycles.get_value(),
-                        vertex.resources_required.sdram.get_value(),
-                        vertex.resources_required.dtcm.get_value()))
-                self._vertex_to_id[vertex] = idx
+                    "VALUES(?, ?, ?, ?)",
+                    vertex.label,
+                    vertex.resources_required.cpu_cycles.get_value(),
+                    vertex.resources_required.sdram.get_value(),
+                    vertex.resources_required.dtcm.get_value())
 
             # add machine edges
-            for idx, edge in enumerate(machine_graph.edges, start=1):
-                c.execute(
+            for edge in machine_graph.edges:
+                self._ins(
                     "INSERT INTO Machine_edges ("
                     "  pre_vertex, post_vertex, label) "
-                    "VALUES(?, ?, ?)", (
-                        self._vertex_to_id[edge.pre_vertex],
-                        self._vertex_to_id[edge.post_vertex],
-                        edge.label))
+                    "VALUES(?, ?, ?)",
+                    self._vertex_to_id[edge.pre_vertex],
+                    self._vertex_to_id[edge.post_vertex], edge.label)
 
             # add to machine graph
             for vertex in machine_graph.vertices:
                 for edge in machine_graph.get_edges_starting_at_vertex(vertex):
-                    c.execute(
+                    self._ins(
                         "INSERT INTO Machine_graph ("
                         "  vertex_id, edge_id) "
-                        "VALUES(?, ?)", (
-                            self._vertex_to_id[vertex],
-                            self._edge_to_id[edge]))
+                        "VALUES(?, ?)",
+                        self._vertex_to_id[vertex], self._edge_to_id[edge])
 
             if application_graph is not None:
                 for machine_vertex in machine_graph.vertices:
                     app_vertex = graph_mapper.get_application_vertex(
                         machine_vertex)
                     vertex_slice = graph_mapper.get_slice(machine_vertex)
-                    c.execute(
+                    self._ins(
                         "INSERT INTO graph_mapper_vertex ("
                         "  application_vertex_id, machine_vertex_id, "
                         "  lo_atom, hi_atom) "
-                        "VALUES(?, ?, ?, ?)", (
-                            self._vertex_to_id[app_vertex],
-                            self._vertex_to_id[machine_vertex],
-                            vertex_slice.lo_atom, vertex_slice.hi_atom))
+                        "VALUES(?, ?, ?, ?)",
+                        self._vertex_to_id[app_vertex],
+                        self._vertex_to_id[machine_vertex],
+                        vertex_slice.lo_atom, vertex_slice.hi_atom)
 
                 # add graph_mapper edges
                 for edge in machine_graph.edges:
                     app_edge = graph_mapper.get_application_edge(edge)
-                    c.execute(
+                    self._ins(
                         "INSERT INTO graph_mapper_edges ("
                         "  application_edge_id, machine_edge_id) "
-                        "VALUES(?, ?)", (
-                            self._edge_to_id[edge],
-                            self._edge_to_id[app_edge]))
+                        "VALUES(?, ?)",
+                        self._edge_to_id[edge], self._edge_to_id[app_edge])
 
     def add_placements(self, placements):
         """ Adds the placements objects into the database
@@ -282,16 +274,15 @@ class DatabaseWriter(object):
         :param machine_graph: the machine graph object
         :rtype: None
         """
-        with self._connection as c:
+        with self._connection:
             # add records
             for placement in placements.placements:
-                c.execute(
+                self._ins(
                     "INSERT INTO Placements("
                     "  vertex_id, chip_x, chip_y, chip_p, machine_id) "
-                    "VALUES(?, ?, ?, ?, ?)", (
-                        self._vertex_to_id[placement.vertex],
-                        placement.x, placement.y, placement.p,
-                        self._machine_id))
+                    "VALUES(?, ?, ?, ?, ?)",
+                    self._vertex_to_id[placement.vertex],
+                    placement.x, placement.y, placement.p, self._machine_id)
 
     def add_routing_infos(self, routing_infos, machine_graph):
         """ Adds the routing information (key masks etc) into the database
@@ -300,18 +291,18 @@ class DatabaseWriter(object):
         :param machine_graph: the machine graph object
         :rtype: None:
         """
-        with self._connection as c:
+        with self._connection:
             for partition in machine_graph.outgoing_edge_partitions:
                 rinfo = routing_infos.get_routing_info_from_partition(
                     partition)
                 for edge in partition.edges:
                     for key_mask in rinfo.keys_and_masks:
-                        c.execute(
+                        self._ins(
                             "INSERT INTO Routing_info("
                             "  edge_id, \"key\", mask) "
-                            "VALUES(?, ?, ?)", (
-                                self._edge_to_id[edge],
-                                key_mask.key, key_mask.mask))
+                            "VALUES(?, ?, ?)",
+                            self._edge_to_id[edge],
+                            key_mask.key, key_mask.mask)
 
     def add_routing_tables(self, routing_tables):
         """ Adds the routing tables into the database
@@ -319,7 +310,7 @@ class DatabaseWriter(object):
         :param routing_tables: the routing tables object
         :rtype: None
         """
-        with self._connection as c:
+        with self._connection:
             for routing_table in routing_tables.routing_tables:
                 for counter, entry in \
                         enumerate(routing_table.multicast_routing_entries):
@@ -328,12 +319,12 @@ class DatabaseWriter(object):
                         route_entry |= 1 << (6 + processor_id)
                     for link_id in entry.link_ids:
                         route_entry |= 1 << link_id
-                    c.execute(
+                    self._ins(
                         "INSERT INTO Routing_table("
                         "  chip_x, chip_y, position, key_combo, mask, route) "
-                        "VALUES(?, ?, ?, ?, ?, ?)", (
-                            routing_table.x, routing_table.y, counter,
-                            entry.routing_entry_key, entry.mask, route_entry))
+                        "VALUES(?, ?, ?, ?, ?, ?)",
+                        routing_table.x, routing_table.y, counter,
+                        entry.routing_entry_key, entry.mask, route_entry)
 
     def add_tags(self, machine_graph, tags):
         """ Adds the tags into the database
@@ -342,31 +333,31 @@ class DatabaseWriter(object):
         :param tags: the tags object
         :rtype: None
         """
-        with self._connection as c:
+        with self._connection:
             for vertex in machine_graph.vertices:
+                vertex_id = self._vertex_to_id[vertex]
                 ip_tags = tags.get_ip_tags_for_vertex(vertex)
-                index = self._vertex_to_id[vertex]
                 if ip_tags is not None:
                     for ip_tag in ip_tags:
-                        c.execute(
+                        self._ins(
                             "INSERT INTO IP_tags("
                             "  vertex_id, tag, board_address, ip_address,"
                             "  port, strip_sdp) "
-                            "VALUES (?, ?, ?, ?, ?, ?)", (
-                                index, ip_tag.tag, ip_tag.board_address,
-                                ip_tag.ip_address, ip_tag.port,
-                                1 if ip_tag.strip_sdp else 0))
+                            "VALUES (?, ?, ?, ?, ?, ?)",
+                            vertex_id, ip_tag.tag, ip_tag.board_address,
+                            ip_tag.ip_address, ip_tag.port,
+                            1 if ip_tag.strip_sdp else 0)
                 reverse_ip_tags = tags.get_reverse_ip_tags_for_vertex(
                     vertex)
                 if reverse_ip_tags is not None:
                     for reverse_ip_tag in reverse_ip_tags:
-                        c.execute(
+                        self._ins(
                             "INSERT INTO Reverse_IP_tags("
                             "  vertex_id, tag, board_address, port) "
-                            "VALUES (?, ?, ?, ?)", (
-                                index, reverse_ip_tag.tag,
-                                reverse_ip_tag.board_address,
-                                reverse_ip_tag.port))
+                            "VALUES (?, ?, ?, ?)",
+                            vertex_id, reverse_ip_tag.tag,
+                            reverse_ip_tag.board_address,
+                            reverse_ip_tag.port)
 
     def create_atom_to_event_id_mapping(
             self, application_graph, machine_graph, routing_infos,
@@ -381,7 +372,7 @@ class DatabaseWriter(object):
         """
         have_app_graph = (application_graph is not None and
                           application_graph.n_vertices != 0)
-        with self._connection as c:
+        with self._connection:
             for vertex in machine_graph.vertices:
                 for partition in machine_graph.\
                         get_outgoing_edge_partitions_starting_at_vertex(
@@ -389,19 +380,18 @@ class DatabaseWriter(object):
                     if have_app_graph:
                         self._insert_vertex_atom_to_key_map(
                             graph_mapper.get_application_vertex(vertex),
-                            partition, routing_infos, c)
+                            partition, routing_infos)
                     else:
                         self._insert_vertex_atom_to_key_map(
-                            vertex, partition, routing_infos, c)
+                            vertex, partition, routing_infos)
 
     def _insert_vertex_atom_to_key_map(
-            self, vertex, partition, routing_infos, cur):
+            self, vertex, partition, routing_infos):
         """
 
         :param vertex:
         :param partition:
         :param routing_infos:
-        :param cur:
         :rtype: None
         """
         if isinstance(vertex, AbstractProvidesKeyToAtomMapping):
@@ -410,8 +400,8 @@ class DatabaseWriter(object):
                 partition)
             for atom_id, key in vertex.routing_key_partition_atom_mapping(
                     routing_info, partition):
-                cur.execute(
+                self._ins(
                     "INSERT INTO event_to_atom_mapping("
                     "  vertex_id, event_id, atom_id) "
-                    "VALUES (?, ?, ?)", (
-                        vertex_id, key, atom_id))
+                    "VALUES (?, ?, ?)",
+                    vertex_id, key, atom_id)

--- a/spinn_front_end_common/utilities/database/db.sql
+++ b/spinn_front_end_common/utilities/database/db.sql
@@ -1,0 +1,177 @@
+-- We want foreign key enforcement; it should be default on, but it isn't for
+-- messy historical reasons.
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS configuration_parameters(
+	parameter_id TEXT,
+	value REAL,
+	PRIMARY KEY (parameter_id));
+
+CREATE TABLE IF NOT EXISTS Machine_layout(
+	machine_id INTEGER PRIMARY KEY AUTOINCREMENT,
+	x_dimension INT,
+	y_dimension INT);
+
+-- A collection of processors
+CREATE TABLE IF NOT EXISTS Machine_chip(
+	no_processors INT,
+	chip_x INTEGER,
+	chip_y INTEGER,
+	machine_id INTEGER,
+	avilableSDRAM INT,
+	PRIMARY KEY (chip_x, chip_y, machine_id),
+	FOREIGN KEY (machine_id)
+		REFERENCES Machine_layout(machine_id));
+
+-- An atomic processing element
+CREATE TABLE IF NOT EXISTS Processor(
+	chip_x INTEGER,
+	chip_y INTEGER,
+	machine_id INTEGER,
+	available_DTCM INT,
+	available_CPU INT,
+	physical_id INTEGER,
+	PRIMARY KEY (chip_x, chip_y, machine_id, physical_id),
+	FOREIGN KEY (chip_x, chip_y, machine_id)
+		REFERENCES Machine_chip(chip_x, chip_y, machine_id));
+
+-- One unit of computation at the application level
+CREATE TABLE IF NOT EXISTS Application_vertices(
+	vertex_id INTEGER PRIMARY KEY AUTOINCREMENT,
+	vertex_label TEXT,
+	no_atoms INT,
+	max_atom_constrant INT,
+	recorded INT);
+
+-- A communication link between two application vertices
+CREATE TABLE IF NOT EXISTS Application_edges(
+	edge_id INTEGER PRIMARY KEY AUTOINCREMENT,
+	pre_vertex INTEGER,
+	post_vertex INTEGER,
+	edge_label TEXT,
+	FOREIGN KEY (pre_vertex)
+		REFERENCES Application_vertices(vertex_id),
+	FOREIGN KEY (post_vertex)
+		REFERENCES Application_vertices(vertex_id));
+
+-- The edge identified by edge_id starts at the vertex identified by vertex_id
+CREATE TABLE IF NOT EXISTS Application_graph(
+	vertex_id INTEGER,
+	edge_id INTEGER,
+	PRIMARY KEY (vertex_id, edge_id),
+	FOREIGN KEY (vertex_id)
+		REFERENCES Application_vertices(vertex_id),
+	FOREIGN KEY (edge_id)
+		REFERENCES Application_edges(edge_id));
+
+-- One unit of computation at the system level; deploys to one processor
+CREATE TABLE IF NOT EXISTS Machine_vertices(
+	vertex_id INTEGER PRIMARY KEY AUTOINCREMENT,
+	label TEXT,
+	cpu_used INT,
+	sdram_used INT,
+	dtcm_used INT);
+
+-- A communication link between two machine vertices
+CREATE TABLE IF NOT EXISTS Machine_edges(
+	edge_id INTEGER PRIMARY KEY AUTOINCREMENT,
+	pre_vertex INTEGER,
+	post_vertex INTEGER,
+	label TEXT,
+	FOREIGN KEY (pre_vertex)
+		REFERENCES Machine_vertices(vertex_id),
+	FOREIGN KEY (post_vertex)
+		REFERENCES Machine_vertices(vertex_id));
+
+-- The edge identified by edge_id starts at the vertex identified by vertex_id
+CREATE TABLE IF NOT EXISTS Machine_graph(
+	vertex_id INTEGER,
+	edge_id INTEGER,
+	PRIMARY KEY (vertex_id, edge_id),
+	FOREIGN KEY (vertex_id)
+		REFERENCES Machine_vertices(vertex_id),
+	FOREIGN KEY (edge_id)
+		REFERENCES Machine_edges(edge_id));
+
+-- The state of the graph mapper, which links each application vertex to a
+-- number of machine vertexes, with contiguous-but-non-overlapping ranges of
+-- atoms.
+CREATE TABLE IF NOT EXISTS graph_mapper_vertex(
+	application_vertex_id INTEGER,
+	machine_vertex_id INTEGER,
+	lo_atom INT,
+	hi_atom INT,
+	PRIMARY KEY (application_vertex_id, machine_vertex_id),
+	FOREIGN KEY (machine_vertex_id)
+		REFERENCES Machine_vertices(vertex_id),
+	FOREIGN KEY (application_vertex_id)
+		REFERENCES Application_vertices(vertex_id));
+
+-- The state of the graph mapper, which links each application edge to one or
+-- more machine edges.
+CREATE TABLE IF NOT EXISTS graph_mapper_edges(
+	application_edge_id INTEGER,
+	machine_edge_id INTEGER,
+	PRIMARY KEY (application_edge_id, machine_edge_id),
+	FOREIGN KEY (machine_edge_id)
+		REFERENCES Machine_edges(edge_id),
+	FOREIGN KEY (application_edge_id)
+		REFERENCES Application_edges(edge_id));
+
+-- How the machine vertices are actually placed on the SpiNNaker machine.
+CREATE TABLE IF NOT EXISTS Placements(
+	vertex_id INTEGER PRIMARY KEY,
+	machine_id INTEGER,
+	chip_x INT,
+	chip_y INT,
+	chip_p INT,
+	FOREIGN KEY (vertex_id)
+		REFERENCES Machine_vertices(vertex_id),
+	FOREIGN KEY (chip_x, chip_y, chip_p, machine_id)
+		REFERENCES Processor(chip_x, chip_y, physical_id, machine_id));
+
+-- The mapping of machine edges to the keys and masks used in SpiNNaker
+-- packets.
+CREATE TABLE IF NOT EXISTS Routing_info(
+	edge_id INTEGER,
+	"key" INT,
+	mask INT,
+	PRIMARY KEY (edge_id, "key", mask),
+	FOREIGN KEY (edge_id)
+		REFERENCES Machine_edges(edge_id));
+
+-- The computed routing table for a chip.
+CREATE TABLE IF NOT EXISTS Routing_table(
+	chip_x INTEGER,
+	chip_y INTEGER,
+	position INTEGER,
+	key_combo INT,
+	mask INT,
+	route INT,
+	PRIMARY KEY (chip_x, chip_y, position));
+
+CREATE TABLE IF NOT EXISTS IP_tags(
+	vertex_id INTEGER,
+	tag INTEGER,
+	board_address TEXT,
+	ip_address TEXT,
+	port INTEGER,
+	strip_sdp BOOLEAN,
+	PRIMARY KEY (vertex_id, tag, board_address, ip_address, port, strip_sdp),
+	FOREIGN KEY (vertex_id)
+		REFERENCES Machine_vertices(vertex_id));
+
+CREATE TABLE IF NOT EXISTS Reverse_IP_tags(
+	vertex_id INTEGER PRIMARY KEY,
+	tag INTEGER,
+	board_address TEXT,
+	port INTEGER,
+	FOREIGN KEY (vertex_id)
+		REFERENCES Machine_vertices(vertex_id));
+
+CREATE TABLE IF NOT EXISTS event_to_atom_mapping(
+	vertex_id INTEGER,
+	atom_id INTEGER,
+	event_id INTEGER PRIMARY KEY,
+	FOREIGN KEY (vertex_id)
+		REFERENCES Machine_vertices(vertex_id));


### PR DESCRIPTION
This is a rewrite of the database access layer to make the accesses not vulnerable to SQL injection attacks. It also moves the definitions of the tables into a separate file (`…/db.sql`) so that they are much easier to understand as a whole.

It also takes care to avoid quadratic behaviour when inserting values into the database by tracking more carefully the mapping from vertices and edges to their database IDs.