### PR TITLE
DB buffered

### DIFF
--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -29,6 +29,7 @@ from .recording_utilities import TRAFFIC_IDENTIFIER, \
     get_last_sequence_number, get_region_pointer
 
 # general imports
+import os
 import threading
 from multiprocessing.pool import ThreadPool
 import logging
@@ -70,6 +71,9 @@ class BufferManager(object):
         # storage area for received data from cores
         "_received_data",
 
+        # File used to hold received data
+        "_received_data_db",
+
         # Lock to avoid multiple messages being processed at the same time
         "_thread_lock_buffer_out",
 
@@ -110,7 +114,8 @@ class BufferManager(object):
     def __init__(self, placements, tags, transceiver, extra_monitor_cores,
                  extra_monitor_cores_to_ethernet_connection_map,
                  extra_monitor_to_chip_mapping, machine, fixed_routes,
-                 uses_advanced_monitors, store_to_file=False):
+                 uses_advanced_monitors, store_to_file=False,
+                 database_file=None):
         """
         :param placements: The placements of the vertices
         :type placements:\
@@ -123,6 +128,8 @@ class BufferManager(object):
         :param store_to_file: True if the data should be temporarily stored\
             in a file instead of in RAM (default uses RAM)
         :type store_to_file: bool
+        :param database_file: The file to use as an SQL database.
+        :type database_file: str
         """
         # pylint: disable=too-many-arguments
         self._placements = placements
@@ -146,7 +153,9 @@ class BufferManager(object):
         self._sent_messages = dict()
 
         # storage area for received data from cores
-        self._received_data = BufferedReceivingData(store_to_file)
+        self._received_data = BufferedReceivingData(
+            store_to_file, database_file)
+        self._received_data_db = database_file
         self._store_to_file = store_to_file
 
         # Lock to avoid multiple messages being processed at the same time
@@ -316,7 +325,13 @@ class BufferManager(object):
             data files
         """
         # reset buffered out
-        self._received_data = BufferedReceivingData(self._store_to_file)
+        if self._received_data is not None:
+            self._received_data.close()
+        if self._received_data_db is not None:
+            # Nuke the DB if it existed; it will be recreated
+            os.remove(self._received_data_db)
+        self._received_data = BufferedReceivingData(
+            self._store_to_file, self._received_data_db)
 
         # rewind buffered in
         for vertex in self._sender_vertices:

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffered_receiving_data.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffered_receiving_data.py
@@ -1,6 +1,12 @@
 from collections import defaultdict
-from spinn_storage_handlers \
-    import BufferedBytearrayDataStorage, BufferedTempfileDataStorage
+import os
+import sqlite3
+from spinn_storage_handlers import (
+    BufferedBytearrayDataStorage, BufferedTempfileDataStorage)
+from spinn_storage_handlers.abstract_classes import AbstractBufferedDataStorage
+from spinn_utilities.overrides import overrides
+
+DDL_FILE = os.path.join(os.path.dirname(__file__), "db.sql")
 
 
 class BufferedReceivingData(object):
@@ -13,8 +19,11 @@ class BufferedReceivingData(object):
     """
 
     __slots__ = [
-        # the data to store
+        # the data to store, unless a DB is used
         "_data",
+
+        # the database holding the data to store, if used
+        "_db",
 
         # dict of booleans indicating if a region on a core has been flushed
         "_is_flushed",
@@ -35,15 +44,18 @@ class BufferedReceivingData(object):
         "_end_buffering_state"
     ]
 
-    def __init__(self, store_to_file=False):
+    def __init__(self, store_to_file=False, database_file=None):
         """
         :param store_to_file: A boolean to identify if the data will be stored\
             in memory using a byte array or in a temporary file on the disk
         :type store_to_file: bool
         """
-
         self._data = None
-        if store_to_file:
+        self._db = None
+        if database_file is not None:
+            self._db = sqlite3.connect(database_file)
+            self.__init_db()
+        elif store_to_file:
             self._data = defaultdict(BufferedTempfileDataStorage)
         else:
             self._data = defaultdict(BufferedBytearrayDataStorage)
@@ -53,6 +65,49 @@ class BufferedReceivingData(object):
         self._last_packet_sent = defaultdict(lambda: None)
         self._end_buffering_sequence_no = dict()
         self._end_buffering_state = dict()
+
+    def __init_db(self):
+        """ Set up the database if required. """
+        self._db.row_factory = sqlite3.Row
+        with open(DDL_FILE) as f:
+            sql = f.read()
+        self._db.executescript(sql)
+
+    def __append_contents(self, cursor, x, y, p, region, contents):
+        cursor.execute(
+            "INSERT INTO storage(x, y, processor, region, content) "
+            + "VALUES(?, ?, ?, ?, ?) "
+            + "ON CONFLICT(x, y, processor, region) DO "
+            + "UPDATE SET content = storage.content || excluded.content",
+            (x, y, p, region, contents))
+
+    def __hacky_append(self, cursor, x, y, p, region, contents):
+        """ Used to do an UPSERT when the version of SQLite used by Python\
+            doesn't support the correct syntax for it (because it is older\
+            than 3.24).
+        """
+        cursor.execute(
+            "INSERT OR IGNORE INTO storage(x, y, processor, region, content) "
+            + "VALUES(?, ?, ?, ?, ?)",
+            (x, y, p, region, b""))
+        cursor.execute(
+            "UPDATE storage SET content = content || ? "
+            + "WHERE x = ? AND y = ? AND processor = ? AND region = ?",
+            (contents, x, y, p, region))
+
+    def _read_contents(self, cursor, x, y, p, region):
+        for row in cursor.execute(
+                "SELECT contents FROM storage "
+                + "WHERE x = ? AND y = ? AND processor = ? AND region = ?",
+                (x, y, p, region)):
+            return row["contents"]
+        return b""
+
+    def __delete_contents(self, cursor, x, y, p, region):
+        cursor.execute(
+            "DELETE FROM storage WHERE " +
+            "x = ? AND y = ? AND processor = ? AND region = ?",
+            (x, y, p, region))
 
     def store_data_in_region_buffer(self, x, y, p, region, data):
         """ Store some information in the correspondent buffer class for a\
@@ -70,7 +125,15 @@ class BufferedReceivingData(object):
         :type data: bytearray
         """
         # pylint: disable=too-many-arguments
-        self._data[x, y, p, region].write(data)
+        if self._db is not None:
+            try:
+                with self._db.cursor() as c, self._db:
+                    self.__append_contents(c, x, y, p, region, data)
+            except sqlite3.Error:
+                with self._db.cursor() as c, self._db:
+                    self.__hacky_append(c, x, y, p, region, data)
+        else:
+            self._data[x, y, p, region].write(data)
 
     def is_data_from_region_flushed(self, x, y, p, region):
         """ Check if the data region has been flushed
@@ -215,7 +278,11 @@ class BufferedReceivingData(object):
         missing = None
         if (x, y, p, region) not in self._end_buffering_state:
             missing = (x, y, p, region)
-        data = self._data[x, y, p, region].read_all()
+        if self._db is not None:
+            with self._db.cursor() as c, self._db:
+                data = self._read_contents(c, x, y, p, region)
+        else:
+            data = self._data[x, y, p, region].read_all()
         return data, missing
 
     def get_region_data_pointer(self, x, y, p, region):
@@ -239,7 +306,10 @@ class BufferedReceivingData(object):
             missing = True
         else:
             missing = self._end_buffering_state[x, y, p, region].missing_info
-        data_pointer = self._data[x, y, p, region]
+        if self._db is not None:
+            data_pointer = DBWrapper(self, x, y, p, region)
+        else:
+            data_pointer = self._data[x, y, p, region]
         return data_pointer, missing
 
     def store_end_buffering_state(self, x, y, p, region, state):
@@ -345,5 +415,69 @@ class BufferedReceivingData(object):
         :rtype: None
         """
         del self._end_buffering_state[x, y, p, region_id]
-        del self._data[x, y, p, region_id]
+        if self._db is not None:
+            with self._db.cursor() as c, self._db:
+                self.__delete_contents(c, x, y, p, region_id)
+        else:
+            del self._data[x, y, p, region_id]
         del self._is_flushed[x, y, p, region_id]
+
+
+class DBWrapper(AbstractBufferedDataStorage):
+    def __init__(self, brd, x, y, p, region):
+        self.__brd = brd
+        self.__x = x
+        self.__y = y
+        self.__p = p
+        self.__r = region
+
+    @overrides(AbstractBufferedDataStorage.write)
+    def write(self, data):
+        # TODO implement this? Not actually used...
+        pass
+
+    @overrides(AbstractBufferedDataStorage.read)
+    def read(self, data_size):
+        # TODO implement this? Not actually used...
+        pass
+
+    @overrides(AbstractBufferedDataStorage.readinto)
+    def readinto(self, data):
+        # TODO implement this? Not actually used...
+        pass
+
+    @overrides(AbstractBufferedDataStorage.read_all)
+    def read_all(self):
+        with self.__brd._db.cursor() as c, self.__brd._db:
+            return self.__brd._read_contents(
+                c, self.__x, self.__y, self.__p, self.__region)
+
+    @overrides(AbstractBufferedDataStorage.seek_read)
+    def seek_read(self, offset, whence=os.SEEK_SET):
+        # TODO implement this? Not actually used...
+        pass
+
+    @overrides(AbstractBufferedDataStorage.seek_write)
+    def seek_write(self, offset, whence=os.SEEK_SET):
+        # TODO implement this? Not actually used...
+        pass
+
+    @overrides(AbstractBufferedDataStorage.tell_read)
+    def tell_read(self):
+        # TODO implement this? Not actually used...
+        pass
+
+    @overrides(AbstractBufferedDataStorage.tell_write)
+    def tell_write(self):
+        # TODO implement this? Not actually used...
+        pass
+
+    @overrides(AbstractBufferedDataStorage.eof)
+    def eof(self):
+        # TODO implement this? Not actually used...
+        pass
+
+    @overrides(AbstractBufferedDataStorage.close)
+    def close(self):
+        # TODO implement this? Not actually used...
+        pass

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffered_receiving_data.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffered_receiving_data.py
@@ -66,6 +66,14 @@ class BufferedReceivingData(object):
         self._end_buffering_sequence_no = dict()
         self._end_buffering_state = dict()
 
+    def __del__(self):
+        self.close()
+
+    def close(self):
+        if self._db is not None:
+            self._db.close()
+            self._db = None
+
     def __init_db(self):
         """ Set up the database if required. """
         self._db.row_factory = sqlite3.Row

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/db.sql
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/db.sql
@@ -1,0 +1,11 @@
+-- A table mapping unique names to blobs of data. It's trivial!
+CREATE TABLE IF NOT EXISTS storage(
+	storage_id INTEGER PRIMARY KEY AUTOINCREMENT,
+	x INTEGER NOT NULL,
+	y INTEGER NOT NULL,
+	processor INTEGER NOT NULL,
+	region INTEGER NOT NULL,
+	content BLOB);
+-- Every processor's regions have a unique ID
+CREATE UNIQUE INDEX IF NOT EXISTS sanity ON storage(
+	x ASC, y ASC, processor ASC, region ASC);

--- a/unittests/interface/buffer_management/test_buffered_receiver_with_db.py
+++ b/unittests/interface/buffer_management/test_buffered_receiver_with_db.py
@@ -1,0 +1,36 @@
+import unittest
+import tempfile
+import os
+import shutil
+from spinn_front_end_common.interface.buffer_management.storage_objects \
+    import BufferedReceivingData
+
+
+class TestBufferedReceivingDataWithDB(unittest.TestCase):
+
+    def test_use_database(self):
+        d = tempfile.mkdtemp()
+        f = os.path.join(d, "test.db")
+        try:
+            self.assertFalse(os.path.isfile(f), "no existing DB at first")
+
+            brd = BufferedReceivingData(False, f)
+
+            self.assertTrue(os.path.isfile(f), "DB now exists")
+
+            brd.store_data_in_region_buffer(0, 0, 0, 0, b"abc")
+            brd.flushing_data_from_region(0, 0, 0, 0, b"def")
+            brd.store_end_buffering_state(0, 0, 0, 0, "LOLWUT")
+            data, missing = brd.get_region_data(0, 0, 0, 0)
+
+            self.assertIsNone(missing, "data shouldn't be 'missing'")
+            self.assertEqual(data, b"abcdef")
+
+            brd.clear(0, 0, 0, 0)
+            data, missing = brd.get_region_data(0, 0, 0, 0)
+
+            self.assertIsNotNone(missing, "data should be 'missing'")
+            self.assertEqual(data, b"")
+            self.assertTrue(os.path.isfile(f), "DB still exists")
+        finally:
+            shutil.rmtree(d, True)


### PR DESCRIPTION
This adds in support for a database for storing temporary data inside the buffer manager. The data is in the exact same format that the Java code handles.

This is messy because Python's not necessarily built with a new enough SQLite to understand an UPSERT clause.