### PR TITLE
Synapse expander on chip

### DIFF
--- a/c_common/front_end_common_lib/include/simulation.h
+++ b/c_common/front_end_common_lib/include/simulation.h
@@ -96,7 +96,9 @@ void simulation_set_provenance_function(
 void simulation_set_exit_function(exit_callback_t exit_function);
 
 //! \brief cleans up the house keeping, falls into a sync state and handles
-//!        the resetting up of states as required to resume.
+//!        the resetting up of states as required to resume.  Note that
+//!        following this function, the code should call
+//!        simulation_ready_to_read (see later).
 //! \param[in] resume_function The function to call just before the simulation
 //!            is resumed (to allow the resetting of the simulation)
 void simulation_handle_pause_resume(resume_callback_t resume_function);
@@ -107,6 +109,10 @@ void simulation_exit();
 
 //! \brief Starts the simulation running, returning when it is complete,
 void simulation_run();
+
+//! \brief Indicates that all data has been written and the core is going
+//!        idle, so any data can now be read
+void simulation_ready_to_read();
 
 //! \brief Registers an additional SDP callback on a given SDP port.  This is
 //!        required when using simulation_register_sdp_callback, as this will

--- a/c_common/front_end_common_lib/src/simulation.c
+++ b/c_common/front_end_common_lib/src/simulation.c
@@ -79,19 +79,23 @@ void simulation_run() {
 //!            is resumed (to allow the resetting of the simulation)
 void simulation_handle_pause_resume(resume_callback_t callback){
 
+    // Pause the simulation
+    spin1_pause();
+
     stored_resume_function = callback;
 
     // Store provenance data as required
     _execute_provenance_storage();
-
-    // Pause the simulation
-    spin1_pause();
 }
 
 //! \brief a helper method for people not using the auto pause and
 //! resume functionality
 void simulation_exit(){
     simulation_handle_pause_resume(NULL);
+}
+
+void simulation_ready_to_read() {
+    sark_cpu_state(CPU_STATE_WAIT);
 }
 
 //! \brief method for sending OK response to the host when a command message

--- a/c_common/models/chip_power_monitor/src/chip_power_monitor.c
+++ b/c_common/models/chip_power_monitor/src/chip_power_monitor.c
@@ -56,7 +56,7 @@ static void reset_core_counters(void)
 {
     int i;
     for (i=0 ; i<NUM_CORES ; i++) {
-	    core_counters[i] = 0;
+        core_counters[i] = 0;
     }
     sample_count = 0;
 }
@@ -85,18 +85,21 @@ static void sample_in_slot(uint unused0, uint unused1)
     // check if the simulation has run to completion
     if ((infinite_run != TRUE) && (time >= simulation_ticks)) {
 
-        recording_finalise();
         simulation_handle_pause_resume(resume_callback);
+
+        recording_finalise();
 
         // Subtract 1 from the time so this tick gets done again on the next
         // run
         time -= 1;
+
+        simulation_ready_to_read();
     }
 
     uint32_t sc = ++sample_count;
     uint32_t offset = get_random_busy();
     while (offset --> 0) {
-	    // Do nothing
+        // Do nothing
     }
 
     uint32_t sample = get_sample();
@@ -146,7 +149,7 @@ static bool initialize(uint32_t *timer)
     log_info("total_sim_ticks = %d", simulation_ticks);
 
     address_t recording_region =
-	    data_specification_get_region(RECORDING, address);
+        data_specification_get_region(RECORDING, address);
     bool success = recording_initialize(recording_region, &recording_flags);
     return success;
 }

--- a/c_common/models/command_sender_multicast_source/src/command_sender_multicast_source.c
+++ b/c_common/models/command_sender_multicast_source/src/command_sender_multicast_source.c
@@ -221,15 +221,18 @@ void timer_callback(uint unused0, uint unused1) {
     }
 
     if (((infinite_run != TRUE) && (time >= simulation_ticks))) {
+        simulation_handle_pause_resume(NULL);
+
         run_stop_pause_commands();
 
         log_info("in pause resume mode");
         resume = true;
-        simulation_handle_pause_resume(NULL);
 
         // Subtract 1 from the time so this tick gets done again on the next
         // run
         time -= 1;
+
+        simulation_ready_to_read();
         return;
     }
 

--- a/c_common/models/live_packet_gather/src/live_packet_gather.c
+++ b/c_common/models/live_packet_gather/src/live_packet_gather.c
@@ -180,6 +180,8 @@ void timer_callback(uint unused0, uint unused1) {
         // Subtract 1 from the time so this tick gets done again on the next
         // run
         time -= 1;
+
+        simulation_ready_to_read();
     }
 }
 

--- a/c_common/models/reverse_iptag_multicast_source/src/reverse_iptag_multicast_source.c
+++ b/c_common/models/reverse_iptag_multicast_source/src/reverse_iptag_multicast_source.c
@@ -1064,13 +1064,13 @@ void timer_callback(uint unused0, uint unused1) {
 
     if (stopped || ((infinite_run != TRUE) && (time >= simulation_ticks))) {
 
+        // Enter pause and resume state to avoid another tick
+        simulation_handle_pause_resume(resume_callback);
+
         // Wait for recording to finish
         while (recording_in_progress) {
             spin1_wfi();
         }
-
-        // Enter pause and resume state to avoid another tick
-        simulation_handle_pause_resume(resume_callback);
 
         // close recording channels
         if (recording_flags > 0) {
@@ -1084,6 +1084,7 @@ void timer_callback(uint unused0, uint unused1) {
         // run
         time = simulation_ticks - 1;
 
+        simulation_ready_to_read();
         return;
     }
 

--- a/spinn_front_end_common/interface/interface_functions/application_runner.py
+++ b/spinn_front_end_common/interface/interface_functions/application_runner.py
@@ -5,12 +5,9 @@ from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from spinn_front_end_common.utilities.utility_objs import ExecutableType
 
 from spinnman.messages.scp.enums import Signal
-from spinnman.model.enums import CPUState
 from spinn_utilities.log import FormatAdapter
 
 logger = FormatAdapter(logging.getLogger(__name__))
-_GOOD_STATES = frozenset([
-    CPUState.RUNNING, CPUState.PAUSED, CPUState.FINISHED])
 
 
 class _NotificationWrapper(object):
@@ -93,11 +90,7 @@ class ApplicationRunner(object):
             # fire all signals as required
             txrx.send_signal(app_id, sync_signal)
 
-        # verify all cores are in running states
-        txrx.wait_for_cores_to_be_in_state(
-            executable_targets.all_core_subsets, app_id, _GOOD_STATES)
-
-        # Send start notification
+        # Send start notification to external applications
         notifier.send_start_resume_notification()
 
         # Wait for the application to finish

--- a/spinn_front_end_common/interface/provenance/provides_provenance_data_from_machine_impl.py
+++ b/spinn_front_end_common/interface/provenance/provides_provenance_data_from_machine_impl.py
@@ -159,7 +159,7 @@ class ProvidesProvenanceDataFromMachineImpl(
         data_items.append(ProvenanceDataItem(
             self._add_name(names, "Times_the_timer_tic_over_ran"),
             number_of_times_timer_tic_over_ran,
-            report=number_of_times_timer_tic_over_ran > 4,
+            report=number_of_times_timer_tic_over_ran != 0,
             message=(
                 "A Timer tick callback was still executing when the next "
                 "timer tick callback was fired off for {} on {}, {}, {}, {} "

--- a/spinn_front_end_common/utilities/utility_objs/executable_type.py
+++ b/spinn_front_end_common/utilities/utility_objs/executable_type.py
@@ -21,8 +21,8 @@ class ExecutableType(Enum):
         "Calls spin1_start(SYNC_WAIT) and then eventually spin1_exit()")
     USES_SIMULATION_INTERFACE = (
         2,
-        [CPUState.SYNC0, CPUState.SYNC1, CPUState.PAUSED],
-        [CPUState.PAUSED],
+        [CPUState.SYNC0, CPUState.SYNC1, CPUState.PAUSED, CPUState.READY],
+        [CPUState.READY],
         True,
         "Calls simulation_run() and simulation_exit() / "
         "simulation_handle_pause_resume()")


### PR DESCRIPTION
A few changes required to avoid timer tick overloads from being reported when using synapse expander on chip in sPyNNaker (there is no obvious reason why the timer ticks at the end of simulation suddenly go from 4 to 5 with the expander on chip branch, but it does, so this fixes this issue - welcome to the wonderful world of C compilers and their optimisations).

The fix is that at the end of simulation, the user calls simulation_handle_pause_and_resume() or simulation_exit() as before, but this is now done as soon as the simulation is noted to be finished i.e. before data is copied to SDRAM.  Once data has been copied, a second call is made, this time to simulation_ready_to_read().  This must be done even if no data is copied, as it changes the CPU state to WAIT (known as READY in the python code).  The Python code will now wait for this state to indicate the end of simulation.

An additional fix in this branch is to remove the check for running states (see comment at then end of #348), as this can interfere with simulations.