### PR TITLE
Fix IP Tag Issue

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1637,14 +1637,6 @@ class AbstractSpinnakerBase(SimulatorInterface):
 
         if not self._use_virtual_board:
             self._buffer_manager = executor.get_item("BufferManager")
-        else:
-            # Fill in IP Tag ports (virtual so won't actually be used)
-            for tag in self._tags.ip_tags:
-                if tag.port is None:
-                    tag.port = 65534
-            for tag in self._tags.reverse_ip_tags:
-                if tag.port is None:
-                    tag.port = 64434
 
         self._mapping_time += \
             helpful_functions.convert_time_diff_to_total_milliseconds(

--- a/spinn_front_end_common/utilities/database/database_writer.py
+++ b/spinn_front_end_common/utilities/database/database_writer.py
@@ -241,6 +241,9 @@ class DatabaseWriter(object):
             int(entry.routing_entry_key), int(entry.mask), int(route))
 
     def __insert_ip_tag(self, vertex, ip_tag):
+        port = ip_tag.port
+        if port is None:
+            port = 0
         return self.__insert(
             "INSERT INTO IP_tags("
             "  vertex_id, tag, board_address, ip_address,"
@@ -248,16 +251,19 @@ class DatabaseWriter(object):
             "VALUES (?, ?, ?, ?, ?, ?)",
             int(self._vertex_to_id[vertex]),
             int(ip_tag.tag), str(ip_tag.board_address),
-            str(ip_tag.ip_address), int(ip_tag.port),
+            str(ip_tag.ip_address), int(port),
             1 if ip_tag.strip_sdp else 0)
 
     def __insert_reverse_ip_tag(self, vertex, reverse_ip_tag):
+        port = reverse_ip_tag.port
+        if port is None:
+            port = 0
         return self.__insert(
             "INSERT INTO Reverse_IP_tags("
             "  vertex_id, tag, board_address, port) "
             "VALUES (?, ?, ?, ?)",
             int(self._vertex_to_id[vertex]), int(reverse_ip_tag.tag),
-            str(reverse_ip_tag.board_address), int(reverse_ip_tag.port))
+            str(reverse_ip_tag.board_address), int(port))
 
     def __insert_event_atom_mapping(self, vertex, event_id, atom_id):
         return self.__insert(


### PR DESCRIPTION
Fixes the use of IP tags with virtual boards, by not actually setting the port in the tag, but instead using a default in the database when the tag port has not been assigned.