### PR TITLE
Allow applications to specify use of PROFILER from their own Makefile

### DIFF
--- a/c_common/front_end_common_lib/local.mk
+++ b/c_common/front_end_common_lib/local.mk
@@ -66,7 +66,9 @@ LIBRARIES += -lspinn_frontend_common -lspinn_common -lm
 ifndef FEC_DEBUG
 	FEC_DEBUG := PRODUCTION_CODE
 endif
-PROFILER := PROFILER_DISABLED
+ifndef PROFILER
+	PROFILER := PROFILER_DISABLED
+endif
 
 # Set up the default C Flags
 FEC_OPT = $(OTIME)


### PR DESCRIPTION
Similarly to the debug option added earlier, we should probably allow users to set this tag from their own makefiles rather than having to go in here and do it.