### PR TITLE
Actually make sure an individual word gets sent during speed up protocol

### DIFF
--- a/c_common/models/extra_monitor_support/src/extra_monitor_support.c
+++ b/c_common/models/extra_monitor_support/src/extra_monitor_support.c
@@ -787,7 +787,7 @@ void dma_complete_reading_for_original_transmission(void) {
     // if a full packet, read another and try again
     //io_printf(IO_BUF, "next position %d, elements %d\n", position_in_store,
     //          number_of_elements_to_read_from_sdram);
-    if (position_in_store < number_of_elements_to_read_from_sdram - 1) {
+    if (position_in_store < number_of_elements_to_read_from_sdram) {
         //io_printf(IO_BUF, "setting off another DMA\n");
         //log_info("setting off another DMA");
         uint32_t num_items_to_read =


### PR DESCRIPTION
Fix for https://github.com/SpiNNakerManchester/sPyNNaker/issues/652; in this particular case, the bug was only present with advanced monitor support turned on; in the particular example, the final message sent using the data speed up protocol was only one word in size, and was not being sent by the monitor core to the speed up core - and so the final data value was not being filled in correctly.