### PR TITLE
supports pre allocation of iptags and reverse iptags

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -2135,6 +2135,10 @@ class AbstractSpinnakerBase(SimulatorInterface):
         return self._placements
 
     @property
+    def tags(self):
+        return self._tags
+
+    @property
     def transceiver(self):
         return self._txrx
 

--- a/spinn_front_end_common/interface/interface_functions/pre_allocate_resources_for_live_packet_gatherers.py
+++ b/spinn_front_end_common/interface/interface_functions/pre_allocate_resources_for_live_packet_gatherers.py
@@ -70,8 +70,8 @@ class PreAllocateResourcesForLivePacketGatherers(object):
                     board=chip.ip_address,
                     ip_address=lpg_params.hostname, port=lpg_params.port,
                     strip_sdp=lpg_params.strip_sdp, tag=lpg_params.tag,
-                    traffic_identifier=
-                    LivePacketGatherMachineVertex.TRAFFIC_IDENTIFIER))
+                    traffic_identifier=(
+                        LivePacketGatherMachineVertex.TRAFFIC_IDENTIFIER)))
 
         if sdram_reqs > 0:
             sdrams.append(SpecificChipSDRAMResource(chip, sdram_reqs))

--- a/spinn_front_end_common/utilities/failed_state.py
+++ b/spinn_front_end_common/utilities/failed_state.py
@@ -50,6 +50,10 @@ class FailedState(SimulatorInterface):
     def placements(self):
         raise ConfigurationException(FAILED_STATE_MSG)
 
+    @property
+    def tags(self):
+        raise ConfigurationException(FAILED_STATE_MSG)
+
     def run(self, run_time):
         raise ConfigurationException(FAILED_STATE_MSG)
 

--- a/spinn_front_end_common/utilities/simulator_interface.py
+++ b/spinn_front_end_common/utilities/simulator_interface.py
@@ -59,6 +59,10 @@ class SimulatorInterface(object):
         pass
 
     @abstractproperty
+    def tags(self):
+        pass
+
+    @abstractproperty
     def run(self, run_time):
         pass
 

--- a/spinn_front_end_common/utility_models/live_packet_gather.py
+++ b/spinn_front_end_common/utility_models/live_packet_gather.py
@@ -125,8 +125,8 @@ class LivePacketGather(
             iptags=[IPtagResource(
                 ip_address=self._ip_address, port=self._port,
                 strip_sdp=self._strip_sdp, tag=self._tag,
-                traffic_identifier=
-                LivePacketGatherMachineVertex.TRAFFIC_IDENTIFIER)])
+                traffic_identifier=(
+                    LivePacketGatherMachineVertex.TRAFFIC_IDENTIFIER))])
 
     @overrides(AbstractGeneratesDataSpecification.generate_data_specification)
     def generate_data_specification(self, spec, placement):

--- a/spinn_front_end_common/utility_models/live_packet_gather.py
+++ b/spinn_front_end_common/utility_models/live_packet_gather.py
@@ -125,7 +125,8 @@ class LivePacketGather(
             iptags=[IPtagResource(
                 ip_address=self._ip_address, port=self._port,
                 strip_sdp=self._strip_sdp, tag=self._tag,
-                traffic_identifier="LPG_EVENT_STREAM")])
+                traffic_identifier=
+                LivePacketGatherMachineVertex.TRAFFIC_IDENTIFIER)])
 
     @overrides(AbstractGeneratesDataSpecification.generate_data_specification)
     def generate_data_specification(self, spec, placement):

--- a/spinn_front_end_common/utility_models/live_packet_gather_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/live_packet_gather_machine_vertex.py
@@ -37,6 +37,8 @@ class LivePacketGatherMachineVertex(
                ('CONFIG', 1),
                ('PROVENANCE', 2)])
 
+    TRAFFIC_IDENTIFIER = "LPG_EVENT_STREAM"
+
     N_ADDITIONAL_PROVENANCE_ITEMS = 2
     _CONFIG_SIZE = 48
     _PROVENANCE_REGION_SIZE = 8
@@ -59,7 +61,7 @@ class LivePacketGatherMachineVertex(
             iptags=[IPtagResource(
                 ip_address=hostname, port=port,
                 strip_sdp=strip_sdp, tag=tag,
-                traffic_identifier="LPG_EVENT_STREAM")])
+                traffic_identifier=self.TRAFFIC_IDENTIFIER)])
 
         # app specific data items
         self._use_prefix = use_prefix


### PR DESCRIPTION
this supports the pre allocation of iptags and reverse iptags. this should (i think) have been done during LPG stuff, but I only picked it up when starting the integration of the 15 speed up data extractor.

tested with spike io.
needs a PACMAN equiv brnach to be merged as well
SpiNNakerManchester/PACMAN#125

togehter complete issue
SpiNNakerManchester/SpiNNFrontEndCommon#209