### PR TITLE
Don't expect commands to be sent if you've paused the simulation...

### DIFF
--- a/c_common/models/command_sender_multicast_source/src/command_sender_multicast_source.c
+++ b/c_common/models/command_sender_multicast_source/src/command_sender_multicast_source.c
@@ -221,9 +221,9 @@ void timer_callback(uint unused0, uint unused1) {
     }
 
     if (((infinite_run != TRUE) && (time >= simulation_ticks))) {
-        simulation_handle_pause_resume(NULL);
-
         run_stop_pause_commands();
+
+        simulation_handle_pause_resume(NULL);
 
         log_info("in pause resume mode");
         resume = true;


### PR DESCRIPTION
After investigating https://github.com/SpiNNakerManchester/sPyNNaker8/issues/189 for a while, the solution was as simple as switching the order of functions being called: don't expect to be able to send commands if the simulation has been paused...