### PR TITLE
report stating what chips reside on what board given ip address. 

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -671,6 +671,11 @@ class AbstractSpinnakerBase(SimulatorInterface):
                     "EnergySavings", "turn_off_board_after_discovery", "False")
                 logger.info("[EnergySavings]turn_off_board_after_discovery has"
                             " been set to False as s using virtual boards")
+            if self._config.getboolean(
+                    "Reports", "write_board_chip_report") is True:
+                self._config.set("Reports", "write_board_chip_report", "False")
+                logger.info("[Reports]write_board_chip_report has been set to"
+                            " False as using virtual boards")
 
     def _set_up_output_folders(self):
         """ Sets up the outgoing folders (reports and app data) by creating\
@@ -1618,6 +1623,10 @@ class AbstractSpinnakerBase(SimulatorInterface):
                     "Reports", "write_routing_tables_from_machine_report"):
                 optional_algorithms.append(
                     "RoutingTableFromMachineReport")
+
+            # only add board chip report if requested
+            if self._config.getboolean("Reports", "write_board_chip_report"):
+                algorithms.append("BoardChipReport")
 
             # only add partitioner report if using an application graph
             if (self._config.getboolean(

--- a/spinn_front_end_common/interface/spinnaker.cfg
+++ b/spinn_front_end_common/interface/spinnaker.cfg
@@ -55,6 +55,7 @@ write_provenance_data = True
 write_tag_allocation_reports = True
 write_algorithm_timings = True
 write_reload_steps = False
+write_board_chip_report = True
 
 # NOTE ***that for bespoke file paths, folders will not be automatically deleted***
 # options are DEFAULT or a file path

--- a/spinn_front_end_common/utilities/report_functions/board_chip_report.py
+++ b/spinn_front_end_common/utilities/report_functions/board_chip_report.py
@@ -1,0 +1,35 @@
+import os
+from spinn_utilities.progress_bar import ProgressBar
+
+
+class BoardChipReport(object):
+    """ Report on memory usage
+    """
+
+    AREA_CODE_REPORT_NAME = "board_chip_report.txt"
+
+    def __call__(self, report_default_directory, machine):
+        """ creates a report that states where in sdram each region is
+
+        :param report_default_directory: the folder where reports are written
+        :param machine: python representation of the machine
+        :rtype: None
+        """
+
+        # create file path
+        directory_name = os.path.join(
+            report_default_directory, self.AREA_CODE_REPORT_NAME)
+
+        # create the progress bar for end users
+        progress_bar = ProgressBar(
+            len(machine.ethernet_connected_chips),
+            "Writing the board chip report")
+
+        # iterate over ethernet chips and then the chips on that board
+        with open(directory_name, "w") as writer:
+            for ethernet_connected_chip in \
+                    progress_bar.over(machine.ethernet_connected_chips):
+                chips = machine.get_chips_on_board(ethernet_connected_chip)
+                writer.write(
+                    "board with ip address : {} : has chips {}\n".format(
+                        ethernet_connected_chip.ip_address, list(chips)))

--- a/spinn_front_end_common/utilities/report_functions/front_end_common_reports.xml
+++ b/spinn_front_end_common/utilities/report_functions/front_end_common_reports.xml
@@ -2,6 +2,24 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="https://github.com/SpiNNakerManchester/PACMAN
             https://raw.githubusercontent.com/SpiNNakerManchester/PACMAN/master/pacman/operations/algorithms_metadata_schema.xsd">
+    <algorithm name="BoardChipReport">
+        <python_module>spinn_front_end_common.utilities.report_functions.board_chip_report</python_module>
+        <python_class>BoardChipReport</python_class>
+        <input_definitions>
+            <parameter>
+                <param_name>report_default_directory</param_name>
+                <param_type>ReportFolder</param_type>
+            </parameter>
+            <parameter>
+                <param_name>machine</param_name>
+                <param_type>MemoryExtendedMachine</param_type>
+            </parameter>
+        </input_definitions>
+        <required_inputs>
+            <param_name>report_default_directory</param_name>
+            <param_name>machine</param_name>
+        </required_inputs>
+    </algorithm>
     <algorithm name="FixedRouteFromMachineReport">
         <python_module>spinn_front_end_common.utilities.report_functions.fixed_route_from_machine_report</python_module>
         <python_class>FixedRouteFromMachineReport</python_class>


### PR DESCRIPTION
supports easier debugging when handling multi board machines. when errors such as chip x,y fail, you can now know which board ip address it was on, and thus which hardware board it was. 