### PR TITLE
Python 3: Revenge of the divide monster

### DIFF
--- a/spinn_front_end_common/interface/interface_functions/profile_data_gatherer.py
+++ b/spinn_front_end_common/interface/interface_functions/profile_data_gatherer.py
@@ -21,7 +21,7 @@ class ProfileDataGatherer(object):
         :param machine_time_step: machine time step in ms
         """
         # pylint: disable=too-many-arguments
-        machine_time_step_ms = machine_time_step // 1000
+        machine_time_step_ms = float(machine_time_step) / 1000.0
 
         progress = ProgressBar(
             placements.n_placements, "Getting profile data")

--- a/spinn_front_end_common/interface/profiling/profile_data.py
+++ b/spinn_front_end_common/interface/profiling/profile_data.py
@@ -1,5 +1,6 @@
 import logging
 import numpy
+import math
 import scipy.stats
 from spinn_utilities.log import FormatAdapter
 
@@ -154,8 +155,10 @@ class ProfileData(object):
         :type run_time_ms: float
         :rtype: float
         """
-        bins = numpy.arange(
-            0, self._max_time + machine_time_step_ms, machine_time_step_ms)
+        n_points = math.ceil(
+            self._max_time / machine_time_step_ms)
+        endpoint = n_points * machine_time_step_ms
+        bins = numpy.linspace(0, endpoint, n_points + 1)
         return numpy.average(numpy.histogram(
             self._tags[tag][_START_TIME], bins)[0])
 
@@ -172,8 +175,10 @@ class ProfileData(object):
         :type run_time_ms: float
         :rtype: float
         """
-        bins = numpy.arange(
-            0, self._max_time + machine_time_step_ms, machine_time_step_ms)
+        n_points = math.ceil(
+            self._max_time / machine_time_step_ms)
+        endpoint = n_points * machine_time_step_ms
+        bins = numpy.linspace(0, endpoint, n_points + 1)
         mean_per_ts = scipy.stats.binned_statistic(
             self._tags[tag][_START_TIME], self._tags[tag][_DURATION],
             "mean", bins).statistic


### PR DESCRIPTION
Trying to use the profiler with machine_time_step=100 (i.e. timestep=0.1) led to some crazy memory errors.  I'm not sure looking at the history of this code how this ever actually worked in the first place.