### PR TITLE
Fixes buffered out when using multiple runs

### DIFF
--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -150,8 +150,8 @@ class BufferManager(object):
         self._store_to_file = store_to_file
 
         # Lock to avoid multiple messages being processed at the same time
-        self._thread_lock_buffer_out = threading.Lock()
-        self._thread_lock_buffer_in = threading.Lock()
+        self._thread_lock_buffer_out = threading.RLock()
+        self._thread_lock_buffer_in = threading.RLock()
         self._buffering_out_thread_pool = ThreadPool(processes=1)
 
         self._finished = False
@@ -555,6 +555,10 @@ class BufferManager(object):
                 self._finished = True
 
     def get_data_for_vertices(self, vertices, progress=None):
+        with self._thread_lock_buffer_out:
+            self._get_data_for_vertices_locked(vertices, progress)
+
+    def _get_data_for_vertices_locked(self, vertices, progress=None):
         receivers = OrderedSet()
         if self._uses_advanced_monitors:
 
@@ -659,12 +663,14 @@ class BufferManager(object):
                 self._received_data.last_sequence_no_for_core(
                     placement.x, placement.y, placement.p)
 
-            # get the last sequence number
-            last_sequence_number = \
+            # get the sequence number the core was expecting to see next
+            core_next_sequence_number = \
                 self._received_data.get_end_buffering_sequence_number(
                     placement.x, placement.y, placement.p)
 
-            if last_sequence_number == seq_no_last_ack_packet:
+            # if the core was expecting to see our last sent sequence,
+            # it must not have received it
+            if core_next_sequence_number == seq_no_last_ack_packet:
                 self._process_last_ack(placement, recording_region_id,
                                        end_state)
 

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffered_receiving_data.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffered_receiving_data.py
@@ -335,6 +335,7 @@ class BufferedReceivingData(object):
         self._sequence_no = defaultdict(lambda: 0xFF)
         self._last_packet_received = defaultdict(lambda: None)
         self._last_packet_sent = defaultdict(lambda: None)
+        self._end_buffering_sequence_no = dict()
 
     def clear(self, x, y, p, region_id):
         """ Clears the data from a given data region (only clears things\


### PR DESCRIPTION
Found this mostly by accident, but buffered read wasn't working when in multirun, as the buffered information wasn't reset correctly.