### PR TITLE
fixes a issue when the app layer is using differnet outgoing partitions.

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -851,6 +851,7 @@ class AbstractSpinnakerBase(SimulatorInterface):
             self._machine_graph.add_vertex(vertex)
         for outgoing_partition in \
                 self._original_machine_graph.outgoing_edge_partitions:
+            self._machine_graph.add_outgoing_edge_partition(outgoing_partition)
             for edge in outgoing_partition.edges:
                 self._machine_graph.add_edge(
                     edge, outgoing_partition.identifier)


### PR DESCRIPTION
the graph system will add a basic outoging partition if it doesnt exist already. this buggers up end user level outgoing partitions, so this one line just adds the original one in, so that the graph doestn lose the data within. 

only detected when trying to get data from nengo outgoing partitions in mapping, and changing the __repr__ did nowt. lol