### PR TITLE
Encoding and decoding of binary data should use precompiled patterns.

### DIFF
--- a/spinn_front_end_common/interface/buffer_management/recording_utilities.py
+++ b/spinn_front_end_common/interface/buffer_management/recording_utilities.py
@@ -23,6 +23,9 @@ _RECORDING_ELEMENTS_BEFORE_REGION_SIZES = 7
 # The Buffer traffic type
 TRAFFIC_IDENTIFIER = "BufferTraffic"
 
+_ONE_WORD = struct.Struct("<I")
+_TWO_SHORTS = struct.Struct("<HH")
+
 
 def get_recording_header_size(n_recorded_regions):
     """ Get the size of the data to be written for the recording header
@@ -242,8 +245,8 @@ def get_recording_header_array(
     # The parameters
     data.append(len(recorded_region_sizes))
     data.append(buffering_output_tag)
-    data.append(struct.unpack("<I", struct.pack(
-        "<HH", buffering_output_dest_y, buffering_output_dest_x))[0])
+    data.append(_ONE_WORD.unpack(_TWO_SHORTS.pack(
+        buffering_output_dest_y, buffering_output_dest_x))[0])
     data.append(SDP_PORTS.OUTPUT_BUFFERING_SDP_PORT.value)
     if buffer_size_before_request is not None:
         data.append(buffer_size_before_request)
@@ -278,7 +281,7 @@ def get_last_sequence_number(placement, transceiver, recording_data_address):
     data = transceiver.read_memory(
         placement.x, placement.y,
         recording_data_address + _LAST_SEQUENCE_NUMBER_OFFSET, 4)
-    return struct.unpack_from("<I", data)[0]
+    return _ONE_WORD.unpack_from(data)[0]
 
 
 def get_region_pointer(placement, transceiver, recording_data_address, region):
@@ -295,7 +298,7 @@ def get_region_pointer(placement, transceiver, recording_data_address, region):
         placement.x, placement.y,
         recording_data_address + _FIRST_REGION_ADDRESS_OFFSET + (region * 4),
         4)
-    return struct.unpack_from("<I", data)[0]
+    return _ONE_WORD.unpack_from(data)[0]
 
 
 def get_n_timesteps_in_buffer_space(buffer_space, buffered_sdram_per_timestep):

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/channel_buffer_state.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/channel_buffer_state.py
@@ -2,6 +2,8 @@ from spinn_front_end_common.utilities.constants import BUFFERING_OPERATIONS
 
 import struct
 
+_CHANNEL_BUFFER_PATTERN = struct.Struct("<IIIIIBBBx")
+
 
 class ChannelBufferState(object):
     """ Stores information related to a single channel output\
@@ -115,7 +117,7 @@ class ChannelBufferState(object):
     def create_from_bytearray(data):
         (start_address, current_write, current_dma_write, current_read,
          end_address, region_id, missing_info, last_buffer_operation) = \
-            struct.unpack_from("<IIIIIBBBx", data)
+            _CHANNEL_BUFFER_PATTERN.unpack_from(data)
         if last_buffer_operation == 0:
             last_buffer_operation = BUFFERING_OPERATIONS.BUFFER_READ.value
         else:

--- a/spinn_front_end_common/interface/interface_functions/application_finisher.py
+++ b/spinn_front_end_common/interface/interface_functions/application_finisher.py
@@ -6,6 +6,8 @@ from spinnman.messages.sdp import SDPFlag, SDPHeader, SDPMessage
 from spinnman.model.enums import CPUState
 from spinn_utilities.progress_bar import ProgressBar
 
+_ONE_WORD = struct.Struct("<I")
+
 
 class ApplicationFinisher(object):
     __slots__ = []
@@ -61,8 +63,7 @@ class ApplicationFinisher(object):
 
     @staticmethod
     def _update_provenance_and_exit(txrx, processor, core_subset):
-        byte_data = struct.pack(
-            "<I",
+        byte_data = _ONE_WORD.pack(
             constants.SDP_RUNNING_MESSAGE_CODES
             .SDP_UPDATE_PROVENCE_REGION_AND_EXIT.value)
 

--- a/spinn_front_end_common/interface/interface_functions/chip_provenance_updater.py
+++ b/spinn_front_end_common/interface/interface_functions/chip_provenance_updater.py
@@ -9,6 +9,7 @@ from spinn_front_end_common.utilities.constants \
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 
 logger = logging.getLogger(__name__)
+_ONE_WORD = struct.Struct("<I")
 
 
 class ChipProvenanceUpdater(object):
@@ -52,8 +53,8 @@ class ChipProvenanceUpdater(object):
                 all_core_subsets, CPUState.FINISHED)
 
             for (x, y, p) in unsuccessful_cores.iterkeys():
-                data = struct.pack(
-                    "<I", SDP_RUNNING_MESSAGE_CODES.
+                data = _ONE_WORD.pack(
+                    SDP_RUNNING_MESSAGE_CODES.
                     SDP_UPDATE_PROVENCE_REGION_AND_EXIT.value)
                 txrx.send_sdp_message(SDPMessage(SDPHeader(
                     flags=SDPFlag.REPLY_NOT_EXPECTED,

--- a/spinn_front_end_common/interface/interface_functions/host_execute_data_specification.py
+++ b/spinn_front_end_common/interface/interface_functions/host_execute_data_specification.py
@@ -12,6 +12,7 @@ import struct
 import numpy
 
 logger = logging.getLogger(__name__)
+_ONE_WORD = struct.Struct("<I")
 
 
 class HostExecuteDataSpecification(object):
@@ -99,8 +100,7 @@ class HostExecuteDataSpecification(object):
             # set user 0 register appropriately to the application data
             user_0_address = \
                 transceiver.get_user_0_register_address_from_core(x, y, p)
-            start_address_encoded = \
-                buffer(struct.pack("<I", start_address))
+            start_address_encoded = buffer(_ONE_WORD.pack(start_address))
             transceiver.write_memory(
                 x, y, user_0_address, start_address_encoded)
 

--- a/spinn_front_end_common/interface/interface_functions/machine_execute_data_specification.py
+++ b/spinn_front_end_common/interface/interface_functions/machine_execute_data_specification.py
@@ -14,6 +14,7 @@ import logging
 import struct
 
 logger = logging.getLogger(__name__)
+_FOUR_WORDS = struct.Struct("<4I")
 
 
 class MachineExecuteDataSpecification(object):
@@ -63,8 +64,8 @@ class MachineExecuteDataSpecification(object):
             base_address = transceiver.malloc_sdram(
                 x, y, data_spec_file_size, dse_app_id)
 
-            dse_data_struct_data = struct.pack(
-                "<4I", base_address, data_spec_file_size, app_id,
+            dse_data_struct_data = _FOUR_WORDS.pack(
+                base_address, data_spec_file_size, app_id,
                 write_memory_map_report)
 
             transceiver.write_memory(

--- a/spinn_front_end_common/interface/profiling/profile_utils.py
+++ b/spinn_front_end_common/interface/profiling/profile_utils.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 PROFILE_HEADER_SIZE_BYTES = 4
 SIZE_OF_PROFILE_DATA_ENTRY_IN_BYTES = 8
 BYTE_OFFSET_OF_PROFILE_DATA_IN_PROFILE_REGION = 4
+_ONE_WORD = struct.Struct("<I")
 
 
 def get_profile_region_size(n_samples):
@@ -66,12 +67,9 @@ def get_profiling_data(profile_region, tag_labels, txrx, placement):
             placement=placement, region=profile_region, transceiver=txrx)
 
     # Read the profiling data size
-    words_written_data =\
-        buffer(txrx.read_memory(
-            placement.x, placement.y,
-            profiling_region_base_address, 4))
-    words_written = \
-        struct.unpack_from("<I", words_written_data)[0]
+    words_written_data = buffer(txrx.read_memory(
+        placement.x, placement.y, profiling_region_base_address, 4))
+    words_written = _ONE_WORD.unpack_from(words_written_data)[0]
 
     # Read the profiling data
     if words_written != 0:

--- a/spinn_front_end_common/interface/provenance/provides_provenance_data_from_machine_impl.py
+++ b/spinn_front_end_common/interface/provenance/provides_provenance_data_from_machine_impl.py
@@ -11,6 +11,8 @@ from data_specification.utility_calls import get_region_base_address_offset
 import struct
 from enum import Enum
 
+_ONE_WORD = struct.Struct("<I")
+
 
 @add_metaclass(AbstractBase)
 class ProvidesProvenanceDataFromMachineImpl(
@@ -70,7 +72,7 @@ class ProvidesProvenanceDataFromMachineImpl(
             app_data_base_address, self._provenance_region_id)
         base_address_buffer = buffer(transceiver.read_memory(
             placement.x, placement.y, base_address_offset, 4))
-        return struct.unpack("<I", base_address_buffer)[0]
+        return _ONE_WORD.unpack(base_address_buffer)[0]
 
     def _read_provenance_data(self, transceiver, placement):
         provenance_address = self._get_provenance_region_address(

--- a/spinn_front_end_common/utilities/helpful_functions.py
+++ b/spinn_front_end_common/utilities/helpful_functions.py
@@ -17,6 +17,7 @@ from ConfigParser import RawConfigParser
 
 logger = logging.getLogger(__name__)
 FINISHED_FILENAME = "finished"
+_ONE_WORD = struct.Struct("<I")
 
 
 def read_data(x, y, address, length, data_format, transceiver):
@@ -55,7 +56,7 @@ def locate_memory_region_for_placement(placement, region, transceiver):
             regions_base_address, region)
     region_address = buffer(transceiver.read_memory(
         placement.x, placement.y, region_offset_in_pointer_table, 4))
-    region_address_decoded = struct.unpack_from("<I", region_address)[0]
+    region_address_decoded = _ONE_WORD.unpack_from(region_address)[0]
     return region_address_decoded
 
 

--- a/spinn_front_end_common/utilities/report_functions/memory_map_on_chip_report.py
+++ b/spinn_front_end_common/utilities/report_functions/memory_map_on_chip_report.py
@@ -7,7 +7,8 @@ import os
 import struct
 
 logger = logging.getLogger(__name__)
-
+_ONE_WORD = struct.Struct("<I")
+_FOUR_WORDS = struct.Struct("<IIII")
 MEM_MAP_SUBDIR_NAME = "memory_map_reports"
 
 
@@ -83,7 +84,7 @@ class MemoryMapOnChipReport(object):
             x, y, p)
         data_address_encoded = txrx.read_memory(
             x, y, data_address_pointer, 4)
-        return struct.unpack_from("<I", buffer(data_address_encoded))[0]
+        return _ONE_WORD.unpack_from(buffer(data_address_encoded))[0]
 
 
 class _MemoryChannelState(object):
@@ -122,10 +123,9 @@ class _MemoryChannelState(object):
 
     @staticmethod
     def from_bytestring(data, offset=0):
-        start, size, unfilled, write = \
-            struct.unpack_from("<IIII", data, offset)
+        start, size, unfilled, write = _FOUR_WORDS.unpack_from(data, offset)
         return _MemoryChannelState(start, size, unfilled, write)
 
     def bytestring(self):
-        return struct.pack("<IIII", self._start_address, self._size,
-                           self._unfilled, self._write_pointer)
+        return _FOUR_WORDS.pack(self._start_address, self._size,
+                                self._unfilled, self._write_pointer)

--- a/spinn_front_end_common/utilities/report_functions/memory_map_on_host_chip_report.py
+++ b/spinn_front_end_common/utilities/report_functions/memory_map_on_host_chip_report.py
@@ -7,7 +7,7 @@ import os
 import struct
 
 logger = logging.getLogger(__name__)
-
+_ONE_WORD = struct.Struct("<I")
 MEM_MAP_SUBDIR_NAME = "memory_map_reports"
 
 
@@ -62,8 +62,8 @@ class MemoryMapOnHostChipReport(object):
 
                     offset = 0
                     for i in xrange(MAX_MEM_REGIONS):
-                        region_address = int(struct.unpack_from(
-                            "<I", mem_map_report_data, offset)[0])
+                        region_address = int(_ONE_WORD.unpack_from(
+                            mem_map_report_data, offset)[0])
                         offset += 4
                         f.write("Region {0:d}:\n\t start address: 0x{1:x}\n\t"
                                 .format(i, region_address))
@@ -73,4 +73,4 @@ class MemoryMapOnHostChipReport(object):
 
     def _get_app_pointer_table(self, txrx, x, y, table_pointer):
         encoded_address = buffer(txrx.read_memory(x, y, table_pointer, 4))
-        return int(struct.unpack_from("<I", encoded_address)[0]) + 8
+        return int(_ONE_WORD.unpack_from(encoded_address)[0]) + 8

--- a/spinn_front_end_common/utility_models/live_packet_gather_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/live_packet_gather_machine_vertex.py
@@ -22,6 +22,9 @@ from spinnman.messages.eieio import EIEIOType
 from enum import Enum
 import struct
 
+_ONE_SHORT = struct.Struct("<H")
+_TWO_BYTES = struct.Struct("<BB")
+
 
 class LivePacketGatherMachineVertex(
         MachineVertex, ProvidesProvenanceDataFromMachineImpl,
@@ -247,8 +250,8 @@ class LivePacketGatherMachineVertex(
         # SDP tag
         iptag = iter(iptags).next()
         spec.write_value(data=iptag.tag)
-        spec.write_value(struct.unpack("<H", struct.pack(
-            "<BB", iptag.destination_y, iptag.destination_x))[0])
+        spec.write_value(_ONE_SHORT.unpack(_TWO_BYTES.pack(
+            iptag.destination_y, iptag.destination_x))[0])
 
         # number of packets to send per time stamp
         spec.write_value(data=self._number_of_packets_sent_per_time_step)

--- a/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
@@ -44,6 +44,8 @@ import sys
 import struct
 
 _DEFAULT_MALLOC_REGIONS = 2
+_ONE_WORD = struct.Struct("<I")
+_TWO_SHORTS = struct.Struct("<HH")
 
 
 @supports_injection
@@ -529,8 +531,8 @@ class ReverseIPTagMulticastSourceMachineVertex(
             spec.write_value(data=buffer_space)
             spec.write_value(data=self._send_buffer_space_before_notify)
             spec.write_value(data=this_tag.tag)
-            spec.write_value(struct.unpack("<I", struct.pack(
-                "<HH", this_tag.destination_y, this_tag.destination_x))[0])
+            spec.write_value(_ONE_WORD.unpack(_TWO_SHORTS.pack(
+                this_tag.destination_y, this_tag.destination_x))[0])
         else:
             spec.write_value(data=0)
             spec.write_value(data=0)


### PR DESCRIPTION
I was reading through the [struct documentation](https://docs.python.org/2/library/struct.html#classes) and I noted that it said

 > "Creating a Struct object once and calling its methods is more efficient than calling the struct functions with the same format since the format string only needs to be compiled once."
 
which I think is highly relevant to us, especially in an area that is a bit of a bottleneck. And this is a feature of a core Python library that we already use too.