### PR TITLE
Add reset of reloadable regions after DSG

### DIFF
--- a/spinn_front_end_common/interface/interface_functions/graph_data_specification_writer.py
+++ b/spinn_front_end_common/interface/interface_functions/graph_data_specification_writer.py
@@ -33,7 +33,8 @@ class GraphDataSpecificationWriter(object):
     def __call__(
             self, placements, hostname,
             report_default_directory, write_text_specs,
-            app_data_runtime_folder, machine, graph_mapper=None):
+            app_data_runtime_folder, machine, graph_mapper=None,
+            placement_order=None):
         """
 
         :param placements: placements of machine graph to cores
@@ -46,6 +47,8 @@ class GraphDataSpecificationWriter(object):
         :param machine: the python representation of the spinnaker machine
         :param graph_mapper:\
             the mapping between application and machine graph
+        :param placement:\
+            the optional order in which placements should be examined
 
         :return: dsg targets (map of placement tuple and filename)
         """
@@ -55,10 +58,13 @@ class GraphDataSpecificationWriter(object):
         # vertex
         dsg_targets = dict()
 
+        if placement_order is None:
+            placement_order = placements.placements
+
         progress = ProgressBar(
             placements.n_placements, "Generating data specifications")
         vertices_to_reset = list()
-        for placement in progress.over(placements.placements):
+        for placement in progress.over(placement_order):
             # Try to generate the data spec for the placement
             generated = self._generate_data_spec_for_vertices(
                 placement, placement.vertex, dsg_targets, hostname,
@@ -80,7 +86,7 @@ class GraphDataSpecificationWriter(object):
                     app_data_runtime_folder, machine)
                 if generated and isinstance(
                         associated_vertex, AbstractRewritesDataSpecification):
-                    vertices_to_reset.append(placement.vertex)
+                    vertices_to_reset.append(associated_vertex)
 
         # Ensure that the vertices know their regions have been reloaded
         for vertex in vertices_to_reset:

--- a/spinn_front_end_common/interface/interface_functions/graph_data_specification_writer.py
+++ b/spinn_front_end_common/interface/interface_functions/graph_data_specification_writer.py
@@ -1,7 +1,8 @@
 from collections import defaultdict
 
 from spinn_utilities.progress_bar import ProgressBar
-from spinn_front_end_common.abstract_models.abstract_rewrites_data_specification import AbstractRewritesDataSpecification
+from spinn_front_end_common.abstract_models \
+    import AbstractRewritesDataSpecification
 
 from data_specification.utility_calls \
     import get_data_spec_and_file_writer_filename


### PR DESCRIPTION
This is needed to avoid a call which changes something meaning that DSG reload occurs when it shouldn't.  If you have done DSG, we can be sure the region has been reloaded after all...