### PR TITLE
check if send_buffer_times exists, truth of array is ambiguous

### DIFF
--- a/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
@@ -224,7 +224,8 @@ class ReverseIPTagMulticastSourceMachineVertex(
             self._install_virtual_key(n_keys)
 
     def _install_send_buffer(self, n_keys, send_buffer_times, target_address):
-        if send_buffer_times and hasattr(send_buffer_times[0], "__len__"):
+        if (send_buffer_times is not None and
+                hasattr(send_buffer_times[0], "__len__")):
             # Working with a list of lists so check length
             if len(send_buffer_times) != n_keys:
                 raise ConfigurationException(

--- a/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
@@ -224,7 +224,7 @@ class ReverseIPTagMulticastSourceMachineVertex(
             self._install_virtual_key(n_keys)
 
     def _install_send_buffer(self, n_keys, send_buffer_times, target_address):
-        if (send_buffer_times is not None and
+        if (len(send_buffer_times) and
                 hasattr(send_buffer_times[0], "__len__")):
             # Working with a list of lists so check length
             if len(send_buffer_times) != n_keys:


### PR DESCRIPTION
Fix for issue https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/issues/288 which happened when I updated to recent master and tried to run fixed-number connectors; I don't know precisely why it's only happening with fixed number connectors and nothing else (as far as I can tell), but this change seems to fix the problem.