### PR TITLE
Remove #include that wasn't needed and caused failures

### DIFF
--- a/c_common/front_end_common_lib/src/recording.c
+++ b/c_common/front_end_common_lib/src/recording.c
@@ -16,7 +16,6 @@
 extern void spin1_wfi();
 
 // Standard includes
-#include <string.h>
 #include <debug.h>
 
 enum recording_data_e {

--- a/c_common/models/command_sender_multicast_source/command_sender_multicast_source.c
+++ b/c_common/models/command_sender_multicast_source/command_sender_multicast_source.c
@@ -2,7 +2,6 @@
 #include <data_specification.h>
 #include <debug.h>
 #include <simulation.h>
-#include <string.h>
 #include <stdbool.h>
 
 // Command structure
@@ -145,7 +144,7 @@ bool read_scheduled_parameters(address_t address) {
         return false;
     }
 
-    memcpy(
+    spin1_memcpy(
         timed_commands, &address[START_OF_SCHEDULE],
         n_timed_commands * sizeof(timed_command));
 
@@ -171,7 +170,7 @@ bool read_start_resume_commands(address_t address) {
         log_error("Could not allocate the start/resume commands");
         return false;
     }
-    memcpy(
+    spin1_memcpy(
         start_resume_commands, &address[START_OF_SCHEDULE],
         n_start_resume_commands * sizeof(command));
 
@@ -194,7 +193,7 @@ bool read_pause_stop_commands(address_t address) {
         log_error("Could not allocate the pause/stop commands");
         return false;
     }
-    memcpy(
+    spin1_memcpy(
         pause_stop_commands, &address[START_OF_SCHEDULE],
         n_pause_stop_commands * sizeof(command));
 

--- a/c_common/models/live_packet_gather/live_packet_gather.c
+++ b/c_common/models/live_packet_gather/live_packet_gather.c
@@ -155,8 +155,7 @@ void flush_events(void) {
 }
 
 //! \brief function to store provenance data elements into SDRAM
-void record_provenance_data(address_t provenance_region_address)
-{
+void record_provenance_data(address_t provenance_region_address) {
     // Copy provenance data into SDRAM region
     spin1_memcpy(provenance_region_address, &provenance_data,
            sizeof(provenance_data));

--- a/c_common/models/live_packet_gather/live_packet_gather.c
+++ b/c_common/models/live_packet_gather/live_packet_gather.c
@@ -4,7 +4,6 @@
 #include <debug.h>
 #include <simulation.h>
 #include <spin1_api.h>
-#include <string.h>
 
 // Globals
 static sdp_msg_t g_event_message;
@@ -156,10 +155,10 @@ void flush_events(void) {
 }
 
 //! \brief function to store provenance data elements into SDRAM
-void record_provenance_data(address_t provenance_region_address) {
-
+void record_provenance_data(address_t provenance_region_address)
+{
     // Copy provenance data into SDRAM region
-    memcpy(provenance_region_address, &provenance_data,
+    spin1_memcpy(provenance_region_address, &provenance_data,
            sizeof(provenance_data));
 }
 

--- a/c_common/models/reverse_iptag_multicast_source/reverse_iptag_multicast_source.c
+++ b/c_common/models/reverse_iptag_multicast_source/reverse_iptag_multicast_source.c
@@ -3,7 +3,6 @@
 #include <debug.h>
 #include <simulation.h>
 #include <sark.h>
-#include <string.h>
 #include <buffered_eieio_defs.h>
 #include "recording.h"
 


### PR DESCRIPTION
This was causing problems on Dave's machine, yet doesn't seem to be needed for anything in the build of FEC at all…