### PR TITLE
Allow FEC_DEBUG to be set by higher-level makefile

### DIFF
--- a/c_common/front_end_common_lib/local.mk
+++ b/c_common/front_end_common_lib/local.mk
@@ -63,7 +63,9 @@ endef
 
 # Add the default libraries and options
 LIBRARIES += -lspinn_frontend_common -lspinn_common -lm
-FEC_DEBUG := PRODUCTION_CODE
+ifndef FEC_DEBUG
+	FEC_DEBUG := PRODUCTION_CODE
+endif
 PROFILER := PROFILER_DISABLED
 
 # Set up the default C Flags


### PR DESCRIPTION
Do we want to do this, and allow users to have possibly different debug levels for different libraries?  Or do we want to set it up so that if they specify it at this level, then it builds FEC etc. at the same level?