### PR TITLE
Use 'install' to install, not 'cp'

### DIFF
--- a/c_common/front_end_common_lib/Makefile
+++ b/c_common/front_end_common_lib/Makefile
@@ -48,13 +48,13 @@ install-headers: $(INSTALL_HEADERS)
 install-makefiles: $(INSTALL_MAKEFILES)
 
 $(SPINN_LIB_DIR)/%.a: $(SPINN_COMMON_BUILD)/%.a
-	$(CP) $< $@
+	$(INSTALL) -c -m644 $< $(SPINN_LIB_DIR)
 
 $(SPINN_INC_DIR)/%.h: include/%.h
-	$(CP) $< $@
+	$(INSTALL) -c -m644 $< $(SPINN_INC_DIR)
 
 $(SPINN_MAKE_LIB_DIR)/%: %
-	$(CP) $< $@
+	$(INSTALL) -c -m644 $< $(SPINN_MAKE_LIB_DIR)
 
 clean:
 	$(RM) $(SPINN_COMMON_BUILD)/libspinn_frontend_common.a $(BUILD_OBJS)

--- a/c_common/front_end_common_lib/Makefile
+++ b/c_common/front_end_common_lib/Makefile
@@ -30,6 +30,9 @@ INSTALL_MAKEFILES = $(MAKEFILES:%=$(SPINN_MAKE_LIB_DIR)/%)
 LIBS = libspinn_frontend_common.a
 INSTALL_LIBS = $(LIBS:%.a=$(SPINN_LIB_DIR)/%.a)
 
+# Ensure $(INSTALL) is defined, even on MinGW
+INSTALL ?= install
+
 # Build rules (default)
 $(SPINN_COMMON_BUILD)/libspinn_frontend_common.a: $(BUILD_OBJS) 
 	$(RM) $@


### PR DESCRIPTION
This switches the installation code in our makefile to use `install`, not `cp`. The `install` program gets more things right _for the installation case_ and makes it a little easier for people reading the code to see what is going on.