### PR TITLE
Travis build java

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - openjdk-r
     packages:
       - libc6:i386
       - vera++
@@ -14,8 +13,6 @@ addons:
       - gcc-arm-none-eabi
       - libnewlib-arm-none-eabi
       - g++-5
-      - openjdk-8-jdk
-      - ant
 
 cache: pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
+      - openjdk-r
     packages:
       - libc6:i386
       - vera++
@@ -13,6 +14,8 @@ addons:
       - gcc-arm-none-eabi
       - libnewlib-arm-none-eabi
       - g++-5
+      - openjdk-8-jdk
+      - ant
 
 cache: pip
 
@@ -60,6 +63,9 @@ script:
   - make -C cpp_common CXX="g++-5"
   - support/run-vera.sh c_common
   - support/run-vera.sh cpp_common
+  # Java
+  - (cd java_common && ant clean jar)
+  ### TODO: Switch to maven to get style check (and other tooling) support
   # Docs
   - support/travis-sphinx.sh html -T -E -b html -d _build/doctrees-readthedocsdirhtml -D language=en . _build/html
   - support/travis-sphinx.sh json -T -b json -d _build/doctrees-json -D language=en . _build/json

--- a/java_common/.gitignore
+++ b/java_common/.gitignore
@@ -1,2 +1,3 @@
 *.class
 .classpath
+bin

--- a/java_common/build.xml
+++ b/java_common/build.xml
@@ -11,7 +11,7 @@
 
 	<target name="compile">
 		<mkdir dir="${classes.dir}" />
-		<javac srcdir="src" destdir="${classes.dir}" includeantruntime="false" />
+		<javac srcdir="src" destdir="${classes.dir}" includeantruntime="false" target="1.8" source="1.8" />
 	</target>
 
 	<target name="jar" depends="compile">


### PR DESCRIPTION
Adds building of the Java code via `ant` on Travis.
<sup>Build is currently failing for reasons not to do with the Java code.</sup>