### PR TITLE
supports fixed route router

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1563,6 +1563,8 @@ class AbstractSpinnakerBase(SimulatorInterface):
         # add check for algorithm start type
         algorithms.append("LocateExecutableStartType")
 
+        optional_algorithms.append("FixedRouteRouter")
+
         # handle outputs
         outputs = [
             "MemoryPlacements", "MemoryRoutingTables",
@@ -1697,6 +1699,10 @@ class AbstractSpinnakerBase(SimulatorInterface):
 
         # algorithms needed for loading the binaries to the SpiNNaker machine
         optional_algorithms.append("LoadExecutableImages")
+
+        # report for fixed routes if applied
+        optional_algorithms.append("LoadFixedRoutes")
+        optional_algorithms.append("FixedRouteFromMachineReport")
 
         # expected outputs from this phase
         outputs = [

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1574,7 +1574,7 @@ class AbstractSpinnakerBase(SimulatorInterface):
         # add check for algorithm start type
         algorithms.append("LocateExecutableStartType")
 
-        optional_algorithms.append("FixedRouteRouter")
+        algorithms.append("FixedRouteRouter")
 
         # handle outputs
         outputs = [
@@ -1712,8 +1712,8 @@ class AbstractSpinnakerBase(SimulatorInterface):
         optional_algorithms.append("LoadExecutableImages")
 
         # report for fixed routes if applied
-        optional_algorithms.append("LoadFixedRoutes")
-        optional_algorithms.append("FixedRouteFromMachineReport")
+        algorithms.append("LoadFixedRoutes")
+        algorithms.append("FixedRouteFromMachineReport")
 
         # expected outputs from this phase
         outputs = [

--- a/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
@@ -2,6 +2,32 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="https://github.com/SpiNNakerManchester/PACMAN
             https://raw.githubusercontent.com/SpiNNakerManchester/PACMAN/master/pacman/operations/algorithms_metadata_schema.xsd">
+    <algorithm name="LoadFixedRoutes">
+        <python_module>spinn_front_end_common.interface.interface_functions.load_fixed_routes</python_module>
+        <python_class>LoadFixedRoutes</python_class>
+        <input_definitions>
+            <parameter>
+                <param_name>fixed_routes</param_name>
+                <param_type>MemoryFixedRoutes</param_type>
+            </parameter>
+            <parameter>
+                <param_name>transceiver</param_name>
+                <param_type>MemoryTransceiver</param_type>
+            </parameter>
+            <parameter>
+                <param_name>app_id</param_name>
+                <param_type>APPID</param_type>
+            </parameter>
+        </input_definitions>
+        <required_inputs>
+            <param_name>fixed_routes</param_name>
+            <param_name>transceiver</param_name>
+            <param_name>app_id</param_name>
+        </required_inputs>
+        <outputs>
+            <param_type>LoadedFixedRoutesToken</param_type>
+        </outputs>
+    </algorithm>
     <algorithm name="PreAllocateResourcesForChipPowerMonitor">
         <python_module>
             spinn_front_end_common.interface.interface_functions.pre_allocate_resources_for_chip_power_monitor

--- a/spinn_front_end_common/interface/interface_functions/load_fixed_routes.py
+++ b/spinn_front_end_common/interface/interface_functions/load_fixed_routes.py
@@ -1,0 +1,16 @@
+from spinn_utilities.progress_bar import ProgressBar
+
+
+class LoadFixedRoutes(object):
+
+    def __call__(self, fixed_routes, transceiver, app_id):
+
+        progress_bar = ProgressBar(
+            total_number_of_things_to_do=len(fixed_routes),
+            string_describing_what_being_progressed="loading fixed routes")
+
+        for chip_x, chip_y in progress_bar.over(fixed_routes.keys):
+            transceiver.load_fixed_route(
+                chip_x, chip_y, fixed_routes[(chip_x, chip_y)], app_id)
+
+        return True

--- a/spinn_front_end_common/interface/interface_functions/load_fixed_routes.py
+++ b/spinn_front_end_common/interface/interface_functions/load_fixed_routes.py
@@ -9,7 +9,7 @@ class LoadFixedRoutes(object):
             total_number_of_things_to_do=len(fixed_routes),
             string_describing_what_being_progressed="loading fixed routes")
 
-        for chip_x, chip_y in progress_bar.over(fixed_routes.keys):
+        for chip_x, chip_y in progress_bar.over(fixed_routes.keys()):
             transceiver.load_fixed_route(
                 chip_x, chip_y, fixed_routes[(chip_x, chip_y)], app_id)
 

--- a/spinn_front_end_common/utilities/report_functions/fixed_route_from_machine_report.py
+++ b/spinn_front_end_common/utilities/report_functions/fixed_route_from_machine_report.py
@@ -37,16 +37,17 @@ class FixedRouteFromMachineReport(object):
         :param machine: 
         :return: 
         """
-        progress = ProgressBar(machine.chips(), "Writing fixed route report")
-        for chip in progress.over(machine.chips()):
+        progress = ProgressBar(machine.chips, "Writing fixed route report")
+        output.write(" x    y       route         [cores][links]\n")
+        for chip in progress.over(machine.chips):
             if not chip.virtual:
                 fixed_route = \
                     transceiver.read_fixed_route(chip.x, chip.y, app_id)
                 output.write(
-                    "{: <3s}:{: <3s} contains route {: <10s} [Cores][Links]"
+                    "{: <3s}:{: <3s} contains route {: <10s} {}\n"
                     .format(
-                        chip.x, chip.y, self._reduce_route_value(
-                            fixed_route.processor_ids, fixed_route.link_ids),
+                        str(chip.x), str(chip.y), str(self._reduce_route_value(
+                            fixed_route.processor_ids, fixed_route.link_ids)),
                         self._expand_route_value(
                             fixed_route.processor_ids, fixed_route.link_ids)))
 

--- a/spinn_front_end_common/utilities/report_functions/fixed_route_from_machine_report.py
+++ b/spinn_front_end_common/utilities/report_functions/fixed_route_from_machine_report.py
@@ -1,0 +1,85 @@
+import os
+
+from spinn_utilities.progress_bar import ProgressBar
+
+
+class FixedRouteFromMachineReport(object):
+    """ function for writing the fixed routes from the machine
+    """
+
+    def __call__(self, transceiver, machine, report_default_directory,
+                 app_id, loaded_fixed_routes_on_machine_token):
+        """ writing the fixed routes from the machine
+        
+        :param transceiver: spinnMan instance
+        :param machine: SpiNNMachine instance
+        :param report_default_directory: folder where reports reside
+        :param loaded_fixed_routes_on_machine_token: token that states fixed \
+        routes have been loaded
+        :param app_id: the app id the fixed routes were loaded with
+        :rtype: None 
+        """
+
+        if not loaded_fixed_routes_on_machine_token:
+            raise loaded_fixed_routes_on_machine_token(
+                "Needs to have loaded fixed route data for this to work.")
+
+        file_name = os.path.join(
+            report_default_directory, "fixed_route_routers")
+
+        with open(file_name, "w") as output:
+                self._write_fixed_routers(output, transceiver, machine, app_id)
+
+    def _write_fixed_routers(self, output, transceiver, machine, app_id):
+        """
+        
+        :param transceiver: 
+        :param machine: 
+        :return: 
+        """
+        progress = ProgressBar(machine.chips(), "Writing fixed route report")
+        for chip in progress.over(machine.chips()):
+            if not chip.virtual:
+                fixed_route = \
+                    transceiver.read_fixed_route(chip.x, chip.y, app_id)
+                output.write(
+                    "{: <3s}:{: <3s} contains route {: <10s} [Cores][Links]"
+                    .format(
+                        chip.x, chip.y, self._reduce_route_value(
+                            fixed_route.processor_ids, fixed_route.link_ids),
+                        self._expand_route_value(
+                            fixed_route.processor_ids, fixed_route.link_ids)))
+
+    @staticmethod
+    def _reduce_route_value(processors_ids, link_ids):
+        value = 0
+        for link in link_ids:
+            value += 1 << link
+        for processor in processors_ids:
+            value += 1 << (processor + 6)
+        return value
+
+    @staticmethod
+    def _expand_route_value(processors_ids, link_ids):
+        """ Convert a 32-bit route word into a string which lists the target cores\
+            and links.
+        """
+
+        # Convert processor targets to readable values:
+        route_string = "["
+        separator = ""
+        for processor in processors_ids:
+            route_string += "{}{}".format(separator, processor)
+            separator = ", "
+
+        route_string += "] ["
+
+        # Convert link targets to readable values:
+        link_labels = {0: 'E', 1: 'NE', 2: 'N', 3: 'W', 4: 'SW', 5: 'S'}
+
+        separator = ""
+        for link in link_ids:
+            route_string += "{}{}".format(separator, link_labels[link])
+            separator = ", "
+        route_string += "]"
+        return route_string

--- a/spinn_front_end_common/utilities/report_functions/front_end_common_reports.xml
+++ b/spinn_front_end_common/utilities/report_functions/front_end_common_reports.xml
@@ -2,6 +2,39 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xsi:schemaLocation="https://github.com/SpiNNakerManchester/PACMAN
 			https://raw.githubusercontent.com/SpiNNakerManchester/PACMAN/master/pacman/operations/algorithms_metadata_schema.xsd">
+    <algorithm name="FixedRouteFromMachineReport">
+        <python_module>spinn_front_end_common.utilities.report_functions.fixed_route_from_machine_report</python_module>
+        <python_class>FixedRouteFromMachineReport</python_class>
+        <input_definitions>
+            <parameter>
+                <param_name>transceiver</param_name>
+                <param_type>MemoryTransceiver</param_type>
+            </parameter>
+            <parameter>
+                <param_name>machine</param_name>
+                <param_type>MemoryMachine</param_type>
+            </parameter>
+            <parameter>
+                <param_name>report_default_directory</param_name>
+                <param_type>ReportFolder</param_type>
+            </parameter>
+            <parameter>
+                <param_name>app_id</param_name>
+                <param_type>APPID</param_type>
+            </parameter>
+            <parameter>
+                <param_name>loaded_fixed_routes_on_machine_token</param_name>
+                <param_type>LoadedFixedRoutesToken</param_type>
+            </parameter>
+        </input_definitions>
+        <required_inputs>
+            <param_name>transceiver</param_name>
+            <param_name>machine</param_name>
+            <param_name>report_default_directory</param_name>
+            <param_name>app_id</param_name>
+            <param_name>loaded_fixed_routes_on_machine_token</param_name>
+        </required_inputs>
+    </algorithm>
     <algorithm name="RoutingTableFromMachineReport">
         <python_module>spinn_front_end_common.utilities.report_functions</python_module>
         <python_class>RoutingTableFromMachineReport</python_class>


### PR DESCRIPTION
allows the extra monitor core to use the fixed routes. Is tied to the following pull requests:

PAC, https://github.com/SpiNNakerManchester/PACMAN/pull/127
SPinnMan, https://github.com/SpiNNakerManchester/SpiNNMan/pull/98
SpinnMachine, https://github.com/SpiNNakerManchester/SpiNNMachine/pull/52
GFE https://github.com/SpiNNakerManchester/SpiNNakerGraphFrontEnd/pull/68

need to all be merged at same time.

Note: this one forces a input which 