### PR TITLE
Python3 cares about the difference between string and bytestring

### DIFF
--- a/spinn_front_end_common/utilities/connections/live_event_connection.py
+++ b/spinn_front_end_common/utilities/connections/live_event_connection.py
@@ -261,7 +261,6 @@ class LiveEventConnection(DatabaseConnection):
     def __launch_thread(self, kind, label, callback):
         thread = Thread(
             target=callback, args=(label, self),
-            verbose=True,
             name="{} callback thread for live_event_connection {}:{}".format(
                 kind, self._local_port, self._local_ip_address))
         thread.start()

--- a/spinn_front_end_common/utilities/database/database_connection.py
+++ b/spinn_front_end_common/utilities/database/database_connection.py
@@ -96,7 +96,7 @@ class DatabaseConnection(UDPConnection):
         # Read the read packet confirmation
         logger.info("{}:{} Reading database",
                     self.local_ip_address, self.local_port)
-        database_path = str(data[2:])
+        database_path = data[2:].decode()
 
         # Call the callback
         database_reader = DatabaseReader(database_path)


### PR DESCRIPTION
Fix necessary to make live IO examples work again.

Needs to be merged at same time as https://github.com/SpiNNakerManchester/SpiNNMan/pull/140