### PR TITLE
safety time for power off

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -7,6 +7,7 @@ import math
 import os
 import signal
 import sys
+import time
 from six import iteritems, iterkeys, reraise
 from numpy import __version__ as numpy_version
 import spinn_utilities.conf_loader as conf_loader
@@ -70,6 +71,8 @@ CONFIG_FILE = "spinnaker.cfg"
 # Number of cores to be used when using a Virtual Machine and not specified
 DEFAULT_N_VIRTUAL_CORES = 16
 
+# The minimum time a board is kept in the off state in seconds
+MINIMUM_OFF_STATE_TIME = 20
 
 class AbstractSpinnakerBase(SimulatorInterface):
     """ Main interface into the tools logic flow
@@ -331,7 +334,7 @@ class AbstractSpinnakerBase(SimulatorInterface):
         # time taken by the front end extracting things
         "_extraction_time",
 
-        # power save mode. Only True if power saver has turned off board
+        # power save mode. time board turned off or None if not turned off
         "_machine_is_turned_off",
 
         # Version information from the front end
@@ -499,7 +502,7 @@ class AbstractSpinnakerBase(SimulatorInterface):
         self._raise_keyboard_interrupt = False
 
         # By default board is kept on once started later
-        self._machine_is_turned_off = False
+        self._machine_is_turned_off = None
 
         globals_variables.set_simulator(self)
 
@@ -2458,7 +2461,7 @@ class AbstractSpinnakerBase(SimulatorInterface):
         if self._use_virtual_board:
             return
 
-        if self._machine_is_turned_off:
+        if self._machine_is_turned_off is not None:
             logger.info("Shutdown skipped as board is off for power save")
             return
 
@@ -2740,7 +2743,7 @@ class AbstractSpinnakerBase(SimulatorInterface):
         :rtype: bool
         """
         # already off or no machine to turn off
-        if self._machine_is_turned_off or self._use_virtual_board:
+        if self._machine_is_turned_off is not None or self._use_virtual_board:
             return False
 
         if self._machine_allocation_controller is not None:
@@ -2750,14 +2753,25 @@ class AbstractSpinnakerBase(SimulatorInterface):
 
         self._txrx.power_off_machine()
 
-        self._machine_is_turned_off = True
+        self._machine_is_turned_off = time.time()
         return True
 
     def _turn_on_board_if_saving_power(self):
         # Only required if previously turned off which never happens
         # on virtual machine
-        if not self._machine_is_turned_off:
+        if self._machine_is_turned_off is None:
             return False
+
+        # Ensure the machine is completely powered down and
+        # all residual electrons have gone
+        already_off = time.time() - self._machine_is_turned_off
+        if already_off < MINIMUM_OFF_STATE_TIME:
+            delay = MINIMUM_OFF_STATE_TIME - already_off
+            logger.warning(
+                "Delaying turning machine back on for {} seconds. Consider "
+                "disabling turn_off_board_after_discovery for scripts that "
+                "have short preparation time.".format(delay))
+            time.sleep(delay)
 
         if self._machine_allocation_controller is not None:
             # switch power state if needed
@@ -2767,7 +2781,7 @@ class AbstractSpinnakerBase(SimulatorInterface):
             self._txrx.power_on_machine()
 
         self._txrx.ensure_board_is_ready()
-        self._machine_is_turned_off = False
+        self._machine_is_turned_off = None
         return True
 
     @property

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -74,6 +74,7 @@ DEFAULT_N_VIRTUAL_CORES = 16
 # The minimum time a board is kept in the off state in seconds
 MINIMUM_OFF_STATE_TIME = 20
 
+
 class AbstractSpinnakerBase(SimulatorInterface):
     """ Main interface into the tools logic flow
     """

--- a/spinn_front_end_common/interface/spinnaker.cfg
+++ b/spinn_front_end_common/interface/spinnaker.cfg
@@ -211,4 +211,6 @@ n_samples_per_recording_entry = 100
 # Valid options:
 # True  Which will make sure the board is off at this point
 # False Which will make sure the board is on at this point
+# WARNING To ensure the machine is completly powered down machine are only
+# turned on after 20 seconds so do not use for small scripts!
 turn_off_board_after_discovery = False


### PR DESCRIPTION
In rare but not zero cases after a board is powered down there can be residual electrons floating around which if the board is turned back on quickly will cause an issue.

For example:
Unexpected response RC_ROUTE while performing operation RouterInit using command CMD_RTR 

To avoid this added a safety of waiting at least 20 seconds.