### PR TITLE
Spalloc fixes

### DIFF
--- a/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
@@ -805,6 +805,10 @@
                 <param_name>down_links</param_name>
                 <param_type>DownedLinksDetails</param_type>
             </parameter>
+            <parameter>
+                <param_name>max_sdram_size</param_name>
+                <param_type>MaxSDRAMSize</param_type>
+            </parameter>
         </input_definitions>
         <optional_inputs>
             <param_name>width</param_name>
@@ -816,6 +820,7 @@
             <param_name>down_chips</param_name>
             <param_name>down_cores</param_name>
             <param_name>down_links</param_name>
+            <param_name>max_sdram_size</param_name>
         </optional_inputs>
         <outputs>
             <param_type>MemoryMachine</param_type>

--- a/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
@@ -1538,15 +1538,11 @@
         <outputs>
             <param_type>IPAddress</param_type>
             <param_type>BoardVersion</param_type>
-            <param_type>DownedChipsDetails</param_type>
-            <param_type>DownedCoresDetails</param_type>
-            <param_type>DownedLinksDetails</param_type>
             <param_type>BMPDetails</param_type>
             <param_type>ResetMachineOnStartupFlag</param_type>
             <param_type>AutoDetectBMPFlag</param_type>
             <param_type>ScampConnectionData</param_type>
             <param_type>BootPortNum</param_type>
-            <param_type>MaxSDRAMSize</param_type>
             <param_type>MachineAllocationController</param_type>
         </outputs>
     </algorithm>
@@ -1575,16 +1571,12 @@
         <outputs>
             <param_type>IPAddress</param_type>
             <param_type>BoardVersion</param_type>
-            <param_type>DownedChipsDetails</param_type>
-            <param_type>DownedCoresDetails</param_type>
             <param_type>BMPDetails</param_type>
             <param_type>ResetMachineOnStartupFlag</param_type>
             <param_type>AutoDetectBMPFlag</param_type>
             <param_type>ScampConnectionData</param_type>
             <param_type>BootPortNum</param_type>
-            <param_type>MaxSDRAMSize</param_type>
             <param_type>MachineAllocationController</param_type>
-            <param_type>DownedLinksDetails</param_type>
         </outputs>
     </algorithm>
     <algorithm name="SpallocMaxMachineGenerator">

--- a/spinn_front_end_common/interface/interface_functions/hbp_allocator.py
+++ b/spinn_front_end_common/interface/interface_functions/hbp_allocator.py
@@ -78,9 +78,9 @@ class HBPAllocator(object):
             bmp_details = machine["bmpDetails"]
 
         return (
-            machine["machineName"], int(machine["version"]), None, None,
-            bmp_details, False, False, None, None, None,
-            hbp_job_controller, None)
+            machine["machineName"], int(machine["version"]),
+            bmp_details, False, False, None, None,
+            hbp_job_controller)
 
     def _get_machine(self, url, n_chips, total_run_time):
         get_machine_request = requests.get(

--- a/spinn_front_end_common/interface/interface_functions/hbp_allocator.py
+++ b/spinn_front_end_common/interface/interface_functions/hbp_allocator.py
@@ -12,14 +12,24 @@ class _HBPJobController(MachineAllocationController):
     __slots__ = [
         # the URLs to call the HBP system
         "_extend_lease_url",
-        "_check_lease_url"
+        "_check_lease_url",
+        "_release_machine_url",
+        "_set_power_url",
+        "_where_is_url",
+        "_machine_name",
+        "_power_on"
     ]
 
     _WAIT_TIME_MS = 10000
 
-    def __init__(self, url):
+    def __init__(self, url, machine_name):
         self._extend_lease_url = "{}/extendLease".format(url)
         self._check_lease_url = "{}/checkLease".format(url)
+        self._release_machine_url = url
+        self._set_power_url = "{}/power".format(url)
+        self._where_is_url = "{}/chipCoordinates".format(url)
+        self._machine_name = machine_name
+        self._power_on = True
         # Lower the level of requests to WARNING to avoid extra messages
         logging.getLogger("requests").setLevel(logging.WARNING)
         super(_HBPJobController, self).__init__("HBPJobController")
@@ -33,18 +43,37 @@ class _HBPJobController(MachineAllocationController):
         return requests.get(self._check_lease_url, params={
             "waitTime": wait_time}).json()
 
+    def _release(self, machine_name):
+        requests.delete(self._release_machine_url, params={
+            "machineName": machine_name})
+
+    def _set_power(self, machine_name, power_on):
+        requests.put(self._set_power_url, params={
+            "machineName": machine_name, "on": bool(power_on)})
+
+    def _where_is(self, machine_name, chip_x, chip_y):
+        requests.get(self._where_is_url, params={
+            "machineName": machine_name, "chipX": chip_x, "chipY": chip_y})
+
+    @overrides(AbstractMachineAllocationController.close)
+    def close(self):
+        super(_HBPJobController, self).close()
+        self._release(self._machine_name)
+
+    @overrides(MachineAllocationController._teardown)
+    def _teardown(self):
+        self._release(self._machine_name)
+
     @property
     def power(self):
-        # TODO NEEDS FIXING
-        return True
+        return self._power_on
 
     def set_power(self, power):
-        # TODO NEEDS FIXING
-        pass
+        self._set_power(self._machine_name, power)
+        self._power_on = power
 
     def where_is_machine(self, chip_x, chip_y):
-        # TODO NEEDS FIXING
-        pass
+        return self._where_is(self._machine_name, chip_x, chip_y)
 
     @overrides(MachineAllocationController._wait)
     def _wait(self):
@@ -71,7 +100,7 @@ class HBPAllocator(object):
             url = url[:-1]
 
         machine = self._get_machine(url, n_chips, total_run_time)
-        hbp_job_controller = _HBPJobController(url)
+        hbp_job_controller = _HBPJobController(url, machine["machineName"])
 
         bmp_details = None
         if "bmp_details" in machine:

--- a/spinn_front_end_common/interface/interface_functions/spalloc_allocator.py
+++ b/spinn_front_end_common/interface/interface_functions/spalloc_allocator.py
@@ -106,8 +106,8 @@ class SpallocAllocator(object):
         machine_allocation_controller = _SpallocJobController(job)
 
         return (
-            hostname, self._MACHINE_VERSION, None, None, None, None, False,
-            False, None, None, None, machine_allocation_controller
+            hostname, self._MACHINE_VERSION, None, False,
+            False, None, None, machine_allocation_controller
         )
 
     def _launch_job(self, n_boards, spalloc_kw_args):

--- a/spinn_front_end_common/interface/interface_functions/virtual_machine_generator.py
+++ b/spinn_front_end_common/interface/interface_functions/virtual_machine_generator.py
@@ -10,8 +10,7 @@ class VirtualMachineGenerator(object):
             self, width=None, height=None, virtual_has_wrap_arounds=None,
             version=None, n_cpus_per_chip=18, with_monitors=True,
             down_chips=None, down_cores=None, down_links=None,
-            max_sdram_size=None,
-            max_core_id=(VirtualMachine.MAX_CORES_PER_CHIP - 1)):
+            max_sdram_size=None):
         """
         :param width: The width of the machine in chips
         :param height: The height of the machine in chips
@@ -24,7 +23,6 @@ class VirtualMachineGenerator(object):
         :param down_cores: The set of cores that should be considered broken
         :param down_links: The set of links that should be considered broken
         :param max_sdram_size: The SDRAM that should be given to each chip
-        :param max_core_id: The maximum core that should be used on each chip
         """
         # pylint: disable=too-many-arguments
         machine = VirtualMachine(
@@ -33,7 +31,7 @@ class VirtualMachineGenerator(object):
             version=version, n_cpus_per_chip=n_cpus_per_chip,
             with_monitors=with_monitors, down_chips=down_chips,
             down_cores=down_cores, down_links=down_links,
-            sdram_per_chip=max_sdram_size, n_cpus_per_chip=(max_core_id + 1))
+            sdram_per_chip=max_sdram_size)
 
         # Work out and add the spinnaker links and FPGA links
         machine.add_spinnaker_links(version)

--- a/spinn_front_end_common/interface/interface_functions/virtual_machine_generator.py
+++ b/spinn_front_end_common/interface/interface_functions/virtual_machine_generator.py
@@ -9,7 +9,9 @@ class VirtualMachineGenerator(object):
     def __call__(
             self, width=None, height=None, virtual_has_wrap_arounds=None,
             version=None, n_cpus_per_chip=18, with_monitors=True,
-            down_chips=None, down_cores=None, down_links=None):
+            down_chips=None, down_cores=None, down_links=None,
+            max_sdram_size=None,
+            max_core_id=(VirtualMachine.MAX_CORES_PER_CHIP - 1)):
         """
         :param width: The width of the machine in chips
         :param height: The height of the machine in chips
@@ -18,6 +20,11 @@ class VirtualMachineGenerator(object):
         :param version: The version of board to create
         :param n_cpus_per_chip: The number of cores to put on each chip
         :param with_monitors: If true, CPU 0 will be marked as a monitor
+        :param down_chips: The set of chips that should be considered broken
+        :param down_cores: The set of cores that should be considered broken
+        :param down_links: The set of links that should be considered broken
+        :param max_sdram_size: The SDRAM that should be given to each chip
+        :param max_core_id: The maximum core that should be used on each chip
         """
         # pylint: disable=too-many-arguments
         machine = VirtualMachine(
@@ -25,7 +32,8 @@ class VirtualMachineGenerator(object):
             with_wrap_arounds=virtual_has_wrap_arounds,
             version=version, n_cpus_per_chip=n_cpus_per_chip,
             with_monitors=with_monitors, down_chips=down_chips,
-            down_cores=down_cores, down_links=down_links)
+            down_cores=down_cores, down_links=down_links,
+            sdram_per_chip=max_sdram_size, n_cpus_per_chip=(max_core_id + 1))
 
         # Work out and add the spinnaker links and FPGA links
         machine.add_spinnaker_links(version)


### PR DESCRIPTION
Fixes #291 

Also adds some calls to the HBP allocation that will make the interaction work better.  Although this requires the HBP portal to also be updated (see SpiNNakerManchester/RemoteSpiNNaker#23), this can still be merged now, as this software would also have to be released on the portal VM before it became an issue.