### PR TITLE
Fix iobuf extraction

### DIFF
--- a/spinn_front_end_common/interface/interface_functions/chip_iobuf_extractor.py
+++ b/spinn_front_end_common/interface/interface_functions/chip_iobuf_extractor.py
@@ -88,7 +88,6 @@ class ChipIOBufExtractor(object):
     def _run_for_core_subsets(
             self, core_subsets, binary, transceiver, provenance_file_path,
             error_entries, warn_entries):
-
         replacer = Replacer(binary)
 
         # extract iobuf
@@ -106,26 +105,21 @@ class ChipIOBufExtractor(object):
             if os.path.exists(file_name):
                 mode = "a"
 
-            # write iobuf to file.
+            # write iobuf to file and call out errors and warnings.
             with open(file_name, mode) as f:
                 for line in iobuf.iobuf.split("\n"):
-                    f.write(replacer.replace(line))
+                    replaced = replacer.replace(line)
+                    f.write(replaced)
                     f.write("\n")
-            self._check_iobuf_for_error(iobuf, error_entries, warn_entries)
-
-    def _check_iobuf_for_error(self, iobuf, error_entries, warn_entries):
-        lines = iobuf.iobuf.split("\n")
-        for line in lines:
-            line = line.encode('ascii', 'ignore')
-            self._add_value_if_match(
-                ERROR_ENTRY, line, error_entries, iobuf.x, iobuf.y, iobuf.p)
-            self._add_value_if_match(
-                WARNING_ENTRY, line, warn_entries, iobuf.x, iobuf.y, iobuf.p)
+                    self._add_value_if_match(
+                        ERROR_ENTRY, replaced, error_entries, iobuf)
+                    self._add_value_if_match(
+                        WARNING_ENTRY, replaced, warn_entries, iobuf)
 
     @staticmethod
-    def _add_value_if_match(regex, line, entries, x, y, p):
-        # pylint: disable=too-many-arguments
-        match = regex.match(line.decode('ascii'))
+    def _add_value_if_match(regex, line, entries, place):
+        match = regex.match(line)
         if match:
             entries.append("{}, {}, {}: {} ({})".format(
-                x, y, p, match.group(ENTRY_TEXT), match.group(ENTRY_FILE)))
+                place.x, place.y, place.p, match.group(ENTRY_TEXT),
+                match.group(ENTRY_FILE)))


### PR DESCRIPTION
We were failing to add errors and warnings to the lists accumulating them (though they were being written to files correctly). The problem was that the detection of errors and warnings was being applied to the *unexpanded* iobuf contents, despite the strings being looked for only ever matching if they were the *expanded* contents.

Oops!