### PR TITLE
Avoid load stuff not required after reset

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1717,8 +1717,7 @@ class AbstractSpinnakerBase(SimulatorInterface):
         loading_algorithm = helpful_functions.read_config(
             self._config, "Mapping", "loading_algorithms")
         if loading_algorithm is not None and application_graph_changed:
-            algorithms.extend(
-                self._config.get("Mapping", "loading_algorithms").split(","))
+            algorithms.extend(loading_algorithm.split(","))
         algorithms.extend(self._extra_load_algorithms)
 
         write_memory_report = self._config.getboolean(

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -601,6 +601,21 @@ class AbstractSpinnakerBase(SimulatorInterface):
                                         "has been set to True".format(option))
                     except ValueError:
                         pass
+        elif not self._config.getboolean("Reports", "reportsEnabled"):
+            for option in self._config.options("Reports"):
+                # options names are all lower without _ inside config
+                if (option in ["displayalgorithmtimings",
+                               "clear_iobuf_during_run",
+                               "extract_iobuf", "extract_iobuf_during_run"]
+                        or option[:5] == "write"):
+                    try:
+                        if not self._config.get_bool("Reports", option):
+                            self._config.set("Reports", option, "False")
+                            logger.info(
+                                "As reportsEnabled == \"False\" [Reports] {} "
+                                "has been set to False".format(option))
+                    except ValueError:
+                        pass
 
         if runtime is None:
             if self._config.getboolean(
@@ -1185,8 +1200,7 @@ class AbstractSpinnakerBase(SimulatorInterface):
             algorithms.append("PreAllocateResourcesForLivePacketGatherers")
             inputs['LivePacketRecorderParameters'] = \
                 self._live_packet_recorder_params
-        if (self._config.getboolean("Reports", "reportsEnabled") and
-                self._config.getboolean("Reports", "write_energy_report")):
+        if self._config.getboolean("Reports", "write_energy_report"):
 
             algorithms.append("PreAllocateResourcesForChipPowerMonitor")
             inputs['MemorySamplingFrequency'] = self._config.getfloat(
@@ -1500,8 +1514,7 @@ class AbstractSpinnakerBase(SimulatorInterface):
             inputs['LivePacketRecorderParameters'] = \
                 self._live_packet_recorder_params
 
-        if (self._config.getboolean("Reports", "reportsEnabled") and
-                self._config.getboolean("Reports", "write_energy_report")):
+        if self._config.getboolean("Reports", "write_energy_report"):
             algorithms.append(
                 "InsertChipPowerMonitorsToGraphs")
             inputs['MemorySamplingFrequency'] = self._config.getfloat(
@@ -2459,8 +2472,7 @@ class AbstractSpinnakerBase(SimulatorInterface):
                 algorithms.append("ChipIOBufExtractor")
 
             # add extractor of provenance if needed
-            if (self._config.getboolean("Reports", "reportsEnabled") and
-                    self._config.getboolean("Reports", "writeProvenanceData")):
+            if self._config.getboolean("Reports", "writeProvenanceData"):
                 algorithms.append("PlacementsProvenanceGatherer")
                 algorithms.append("RouterProvenanceGatherer")
                 algorithms.append("ProfileDataGatherer")
@@ -2480,9 +2492,7 @@ class AbstractSpinnakerBase(SimulatorInterface):
                 run_complete = True
 
                 # write provenance to file if necessary
-                if (self._config.getboolean("Reports", "reportsEnabled") and
-                        self._config.getboolean(
-                            "Reports", "writeProvenanceData")):
+                if self._config.getboolean("Reports", "writeProvenanceData"):
                     prov_items = executor.get_item("ProvenanceItems")
                     prov_items.extend(self._pacman_provenance.data_items)
                     self._pacman_provenance.clear()
@@ -2504,8 +2514,7 @@ class AbstractSpinnakerBase(SimulatorInterface):
                     logger.error("Error when attempting to recover from error",
                                  exc_info=True)
 
-        if (self._config.getboolean("Reports", "reportsEnabled") and
-                self._config.getboolean("Reports", "write_energy_report") and
+        if (self._config.getboolean("Reports", "write_energy_report") and
                 self._buffer_manager is not None):
 
             # create energy report

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1707,9 +1707,9 @@ class AbstractSpinnakerBase(SimulatorInterface):
                 # Get the executable targets
                 algorithms.append("GraphBinaryGatherer")
 
-        if helpful_functions.read_config(
-                self._config, "Mapping", "loading_algorithms") is not None \
-                and self._application_graph_changed:
+        loading_algorithm = helpful_functions.read_config(
+            self._config, "Mapping", "loading_algorithms")
+        if loading_algorithm is not None and self._application_graph_changed:
             algorithms.extend(
                 self._config.get("Mapping", "loading_algorithms").split(","))
         algorithms.extend(self._extra_load_algorithms)
@@ -1718,17 +1718,18 @@ class AbstractSpinnakerBase(SimulatorInterface):
         optional_algorithms = list()
         optional_algorithms.append("RoutingTableLoader")
         optional_algorithms.append("TagsLoader")
+
+        write_memory_report = self._config.getboolean(
+            "Reports", "write_memory_map_report")
         if self._exec_dse_on_host:
             optional_algorithms.append("HostExecuteDataSpecification")
-            if self._config.getboolean(
-                    "Reports", "write_memory_map_report") and \
-                    self._application_graph_changed:
+
+            if write_memory_report and self._application_graph_changed:
                 algorithms.append("MemoryMapOnHostReport")
                 algorithms.append("MemoryMapOnHostChipReport")
         else:
             optional_algorithms.append("MachineExecuteDataSpecification")
-            if self._config.getboolean(
-                    "Reports", "write_memory_map_report"):
+            if write_memory_report:
                 optional_algorithms.append("MemoryMapOnChipReport")
 
         # Reload any parameters over the loaded data if we have already
@@ -1743,6 +1744,7 @@ class AbstractSpinnakerBase(SimulatorInterface):
         optional_algorithms.append("LoadExecutableImages")
 
         # Add reports that depend on compression
+
         if self._config.getboolean("Reports", "reports_enabled") and \
                 self._application_graph_changed:
             routing_tables_needed = False
@@ -1758,10 +1760,11 @@ class AbstractSpinnakerBase(SimulatorInterface):
                 algorithms.append("routingCompressionCheckerReport")
             if routing_tables_needed:
                 optional_algorithms.append("RoutingTableFromMachineReport")
+
         # handle extra monitor functionality
-        if self._config.getboolean("Machine",
-                                   "enable_advanced_monitor_support") \
-                and self._application_graph_changed:
+        enable_advanched_monitor = self._config.getboolean(
+            "Machine", "enable_advanced_monitor_support")
+        if enable_advanched_monitor and self._application_graph_changed:
             algorithms.append("LoadFixedRoutes")
             algorithms.append("FixedRouteFromMachineReport")
 

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -606,7 +606,8 @@ class AbstractSpinnakerBase(SimulatorInterface):
                 # options names are all lower without _ inside config
                 if (option in ["displayalgorithmtimings",
                                "clear_iobuf_during_run",
-                               "extract_iobuf", "extract_iobuf_during_run"]
+                               "extract_iobuf",
+                               "extract_iobuf_during_run"]
                         or option[:5] == "write"):
                     try:
                         if not self._config.get_bool("Reports", option):
@@ -1200,8 +1201,8 @@ class AbstractSpinnakerBase(SimulatorInterface):
             algorithms.append("PreAllocateResourcesForLivePacketGatherers")
             inputs['LivePacketRecorderParameters'] = \
                 self._live_packet_recorder_params
-        if self._config.getboolean("Reports", "write_energy_report"):
 
+        if self._config.getboolean("Reports", "write_energy_report"):
             algorithms.append("PreAllocateResourcesForChipPowerMonitor")
             inputs['MemorySamplingFrequency'] = self._config.getfloat(
                 "EnergyMonitor", "sampling_frequency")

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1689,7 +1689,6 @@ class AbstractSpinnakerBase(SimulatorInterface):
         # The initial inputs are the mapping outputs
         inputs = dict(self._mapping_outputs)
         inputs["WriteMemoryMapReportFlag"] = (
-            self._config.getboolean("Reports", "reports_enabled") and
             self._config.getboolean("Reports", "write_memory_map_report") and
             application_graph_changed
         )
@@ -1887,8 +1886,7 @@ class AbstractSpinnakerBase(SimulatorInterface):
         if not self._use_virtual_board:
             algorithms.append("BufferExtractor")
 
-        if (self._config.getboolean("Reports", "reports_enabled") and
-                self._config.getboolean("Reports", "write_provenance_data")):
+        if self._config.getboolean("Reports", "write_provenance_data"):
             algorithms.append("GraphProvenanceGatherer")
 
         # add any extra post algorithms as needed
@@ -1904,8 +1902,7 @@ class AbstractSpinnakerBase(SimulatorInterface):
             algorithms.append("ChipIOBufExtractor")
 
         # add extractor of provenance if needed
-        if (self._config.getboolean("Reports", "reports_enabled") and
-                self._config.getboolean("Reports", "write_provenance_data") and
+        if (self._config.getboolean("Reports", "write_provenance_data") and
                 not self._use_virtual_board and
                 n_machine_time_steps is not None):
             algorithms.append("PlacementsProvenanceGatherer")
@@ -1926,9 +1923,8 @@ class AbstractSpinnakerBase(SimulatorInterface):
             run_complete = True
 
             # write provenance to file if necessary
-            if (self._config.getboolean("Reports", "reports_enabled") and
-                    self._config.getboolean(
-                        "Reports", "write_provenance_data") and
+            if (self._config.getboolean(
+                    "Reports", "write_provenance_data") and
                     not self._use_virtual_board and
                     n_machine_time_steps is not None):
                 prov_items = executor.get_item("ProvenanceItems")


### PR DESCRIPTION
There was a considerable amount of stuff that was done after reset even when the application graph had not changed.

Interestingly enough one thing not done was to change the report folder.
Which meant some reports went pop when trying to recreate the same sub directory.

