### PR TITLE
Disable energy report by default

### DIFF
--- a/spinn_front_end_common/interface/spinnaker.cfg
+++ b/spinn_front_end_common/interface/spinnaker.cfg
@@ -39,7 +39,7 @@ critical =
 # write_router_reports: If True, each router file is written in
 #                 text format to reports/routers
 reports_enabled = True
-write_energy_report = True
+write_energy_report = False
 write_text_specs = False
 write_router_reports = False
 write_partitioner_reports = True


### PR DESCRIPTION
Disable energy report by default as interacts with machine (so can be slow)