### PR TITLE
More warnings

### DIFF
--- a/c_common/front_end_common_lib/local.mk
+++ b/c_common/front_end_common_lib/local.mk
@@ -72,7 +72,8 @@ endif
 
 # Set up the default C Flags
 FEC_OPT = $(OTIME)
-CFLAGS += -Wall -Wextra -D$(FEC_DEBUG) -D$(PROFILER) $(FEC_OPT) 
+WARNING_FLAGS = -Wall -Wextra -Wshadow -Wduplicated-branches -Wduplicated-cond -Wmissing-prototypes
+CFLAGS += $(WARNING_FLAGS) -D$(FEC_DEBUG) -D$(PROFILER) $(FEC_OPT) 
 
 # Get the application name hash by running md5sum on application name and 
 # extracting the first 8 bytes

--- a/c_common/front_end_common_lib/local.mk
+++ b/c_common/front_end_common_lib/local.mk
@@ -72,7 +72,7 @@ endif
 
 # Set up the default C Flags
 FEC_OPT = $(OTIME)
-WARNING_FLAGS = -Wall -Wextra -Wshadow -Wduplicated-branches -Wduplicated-cond -Wmissing-prototypes
+WARNING_FLAGS = -Wall -Wextra -Wshadow -Wmissing-prototypes
 CFLAGS += $(WARNING_FLAGS) -D$(FEC_DEBUG) -D$(PROFILER) $(FEC_OPT) 
 
 # Get the application name hash by running md5sum on application name and 

--- a/c_common/models/command_sender_multicast_source/src/command_sender_multicast_source.c
+++ b/c_common/models/command_sender_multicast_source/src/command_sender_multicast_source.c
@@ -64,6 +64,8 @@ enum time_id {
     FIRST_TIME = 0
 };
 
+void c_main(void);
+
 static void transmit_command(command *command_to_send) {
     // check for repeats
     if (command_to_send->repeats != 0) {
@@ -122,7 +124,7 @@ static void run_start_resume_commands() {
     }
 }
 
-bool read_scheduled_parameters(timed_commands_t *message_ptr) {
+static bool read_scheduled_parameters(timed_commands_t *message_ptr) {
     n_timed_commands = message_ptr->size;
     log_info("%d timed commands", n_timed_commands);
 
@@ -148,7 +150,7 @@ bool read_scheduled_parameters(timed_commands_t *message_ptr) {
     return true;
 }
 
-bool read_start_resume_commands(triggered_commands_t *message_ptr) {
+static bool read_start_resume_commands(triggered_commands_t *message_ptr) {
     n_start_resume_commands = message_ptr->size;
     log_info("%u start/resume commands", n_start_resume_commands);
 
@@ -170,7 +172,7 @@ bool read_start_resume_commands(triggered_commands_t *message_ptr) {
     return true;
 }
 
-bool read_pause_stop_commands(triggered_commands_t *message_ptr) {
+static bool read_pause_stop_commands(triggered_commands_t *message_ptr) {
     n_pause_stop_commands = message_ptr->size;
     log_info("%u pause/stop commands", n_pause_stop_commands);
 
@@ -193,7 +195,7 @@ bool read_pause_stop_commands(triggered_commands_t *message_ptr) {
 }
 
 // Callbacks
-void timer_callback(uint unused0, uint unused1) {
+static void timer_callback(uint unused0, uint unused1) {
     use(unused0);
     use(unused1);
     time++;
@@ -227,8 +229,7 @@ void timer_callback(uint unused0, uint unused1) {
     }
 }
 
-bool initialize(uint32_t *timer_period) {
-
+static bool initialize(uint32_t *timer_period) {
     // Get the address this core's DTCM data starts at from SRAM
     address_t address = data_specification_get_data_address();
 

--- a/c_common/models/data_speed_up_packet_gatherer/src/data_speed_up_packet_gatherer.c
+++ b/c_common/models/data_speed_up_packet_gatherer/src/data_speed_up_packet_gatherer.c
@@ -84,11 +84,11 @@ enum callback_priorities{
 };
 
 
-void resume_callback() {
+static void resume_callback(void) {
     time = UINT32_MAX;
 }
 
-void send_data(){
+static void send_data(void) {
     //log_info("last element is %d", data[position_in_store - 1]);
     //log_info("first element is %d", data[0]);
 
@@ -113,7 +113,7 @@ void send_data(){
     data[0] = seq_num;
 }
 
-void receive_data(uint key, uint payload) {
+static void receive_data(uint key, uint payload) {
     //log_info("packet!");
     if (key == new_sequence_key) {
         if (position_in_store != 1) {

--- a/c_common/models/data_speed_up_packet_gatherer/src/data_speed_up_packet_gatherer.c
+++ b/c_common/models/data_speed_up_packet_gatherer/src/data_speed_up_packet_gatherer.c
@@ -83,11 +83,6 @@ enum callback_priorities{
     DMA = 0
 };
 
-
-static void resume_callback(void) {
-    time = UINT32_MAX;
-}
-
 static void send_data(void) {
     //log_info("last element is %d", data[position_in_store - 1]);
     //log_info("first element is %d", data[0]);

--- a/c_common/models/extra_monitor_support/src/extra_monitor_support.c
+++ b/c_common/models/extra_monitor_support/src/extra_monitor_support.c
@@ -511,7 +511,7 @@ static INT_HANDLER reinjection_dropped_packet_callback() {
 
 //! \brief reads a memory location to set packet types for reinjection
 //! \param[in] address: memory address to read the reinjection packet types
-static static void reinjection_read_packet_types(
+static void reinjection_read_packet_types(
         struct reinject_config_t *config_ptr) {
     // process multicast reinject flag
     if (config_ptr->reinject_multicast == 1) {

--- a/c_common/models/extra_monitor_support/src/extra_monitor_support.c
+++ b/c_common/models/extra_monitor_support/src/extra_monitor_support.c
@@ -501,7 +501,7 @@ INT_HANDLER reinjection_dropped_packet_callback() {
 
 //! \brief reads a memory location to set packet types for reinjection
 //! \param[in] address: memory address to read the reinjection packet types
-void reinjection_read_packet_types(struct reinject_config_t *config_ptr){
+static void reinjection_read_packet_types(struct reinject_config_t *config_ptr) {
     // process multicast reinject flag
     if (config_ptr->reinject_multicast == 1) {
         reinject_mc = false;
@@ -662,7 +662,7 @@ static uint handle_reinjection_command(sdp_msg_t *msg) {
 }
 
 // \brief SARK level timer interrupt setup
-void reinjection_configure_timer() {
+static void reinjection_configure_timer() {
     // Clear the interrupt
     tc[T1_CONTROL] = 0;
     tc[T1_INT_CLR] = 1;
@@ -673,13 +673,13 @@ void reinjection_configure_timer() {
 }
 
 // \brief pass, not a clue.
-void reinjection_configure_comms_controller() {
+static void reinjection_configure_comms_controller() {
     // remember SAR register contents (p2p source ID)
     cc_sar = cc[CC_SAR] & 0x0000ffff;
 }
 
 // \brief sets up SARK and router to have a interrupt when a packet is dropped
-void reinjection_configure_router() {
+static void reinjection_configure_router() {
     // re-configure wait values in router
     rtr[RTR_CONTROL] = (rtr[RTR_CONTROL] & 0x0000ffff) |
 	    ROUTER_INITIAL_TIMEOUT;
@@ -718,7 +718,7 @@ static inline void send_fixed_route_packet(uint32_t key, uint32_t data) {
 //! \param[in] number_of_elements_to_send: the number of multicast packets to send
 //! \param[in] first_packet_key: the first key to transmit with, afterward,
 //! defaults to the default key.
-void send_data_block(
+static void send_data_block(
         uint32_t current_dma_pointer, uint32_t number_of_elements_to_send,
         uint32_t first_packet_key) {
     //log_info("first data is %d", data_to_transmit[current_dma_pointer][0]);
@@ -743,7 +743,7 @@ void send_data_block(
 //! \param[in] dma_tag the DMA tag associated with this read.
 //!            transmission or retransmission
 //! \param[in] offset where in the data array to start writing to
-void read(uint32_t dma_tag, uint32_t offset, uint32_t items_to_read) {
+static void read(uint32_t dma_tag, uint32_t offset, uint32_t items_to_read) {
     // set off DMA
     transmit_dma_pointer = (transmit_dma_pointer + 1) % N_DMA_BUFFERS;
 
@@ -765,12 +765,12 @@ void read(uint32_t dma_tag, uint32_t offset, uint32_t items_to_read) {
 }
 
 //! \brief sends a end flag via multicast
-void data_speed_up_send_end_flag() {
+static void data_speed_up_send_end_flag(void) {
     send_fixed_route_packet(end_flag_key, END_FLAG);
 }
 
 //! \brief DMA complete callback for reading for original transmission
-void dma_complete_reading_for_original_transmission(){
+static void dma_complete_reading_for_original_transmission(void) {
     // set up state
     uint32_t current_dma_pointer = transmit_dma_pointer;
     uint32_t key_to_transmit = basic_data_key;
@@ -838,7 +838,7 @@ void dma_complete_reading_for_original_transmission(){
 //! \param[in] data: data to write into SDRAM
 //! \param[in] length: length of data
 //! \param[in] start_offset: where in the data to start writing in from.
-void write_missing_sdp_seq_nums_into_sdram(
+static void write_missing_sdp_seq_nums_into_sdram(
         uint32_t data[], ushort length, uint32_t start_offset) {
     for (ushort offset=start_offset; offset < length; offset ++) {
         missing_sdp_seq_num_sdram_address[
@@ -860,7 +860,7 @@ void write_missing_sdp_seq_nums_into_sdram(
 //! \param[in] length: how much data to read
 //! \param[in] first: if first packet about missing sequence numbers. If so
 //! there is different behaviour
-void store_missing_seq_nums(uint32_t data[], ushort length, bool first) {
+static void store_missing_seq_nums(uint32_t data[], ushort length, bool first) {
     uint32_t start_reading_offset = 1;
     if (first){
         number_of_missing_seq_sdp_packets =
@@ -896,7 +896,7 @@ void store_missing_seq_nums(uint32_t data[], ushort length, bool first) {
 }
 
 //! \brief sets off a DMA for retransmission stuff
-void retransmission_dma_read() {
+static void retransmission_dma_read() {
     // locate where we are in SDRAM
     address_t data_sdram_position =
         &missing_sdp_seq_num_sdram_address[position_for_retransmission];
@@ -918,7 +918,7 @@ void retransmission_dma_read() {
 
 //! \brief reads in missing sequence numbers and sets off the reading of
 //! SDRAM for the equivalent data
-void the_dma_complete_read_missing_seqeuence_nums() {
+static void the_dma_complete_read_missing_seqeuence_nums() {
     //! check if at end of read missing sequence numbers
     if (position_in_read_data > ITEMS_PER_DATA_PACKET) {
         position_for_retransmission += ITEMS_PER_DATA_PACKET;
@@ -967,7 +967,7 @@ void the_dma_complete_read_missing_seqeuence_nums() {
 }
 
 //! \brief DMA complete callback for have read missing sequence number data
-void dma_complete_reading_retransmission_data() {
+static void dma_complete_reading_retransmission_data() {
     //log_info("just read data for a given missing sequence number");
 
     // set sequence number as first element
@@ -990,14 +990,14 @@ void dma_complete_reading_retransmission_data() {
 }
 
 //! \brief DMA complete callback for have read missing sequence number data
-void dma_complete_writing_missing_seq_to_sdram() {
+static void dma_complete_writing_missing_seq_to_sdram() {
     io_printf(IO_BUF, "Need to figure what to do here\n");
 }
 
 //! \brief the handler for all messages coming in for data speed up
 //! functionality.
 //! \param[in] msg: the SDP message (without SCP header)
-void handle_data_speed_up(struct sdp_msg_pure_data *msg) {
+static void handle_data_speed_up(struct sdp_msg_pure_data *msg) {
     struct sending_data_header_t *header = (struct sending_data_header_t *)
 	    msg->data;
     switch (header->command) {
@@ -1185,7 +1185,7 @@ static inline void *region_address(uint32_t region_index) {
 }
 
 //! \brief sets up data required by the reinjection functionality
-void reinjection_initialise() {
+static void reinjection_initialise() {
     // set up config region and process data
     reinjection_read_packet_types(region_address(CONFIG_REINJECTION));
 
@@ -1208,7 +1208,7 @@ void reinjection_initialise() {
 }
 
 //! \brief sets up data required by the data speed up functionality
-void data_speed_up_initialise() {
+static void data_speed_up_initialise() {
     struct data_speed_config_t *config_ptr =
 	    region_address(CONFIG_DATA_SPEED_UP);
 

--- a/c_common/models/live_packet_gather/src/live_packet_gather.c
+++ b/c_common/models/live_packet_gather/src/live_packet_gather.c
@@ -373,7 +373,7 @@ static bool initialize(uint32_t *timer_period_ptr) {
     return true;
 }
 
-static static bool configure_sdp_msg(void) {
+static bool configure_sdp_msg(void) {
     log_info("configure_sdp_msg\n");
 
     void *temp_ptr;

--- a/c_common/models/live_packet_gather/src/live_packet_gather.c
+++ b/c_common/models/live_packet_gather/src/live_packet_gather.c
@@ -84,7 +84,7 @@ static uint16_t sdp_dest; // Not in the configuration_region_t; type different
 //! Does the packet type include a double-width payload?
 #define HAVE_WIDE_LOAD(pkt_type)	FLAG_IS_SET(pkt_type, 0x2)
 
-void flush_events(void) {
+static void flush_events(void) {
 
     // Send the event message only if there is data
     if (buffer_index > 0) {
@@ -137,14 +137,14 @@ void flush_events(void) {
 }
 
 //! \brief function to store provenance data elements into SDRAM
-void record_provenance_data(address_t provenance_region_address) {
+static void record_provenance_data(address_t provenance_region_address) {
     // Copy provenance data into SDRAM region
     spin1_memcpy(provenance_region_address, &provenance_data,
            sizeof(provenance_data));
 }
 
 // Callbacks
-void timer_callback(uint unused0, uint unused1) {
+static void timer_callback(uint unused0, uint unused1) {
     use(unused0);
     use(unused1);
 
@@ -167,7 +167,7 @@ void timer_callback(uint unused0, uint unused1) {
     }
 }
 
-void flush_events_if_full(void) {
+static void flush_events_if_full(void) {
     uint8_t event_count;
 
     if (HAVE_PAYLOAD(config.packet_type)) {
@@ -182,7 +182,7 @@ void flush_events_if_full(void) {
 }
 
 // processes an incoming multicast packet without payload
-void process_incoming_event(uint key) {
+static void process_incoming_event(uint key) {
     log_debug("Processing key %x", key);
 
     // process the received spike
@@ -229,7 +229,7 @@ void process_incoming_event(uint key) {
 }
 
 // processes an incoming multicast packet with payload
-void process_incoming_event_payload(uint key, uint payload) {
+static void process_incoming_event_payload(uint key, uint payload) {
     log_debug("Processing key %x, payload %x", key, payload);
 
     // process the received spike
@@ -275,7 +275,7 @@ void process_incoming_event_payload(uint key, uint payload) {
     flush_events_if_full();
 }
 
-void incoming_event_process_callback(uint unused0, uint unused1) {
+static void incoming_event_process_callback(uint unused0, uint unused1) {
     use(unused0);
     use(unused1);
 
@@ -293,7 +293,7 @@ void incoming_event_process_callback(uint unused0, uint unused1) {
     } while (processing_events);
 }
 
-void incoming_event_callback(uint key, uint unused) {
+static void incoming_event_callback(uint key, uint unused) {
     use(unused);
     log_debug("Received key %x", key);
     if (circular_buffer_add(without_payload_buffer, key)) {
@@ -306,7 +306,7 @@ void incoming_event_callback(uint key, uint unused) {
     }
 }
 
-void incoming_event_payload_callback(uint key, uint payload) {
+static void incoming_event_payload_callback(uint key, uint payload) {
     log_debug("Received key %x, payload %x", key, payload);
     if (circular_buffer_add(with_payload_buffer, key)) {
         circular_buffer_add(with_payload_buffer, payload);
@@ -319,7 +319,7 @@ void incoming_event_payload_callback(uint key, uint payload) {
     }
 }
 
-void read_parameters(address_t region_address) {
+static void read_parameters(address_t region_address) {
     struct configuration_region_t *config_ptr =
 	    (struct configuration_region_t *) region_address;
 
@@ -340,7 +340,7 @@ void read_parameters(address_t region_address) {
     log_info("packets_per_timestamp: %d\n", config.packets_per_timestamp);
 }
 
-bool initialize(uint32_t *timer_period_ptr) {
+static bool initialize(uint32_t *timer_period_ptr) {
 
     // Get the address this core's DTCM data starts at from SRAM
     address_t address = data_specification_get_data_address();
@@ -373,7 +373,7 @@ bool initialize(uint32_t *timer_period_ptr) {
     return true;
 }
 
-bool configure_sdp_msg(void) {
+static static bool configure_sdp_msg(void) {
     log_info("configure_sdp_msg\n");
 
     void *temp_ptr;


### PR DESCRIPTION
Enables (and fixes most of) more warnings in our builds.

Note that making a function `static` exempts it from needing a declaration. Almost all of our functions should either have a proper declaration somewhere or be `static`; the usual exception to this is `c_main()`, which should instead be `extern` usually since it is the program entry point.

----

Note that this is a PR not to `master`.