### PR TITLE
Cores can now be in paused or ready state

### DIFF
--- a/spinn_front_end_common/interface/interface_functions/chip_runtime_updater.py
+++ b/spinn_front_end_common/interface/interface_functions/chip_runtime_updater.py
@@ -17,7 +17,7 @@ class ChipRuntimeUpdater(object):
             executable_types[ExecutableType.USES_SIMULATION_INTERFACE]
 
         txrx.wait_for_cores_to_be_in_state(
-            core_subsets, app_id, [CPUState.PAUSED])
+            core_subsets, app_id, [CPUState.PAUSED, CPUState.READY])
 
         infinite_run = 0
         if no_machine_timesteps is None:


### PR DESCRIPTION
Multi-run was broken after recent merges (as first reported in https://github.com/SpiNNakerManchester/sPyNNaker8/issues/165), this is part of the fix.