### PR TITLE
Buffer cleanup

### DIFF
--- a/fec_integration_tests/test_buffer_manager_listener_creation.py
+++ b/fec_integration_tests/test_buffer_manager_listener_creation.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 import unittest
 from spinn_utilities.overrides import overrides
 from spinn_front_end_common.interface.buffer_management import BufferManager
@@ -52,8 +54,14 @@ class TestBufferManagerListenerCreation(unittest.TestCase):
         # trnx.register_udp_listener(callback=None,
         #        connection_class=EIEIOConnection)
 
+        dbfile = os.path.join(tempfile.mkdtemp(), "db.sqlite")
         # Create buffer manager
-        bm = BufferManager(pl, t, trnx, None, None, None, None, None)
+        bm = BufferManager(
+            placements=pl, tags=t, transceiver=trnx, extra_monitor_cores=None,
+            extra_monitor_cores_to_ethernet_connection_map=None,
+            extra_monitor_to_chip_mapping=None, machine=None,
+            fixed_routes=None, uses_advanced_monitors=True,
+            database_file=dbfile)
 
         # Register two listeners, and check the second listener uses the
         # first rather than creating a new one

--- a/fec_integration_tests/test_buffer_manager_listener_creation.py
+++ b/fec_integration_tests/test_buffer_manager_listener_creation.py
@@ -53,7 +53,7 @@ class TestBufferManagerListenerCreation(unittest.TestCase):
         #        connection_class=EIEIOConnection)
 
         # Create buffer manager
-        bm = BufferManager(pl, t, trnx, None, None, None, None, None, False)
+        bm = BufferManager(pl, t, trnx, None, None, None, None, None)
 
         # Register two listeners, and check the second listener uses the
         # first rather than creating a new one

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1714,6 +1714,10 @@ class AbstractSpinnakerBase(SimulatorInterface):
             if self._buffer_manager is None:
                 inputs["StoreBufferDataInFile"] = self._config.getboolean(
                     "Buffers", "store_buffer_data_in_file")
+                if self._config.getboolean(
+                        "Buffers", "store_buffer_data_in_database"):
+                    inputs["BufferDatabaseFile"] = os.path.join(
+                            self._report_default_directory, "buffer.sqlite3")
                 algorithms.append("BufferManagerCreator")
                 outputs.append("BufferManager")
             else:

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1712,12 +1712,8 @@ class AbstractSpinnakerBase(SimulatorInterface):
         # Create a buffer manager if there isn't one already
         if not self._use_virtual_board:
             if self._buffer_manager is None:
-                inputs["StoreBufferDataInFile"] = self._config.getboolean(
-                    "Buffers", "store_buffer_data_in_file")
-                if self._config.getboolean(
-                        "Buffers", "store_buffer_data_in_database"):
-                    inputs["BufferDatabaseFile"] = os.path.join(
-                            self._report_default_directory, "buffer.sqlite3")
+                inputs["BufferDatabaseFile"] = os.path.join(
+                    self._report_default_directory, "buffer.sqlite3")
                 algorithms.append("BufferManagerCreator")
                 outputs.append("BufferManager")
             else:

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -86,9 +86,6 @@ class BufferManager(object):
         # listener port
         "_listener_port",
 
-        # Store to file flag
-        "_store_to_file",
-
         # Buffering out thread pool
         "_buffering_out_thread_pool",
 
@@ -114,8 +111,7 @@ class BufferManager(object):
     def __init__(self, placements, tags, transceiver, extra_monitor_cores,
                  extra_monitor_cores_to_ethernet_connection_map,
                  extra_monitor_to_chip_mapping, machine, fixed_routes,
-                 uses_advanced_monitors, store_to_file=False,
-                 database_file=None):
+                 uses_advanced_monitors, database_file):
         """
         :param placements: The placements of the vertices
         :type placements:\
@@ -125,10 +121,6 @@ class BufferManager(object):
         :param transceiver: \
             The transceiver to use for sending and receiving information
         :type transceiver: :py:class:`spinnman.transceiver.Transceiver`
-        :param store_to_file: True if the data should be temporarily stored\
-            in a file instead of in RAM (default uses RAM).
-            Ignored if database_file is not None.
-        :type store_to_file: bool
         :param database_file: The file to use as an SQL database.
         :type database_file: str
         """
@@ -154,10 +146,8 @@ class BufferManager(object):
         self._sent_messages = dict()
 
         # storage area for received data from cores
-        self._received_data = BufferedReceivingData(
-            store_to_file, database_file)
+        self._received_data = BufferedReceivingData(database_file)
         self._received_data_db = database_file
-        self._store_to_file = store_to_file
 
         # Lock to avoid multiple messages being processed at the same time
         self._thread_lock_buffer_out = threading.RLock()
@@ -331,8 +321,7 @@ class BufferManager(object):
         if self._received_data_db is not None:
             # Nuke the DB if it existed; it will be recreated
             os.remove(self._received_data_db)
-        self._received_data = BufferedReceivingData(
-            self._store_to_file, self._received_data_db)
+        self._received_data = BufferedReceivingData(self._received_data_db)
 
         # rewind buffered in
         for vertex in self._sender_vertices:

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -570,17 +570,16 @@ class BufferManager(object):
             with self._thread_lock_buffer_out:
                 self._finished = True
 
-    def get_data_for_vertices(self, vertices, progress=None):
+    def get_data_for_placements(self, placements, progress=None):
         with self._thread_lock_buffer_out:
-            self._get_data_for_vertices_locked(vertices, progress)
+            self._get_data_for_placements_locked(placements, progress)
 
-    def _get_data_for_vertices_locked(self, vertices, progress=None):
+    def _get_data_for_placements_locked(self, placements, progress=None):
         receivers = OrderedSet()
         if self._uses_advanced_monitors:
 
             # locate receivers
-            for vertex in vertices:
-                placement = self._placements.get_placement_of_vertex(vertex)
+            for placement in placements:
                 receivers.add(funs.locate_extra_monitor_mc_receiver(
                     self._machine, placement.x, placement.y,
                     self._extra_monitor_cores_to_ethernet_connection_map))
@@ -593,10 +592,9 @@ class BufferManager(object):
                         self._extra_monitor_cores))
 
         # get data
-        for vertex in vertices:
-            placement = self._placements.get_placement_of_vertex(vertex)
-            for recording_region_id in vertex.get_recorded_region_ids():
-                self.get_data_by_vertex(placement, recording_region_id)
+        for placement in placements:
+            for recording_region_id in placement.vertex.get_recorded_region_ids():
+                self.get_data_by_placement(placement, recording_region_id)
                 if progress is not None:
                     progress.update()
 
@@ -617,9 +615,9 @@ class BufferManager(object):
             the missing flag as before
 
         """
-        raise NotImplementedError("Use get_data_by_vertex instead!.")
+        raise NotImplementedError("Use get_data_by_placement instead!.")
 
-    def get_data_by_vertex(self, placement, recording_region_id):
+    def get_data_by_placement(self, placement, recording_region_id):
 
         """ Get a handle to the data container for all the data retrieved\
             during the simulation from a specific region area of a core
@@ -636,10 +634,10 @@ class BufferManager(object):
 
         # Ensure that any transfers in progress are complete first
         with self._thread_lock_buffer_out:
-            return self._get_data_by_vertex_locked(
+            return self._get_data_by_placement_locked(
                 placement, recording_region_id)
 
-    def _get_data_by_vertex_locked(self, placement, recording_region_id):
+    def _get_data_by_placement_locked(self, placement, recording_region_id):
         """ Get the data for a vertex; must be locked first
 
         :param placement: the placement to get the data from

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -593,7 +593,8 @@ class BufferManager(object):
 
         # get data
         for placement in placements:
-            for recording_region_id in placement.vertex.get_recorded_region_ids():
+            vertex = placement.vertex
+            for recording_region_id in vertex.get_recorded_region_ids():
                 self.get_data_by_placement(placement, recording_region_id)
                 if progress is not None:
                     progress.update()

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -126,7 +126,8 @@ class BufferManager(object):
             The transceiver to use for sending and receiving information
         :type transceiver: :py:class:`spinnman.transceiver.Transceiver`
         :param store_to_file: True if the data should be temporarily stored\
-            in a file instead of in RAM (default uses RAM)
+            in a file instead of in RAM (default uses RAM).
+            Ignored if database_file is not None.
         :type store_to_file: bool
         :param database_file: The file to use as an SQL database.
         :type database_file: str

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -787,7 +787,7 @@ class BufferManager(object):
                     data)
 
         # data flush has been completed - return appropriate data
-        (byte_array, missing) = self._received_data.get_region_data_pointer(
+        (byte_array, missing) = self._received_data.get_region_data(
             placement.x, placement.y, placement.p, recording_region_id)
         return byte_array, missing
 

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -563,7 +563,7 @@ class BufferManager(object):
 
             # locate receivers
             for placement in placements:
-                receivers.add(funs.locate_extra_monitor_mc_receiver(
+                receivers.add(locate_extra_monitor_mc_receiver(
                     self._machine, placement.x, placement.y,
                     self._extra_monitor_cores_to_ethernet_connection_map))
 

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffered_receiving_data.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffered_receiving_data.py
@@ -3,8 +3,6 @@ import os
 import sqlite3
 from spinn_storage_handlers import (
     BufferedBytearrayDataStorage, BufferedTempfileDataStorage)
-from spinn_storage_handlers.abstract_classes import AbstractBufferedDataStorage
-from spinn_utilities.overrides import overrides
 
 DDL_FILE = os.path.join(os.path.dirname(__file__), "db.sql")
 

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffered_receiving_data.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffered_receiving_data.py
@@ -48,6 +48,7 @@ class BufferedReceivingData(object):
         """
         :param store_to_file: A boolean to identify if the data will be stored\
             in memory using a byte array or in a temporary file on the disk
+            Ignored if database_file is not null.
         :type store_to_file: bool
         :param database_file: The name of a file that contains (or will\
             contain) an SQLite database holding the data.
@@ -445,7 +446,7 @@ class DBWrapper(AbstractBufferedDataStorage):
         self.__x = x
         self.__y = y
         self.__p = p
-        self.__r = region
+        self.__region = region
 
     @overrides(AbstractBufferedDataStorage.write)
     def write(self, data):
@@ -461,8 +462,8 @@ class DBWrapper(AbstractBufferedDataStorage):
 
     @overrides(AbstractBufferedDataStorage.read_all)
     def read_all(self):
-        with self.__brd._db.cursor() as c, self.__brd._db:
-            return self.__brd._read_contents(
+        c = self.__brd._db.cursor()
+        return self.__brd._read_contents(
                 c, self.__x, self.__y, self.__p, self.__region)
 
     @overrides(AbstractBufferedDataStorage.seek_read)

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffered_receiving_data.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffered_receiving_data.py
@@ -302,31 +302,12 @@ class BufferedReceivingData(object):
         return data, missing
 
     def get_region_data_pointer(self, x, y, p, region):
-        """ Get the data received during the simulation for a region of a core
-
-        :param x: x coordinate of the chip
-        :type x: int
-        :param y: y coordinate of the chip
-        :type y: int
-        :param p: Core within the specified chip
-        :type p: int
-        :param region: Region containing the data
-        :type region: int
-        :return: all the data received during the simulation, and a flag\
-            indicating if any data was lost
-        :rtype: \
-            tuple(:py:class:`spinn_storage_handlers.abstract_classes.AbstractBufferedDataStorage`,\
-            bool)
         """
-        if (x, y, p, region) not in self._end_buffering_state:
-            missing = True
-        else:
-            missing = self._end_buffering_state[x, y, p, region].missing_info
-        if self._db is not None:
-            data_pointer = DBWrapper(self, x, y, p, region)
-        else:
-            data_pointer = self._data[x, y, p, region]
-        return data_pointer, missing
+        It is no longer possible to get access to the data pointer.
+
+        Use get_region_data to get the data and missing flag directly.
+        """
+        raise NotImplementedError("Use get_region_data instead!.")
 
     def store_end_buffering_state(self, x, y, p, region, state):
         """ Store the end state of buffering
@@ -438,54 +419,3 @@ class BufferedReceivingData(object):
         else:
             del self._data[x, y, p, region_id]
         del self._is_flushed[x, y, p, region_id]
-
-
-class DBWrapper(AbstractBufferedDataStorage):
-    def __init__(self, brd, x, y, p, region):
-        self.__brd = brd
-        self.__x = x
-        self.__y = y
-        self.__p = p
-        self.__region = region
-
-    @overrides(AbstractBufferedDataStorage.write)
-    def write(self, data):
-        raise NotImplementedError()
-
-    @overrides(AbstractBufferedDataStorage.read)
-    def read(self, data_size):
-        raise NotImplementedError()
-
-    @overrides(AbstractBufferedDataStorage.readinto)
-    def readinto(self, data):
-        raise NotImplementedError()
-
-    @overrides(AbstractBufferedDataStorage.read_all)
-    def read_all(self):
-        c = self.__brd._db.cursor()
-        return self.__brd._read_contents(
-                c, self.__x, self.__y, self.__p, self.__region)
-
-    @overrides(AbstractBufferedDataStorage.seek_read)
-    def seek_read(self, offset, whence=os.SEEK_SET):
-        raise NotImplementedError()
-
-    @overrides(AbstractBufferedDataStorage.seek_write)
-    def seek_write(self, offset, whence=os.SEEK_SET):
-        raise NotImplementedError()
-
-    @overrides(AbstractBufferedDataStorage.tell_read)
-    def tell_read(self):
-        raise NotImplementedError()
-
-    @overrides(AbstractBufferedDataStorage.tell_write)
-    def tell_write(self):
-        raise NotImplementedError()
-
-    @overrides(AbstractBufferedDataStorage.eof)
-    def eof(self):
-        raise NotImplementedError()
-
-    @overrides(AbstractBufferedDataStorage.close)
-    def close(self):
-        raise NotImplementedError()

--- a/spinn_front_end_common/interface/interface_functions/buffer_extractor.py
+++ b/spinn_front_end_common/interface/interface_functions/buffer_extractor.py
@@ -12,23 +12,26 @@ class BufferExtractor(object):
     def __call__(self, machine_graph, placements, buffer_manager):
 
         # Count the regions to be read
-        n_regions_to_read, vertices = self._count_regions(machine_graph)
+        n_regions_to_read, recording_placements = self._count_regions(
+            machine_graph, placements)
 
         # Read back the regions
         progress = ProgressBar(
             n_regions_to_read, "Extracting buffers from the last run")
         try:
-            buffer_manager.get_data_for_vertices(vertices, progress)
+            buffer_manager.get_data_for_placements(
+                recording_placements, progress)
         finally:
             progress.end()
 
     @staticmethod
-    def _count_regions(machine_graph):
+    def _count_regions(machine_graph, placements):
         # Count the regions to be read
         n_regions_to_read = 0
-        vertices = list()
+        recording_placements = list()
         for vertex in machine_graph.vertices:
             if isinstance(vertex, AbstractReceiveBuffersToHost):
                 n_regions_to_read += len(vertex.get_recorded_region_ids())
-                vertices.append(vertex)
-        return n_regions_to_read, vertices
+                placement = placements.get_placement_of_vertex(vertex)
+                recording_placements.append(placement)
+        return n_regions_to_read, recording_placements

--- a/spinn_front_end_common/interface/interface_functions/buffer_manager_creator.py
+++ b/spinn_front_end_common/interface/interface_functions/buffer_manager_creator.py
@@ -13,7 +13,27 @@ class BufferManagerCreator(object):
             uses_advanced_monitors, extra_monitor_cores=None,
             extra_monitor_to_chip_mapping=None,
             extra_monitor_cores_to_ethernet_connection_map=None, machine=None,
-            fixed_routes=None):
+            fixed_routes=None, database_file=None):
+        """
+
+        :param placements:
+        :param tags:
+        :param txrx:
+        :param store_to_file: A boolean to identify if the data will be stored\
+            in memory using a byte array or in a temporary file on the disk
+            Ignored if database_file is not null.
+        :type store_to_file: bool
+        :param uses_advanced_monitors:
+        :param extra_monitor_cores:
+        :param extra_monitor_to_chip_mapping:
+        :param extra_monitor_cores_to_ethernet_connection_map:
+        :param machine:
+        :param fixed_routes:
+        :param database_file: The name of a file that contains (or will\
+            contain) an SQLite database holding the data.
+        :type database_file: str
+        :return:
+        """
         # pylint: disable=too-many-arguments
         progress = ProgressBar(placements.placements, "Initialising buffers")
 
@@ -26,7 +46,7 @@ class BufferManagerCreator(object):
                 extra_monitor_cores_to_ethernet_connection_map),
             extra_monitor_to_chip_mapping=extra_monitor_to_chip_mapping,
             machine=machine, uses_advanced_monitors=uses_advanced_monitors,
-            fixed_routes=fixed_routes)
+            fixed_routes=fixed_routes, database_file=database_file)
 
         for placement in progress.over(placements.placements):
             if isinstance(placement.vertex, AbstractSendsBuffersFromHost):

--- a/spinn_front_end_common/interface/interface_functions/buffer_manager_creator.py
+++ b/spinn_front_end_common/interface/interface_functions/buffer_manager_creator.py
@@ -9,7 +9,7 @@ class BufferManagerCreator(object):
     __slots__ = []
 
     def __call__(
-            self, placements, tags, txrx, store_data_in_file,
+            self, placements, tags, txrx,
             uses_advanced_monitors, extra_monitor_cores=None,
             extra_monitor_to_chip_mapping=None,
             extra_monitor_cores_to_ethernet_connection_map=None, machine=None,
@@ -19,10 +19,6 @@ class BufferManagerCreator(object):
         :param placements:
         :param tags:
         :param txrx:
-        :param store_to_file: A boolean to identify if the data will be stored\
-            in memory using a byte array or in a temporary file on the disk
-            Ignored if database_file is not null.
-        :type store_to_file: bool
         :param uses_advanced_monitors:
         :param extra_monitor_cores:
         :param extra_monitor_to_chip_mapping:
@@ -40,7 +36,6 @@ class BufferManagerCreator(object):
         # Create the buffer manager
         buffer_manager = BufferManager(
             placements=placements, tags=tags, transceiver=txrx,
-            store_to_file=store_data_in_file,
             extra_monitor_cores=extra_monitor_cores,
             extra_monitor_cores_to_ethernet_connection_map=(
                 extra_monitor_cores_to_ethernet_connection_map),

--- a/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
@@ -963,10 +963,6 @@
                 <param_type>MemoryTransceiver</param_type>
             </parameter>
             <parameter>
-                <param_name>store_data_in_file</param_name>
-                <param_type>StoreBufferDataInFile</param_type>
-            </parameter>
-            <parameter>
                 <param_name>extra_monitor_cores</param_name>
                 <param_type>MemoryExtraMonitorVertices</param_type>
             </parameter>
@@ -992,10 +988,10 @@
             </parameter>
        </input_definitions>
         <required_inputs>
+            <param_name>database_file</param_name>
             <param_name>placements</param_name>
             <param_name>tags</param_name>
             <param_name>txrx</param_name>
-            <param_name>store_data_in_file</param_name>
             <param_name>uses_advanced_monitors</param_name>
         </required_inputs>
         <optional_inputs>
@@ -1004,7 +1000,6 @@
             <param_name>extra_monitor_to_chip_mapping</param_name>
             <param_name>fixed_routes</param_name>
             <param_name>machine</param_name>
-            <param_name>database_file</param_name>
         </optional_inputs>
         <outputs>
             <param_type>BufferManager</param_type>

--- a/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
@@ -986,7 +986,11 @@
                 <param_name>fixed_routes</param_name>
                 <param_type>MemoryFixedRoutes</param_type>
             </parameter>
-        </input_definitions>
+             <parameter>
+                <param_name>database_file</param_name>
+                <param_type>BufferDatabaseFile</param_type>
+            </parameter>
+       </input_definitions>
         <required_inputs>
             <param_name>placements</param_name>
             <param_name>tags</param_name>
@@ -1000,6 +1004,7 @@
             <param_name>extra_monitor_to_chip_mapping</param_name>
             <param_name>fixed_routes</param_name>
             <param_name>machine</param_name>
+            <param_name>database_file</param_name>
         </optional_inputs>
         <outputs>
             <param_type>BufferManager</param_type>

--- a/spinn_front_end_common/interface/spinnaker.cfg
+++ b/spinn_front_end_common/interface/spinnaker.cfg
@@ -186,9 +186,6 @@ spec_exec_on_host = True
 [Buffers]
 use_auto_pause_and_resume = True
 chip_power_monitor_buffer = 1048576
-# in database has priority over in file if both are True
-store_buffer_data_in_database = False
-store_buffer_data_in_file = True
 
 [Mode]
 # mode = Production or Debug

--- a/spinn_front_end_common/interface/spinnaker.cfg
+++ b/spinn_front_end_common/interface/spinnaker.cfg
@@ -186,6 +186,8 @@ spec_exec_on_host = True
 [Buffers]
 use_auto_pause_and_resume = True
 chip_power_monitor_buffer = 1048576
+# in database has priority over in file if both are True
+store_buffer_data_in_database = False
 store_buffer_data_in_file = True
 
 [Mode]

--- a/spinn_front_end_common/utility_models/chip_power_monitor_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/chip_power_monitor_machine_vertex.py
@@ -347,15 +347,13 @@ class ChipPowerMonitorMachineVertex(
         :rtype: numpy array with 1 dimension
         """
         # for buffering output info is taken form the buffer manager
-        samples, data_missing = buffer_manager.get_data_for_vertex(
+        # get raw data as a byte array
+        record_raw, data_missing = buffer_manager.get_data_by_vertex(
             placement, self.SAMPLE_RECORDING_REGION)
         if data_missing:
             logger.warning(
                 "Chip Power monitor has lost data on chip({}, {})",
                 placement.x, placement.y)
-
-        # get raw data as a byte array
-        record_raw = samples.read_all()
 
         results = (
             numpy.frombuffer(record_raw, dtype="uint32").reshape(-1, 18) /

--- a/spinn_front_end_common/utility_models/chip_power_monitor_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/chip_power_monitor_machine_vertex.py
@@ -348,7 +348,7 @@ class ChipPowerMonitorMachineVertex(
         """
         # for buffering output info is taken form the buffer manager
         # get raw data as a byte array
-        record_raw, data_missing = buffer_manager.get_data_by_vertex(
+        record_raw, data_missing = buffer_manager.get_data_by_placement(
             placement, self.SAMPLE_RECORDING_REGION)
         if data_missing:
             logger.warning(

--- a/unittests/interface/buffer_management/test_buffered_receiver_with_db.py
+++ b/unittests/interface/buffer_management/test_buffered_receiver_with_db.py
@@ -14,7 +14,7 @@ class TestBufferedReceivingDataWithDB(unittest.TestCase):
         try:
             self.assertFalse(os.path.isfile(f), "no existing DB at first")
 
-            brd = BufferedReceivingData(False, f)
+            brd = BufferedReceivingData(f)
 
             self.assertTrue(os.path.isfile(f), "DB now exists")
 


### PR DESCRIPTION
OK to merge.

- Includes but overwrites much of https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/361 (allow user to use sql Lite) so closed that one

- get data is now by placement (which has a vertex) rather than by vertex where the placement must then be found.

- get data directly from BufferedReceivingData rather than getting a pointer and then getting the data.
(avoids the need for a database pointer Object)

Must be done at the same time as: https://github.com/SpiNNakerManchester/SpiNNakerGraphFrontEnd/pull/95 and https://github.com/SpiNNakerManchester/sPyNNaker/pull/565
....