### PR TITLE
as the safety check failed let the os do it.

### DIFF
--- a/spinn_front_end_common/interface/config_handler.py
+++ b/spinn_front_end_common/interface/config_handler.py
@@ -140,8 +140,7 @@ class ConfigHandler(object):
 
     def child_folder(self, parent, child_name):
         child = os.path.join(parent, child_name)
-        if not os.path.exists(child):
-            os.makedirs(child)
+        os.makedirs(child, exist_ok=True)
         return child
 
     def _remove_excess_folders(self, max_kept, starting_directory):


### PR DESCRIPTION
fix for weird behavior seen in
 http://apollo.cs.man.ac.uk:8080/blue/organizations/jenkins/sPyNNaker8%20Integration%20Tests/detail/jenkinsjava/30/pipeline

thanks @dkfellows 