### PR TITLE
Fix spalloc external devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ Debug
 lastfailed
 /.cache
 .coverage
+*.o
+*.class

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -8,7 +8,6 @@ from spinn_utilities import __version__ as spinn_utils_version
 # pacman imports
 from pacman.executor.injection_decorator import provide_injectables, \
     clear_injectables
-from pacman.model.graphs import AbstractVirtualVertex
 from pacman.model.graphs.common import GraphMapper
 from pacman.model.placements import Placements
 from pacman.executor import PACMANAlgorithmExecutor

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1303,14 +1303,13 @@ class AbstractSpinnakerBase(SimulatorInterface):
                 "Machine", "core_limit")
 
             algorithms.append("MachineGenerator")
-            algorithms.append("MallocBasedChipIDAllocator")
 
-            outputs.append("MemoryExtendedMachine")
+            outputs.append("MemoryMachine")
             outputs.append("MemoryTransceiver")
 
             executor = self._run_algorithms(
                 inputs, algorithms, outputs, [], [], "machine_generation")
-            self._machine = executor.get_item("MemoryExtendedMachine")
+            self._machine = executor.get_item("MemoryMachine")
             self._txrx = executor.get_item("MemoryTransceiver")
             self._machine_outputs = executor.get_items()
             self._machine_tokens = executor.get_completed_tokens()
@@ -1332,15 +1331,14 @@ class AbstractSpinnakerBase(SimulatorInterface):
             inputs["CPUsPerVirtualChip"] = 16
 
             algorithms.append("VirtualMachineGenerator")
-            algorithms.append("MallocBasedChipIDAllocator")
 
-            outputs.append("MemoryExtendedMachine")
+            outputs.append("MemoryMachine")
 
             executor = self._run_algorithms(
                 inputs, algorithms, outputs, [], [], "machine_generation")
             self._machine_outputs = executor.get_items()
             self._machine_tokens = executor.get_completed_tokens()
-            self._machine = executor.get_item("MemoryExtendedMachine")
+            self._machine = executor.get_item("MemoryMachine")
 
         if (self._spalloc_server is not None or
                 self._remote_spinnaker_url is not None):
@@ -1425,9 +1423,8 @@ class AbstractSpinnakerBase(SimulatorInterface):
                 algorithms.append("HBPAllocator")
 
             algorithms.append("MachineGenerator")
-            algorithms.append("MallocBasedChipIDAllocator")
 
-            outputs.append("MemoryExtendedMachine")
+            outputs.append("MemoryMachine")
             outputs.append("IPAddress")
             outputs.append("MemoryTransceiver")
             outputs.append("MachineAllocationController")
@@ -1437,7 +1434,7 @@ class AbstractSpinnakerBase(SimulatorInterface):
 
             self._machine_outputs = executor.get_items()
             self._machine_tokens = executor.get_completed_tokens()
-            self._machine = executor.get_item("MemoryExtendedMachine")
+            self._machine = executor.get_item("MemoryMachine")
             self._ip_address = executor.get_item("IPAddress")
             self._txrx = executor.get_item("MemoryTransceiver")
             self._machine_allocation_controller = executor.get_item(
@@ -1479,7 +1476,7 @@ class AbstractSpinnakerBase(SimulatorInterface):
 
     def generate_file_machine(self):
         inputs = {
-            "MemoryExtendedMachine": self.machine,
+            "MemoryMachine": self.machine,
             "FileMachineFilePath": os.path.join(
                 self._json_folder, "machine.json")
         }
@@ -1653,6 +1650,7 @@ class AbstractSpinnakerBase(SimulatorInterface):
                 algorithms.append("NetworkSpecificationReport")
 
         # only add the partitioner if there isn't already a machine graph
+        algorithms.append("MallocBasedChipIDAllocator")
         if (self._application_graph.n_vertices and
                 not self._machine_graph.n_vertices):
             full = self._config.get(
@@ -2419,11 +2417,6 @@ class AbstractSpinnakerBase(SimulatorInterface):
             raise ConfigurationException(
                 "Cannot add vertices to both the machine and application"
                 " graphs")
-        if (isinstance(vertex_to_add, AbstractVirtualVertex) and
-                self._machine is not None):
-            raise ConfigurationException(
-                "A Virtual Vertex cannot be added after the machine has been"
-                " created")
         self._original_application_graph.add_vertex(vertex_to_add)
 
     def add_machine_vertex(self, vertex):
@@ -2438,11 +2431,6 @@ class AbstractSpinnakerBase(SimulatorInterface):
             raise ConfigurationException(
                 "Cannot add vertices to both the machine and application"
                 " graphs")
-        if (isinstance(vertex, AbstractVirtualVertex) and
-                self._machine is not None):
-            raise ConfigurationException(
-                "A Virtual Vertex cannot be added after the machine has been"
-                " created")
         self._original_machine_graph.add_vertex(vertex)
 
     def add_application_edge(self, edge_to_add, partition_identifier):

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1387,7 +1387,6 @@ class AbstractSpinnakerBase(SimulatorInterface):
 
             do_partitioning = False
             if need_virtual_board:
-                algorithms.append("VirtualMallocBasedChipIDAllocator")
 
                 # If we are using an allocation server, and we need a virtual
                 # board, we need to use the virtual board to get the number of

--- a/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
@@ -154,8 +154,8 @@
         <input_definitions>
             <parameter>
                 <param_name>machine</param_name>
-                <param_type>MemoryExtendedVirtualMachine</param_type>
-                <param_type>MemoryExtendedMachine</param_type>
+                <param_type>MemoryVirtualMachine</param_type>
+                <param_type>MemoryMachine</param_type>
             </parameter>
             <parameter>
                 <param_name>pre_allocated_resources</param_name>
@@ -186,8 +186,8 @@
         <input_definitions>
             <parameter>
                 <param_name>machine</param_name>
-                <param_type>MemoryExtendedVirtualMachine</param_type>
-                <param_type>MemoryExtendedMachine</param_type>
+                <param_type>MemoryVirtualMachine</param_type>
+                <param_type>MemoryMachine</param_type>
             </parameter>
             <parameter>
                 <param_name>pre_allocated_resources</param_name>
@@ -282,8 +282,8 @@
             </parameter>
             <parameter>
                 <param_name>machine</param_name>
-                <param_type>MemoryExtendedVirtualMachine</param_type>
-                <param_type>MemoryExtendedMachine</param_type>
+                <param_type>MemoryVirtualMachine</param_type>
+                <param_type>MemoryMachine</param_type>
             </parameter>
             <parameter>
                 <param_name>pre_allocated_resources</param_name>

--- a/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
@@ -1152,6 +1152,7 @@
             <parameter>
                 <param_name>machine</param_name>
                 <param_type>MemoryExtendedMachine</param_type>
+                <param_type>MemoryMachine</param_type>
             </parameter>
             <parameter>
                 <param_name>router_tables</param_name>


### PR DESCRIPTION
Allows the use of spalloc with external devices.  This extends the PACMAN change allowing the user to get the machine and still add virtual vertices to the machine after this has been done.

Dependent on SpiNNakerManchester/PACMAN#157