### PR TITLE
Check for extra monitor support first

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -2000,12 +2000,16 @@ class AbstractSpinnakerBase(SimulatorInterface):
         logger.info("\n\nAttempting to extract data\n\n")
 
         # Extract router provenance
+        extra_monitor_vertices = None
+        if self._read_config_boolean(
+                "Machine", "enable_advanced_monitor_support"):
+            extra_monitor_vertices = self._last_run_outputs[
+                "MemoryExtraMonitorVertices"]
         router_provenance = RouterProvenanceGatherer()
         prov_items = router_provenance(
             transceiver=self._txrx, machine=self._machine,
             router_tables=self._router_tables, has_ran=True,
-            extra_monitor_vertices=(
-                self._last_run_outputs["MemoryExtraMonitorVertices"]),
+            extra_monitor_vertices=extra_monitor_vertices,
             placements=self._placements)
 
         # Find the cores that are not in an expected state

--- a/spinn_front_end_common/interface/interface_functions/router_provenance_gatherer.py
+++ b/spinn_front_end_common/interface/interface_functions/router_provenance_gatherer.py
@@ -134,7 +134,7 @@ class RouterProvenanceGatherer(object):
                 seen_chips.add((x, y))
                 reinjection_status = None
                 if reinjection_data is not None:
-                    reinjection_status = reinjection_data[(chip.x, chip.y)]
+                    reinjection_status = reinjection_data[(x, y)]
                 items.extend(self._write_router_diagnostics(
                     x, y, router_diagnostic, reinjection_status, True,
                     router_table))

--- a/spinn_front_end_common/interface/interface_functions/router_provenance_gatherer.py
+++ b/spinn_front_end_common/interface/interface_functions/router_provenance_gatherer.py
@@ -151,7 +151,9 @@ class RouterProvenanceGatherer(object):
                 if (diagnostic.n_dropped_multicast_packets or
                         diagnostic.n_local_multicast_packets or
                         diagnostic.n_external_multicast_packets):
-                    reinjection_status = reinjection_data[(chip.x, chip.y)]
+                    reinjection_status = None
+                    if reinjection_data is not None:
+                        reinjection_status = reinjection_data[(chip.x, chip.y)]
                     items.extend(self._write_router_diagnostics(
                             chip.x, chip.y, diagnostic, reinjection_status,
                             False, None))

--- a/spinn_front_end_common/interface/interface_functions/router_provenance_gatherer.py
+++ b/spinn_front_end_common/interface/interface_functions/router_provenance_gatherer.py
@@ -132,7 +132,9 @@ class RouterProvenanceGatherer(object):
             try:
                 router_diagnostic = txrx.get_router_diagnostics(x, y)
                 seen_chips.add((x, y))
-                reinjection_status = reinjection_data[(x, y)]
+                reinjection_status = None
+                if reinjection_data is not None:
+                    reinjection_status = reinjection_data[(chip.x, chip.y)]
                 items.extend(self._write_router_diagnostics(
                     x, y, router_diagnostic, reinjection_status, True,
                     router_table))


### PR DESCRIPTION
Fixes a bug: if extra_montor_support is off, and you get an error during run, this will cause an error because it was still looking for the extra monitor cores to get routing provenance.