### PR TITLE
Fix the big_connection test in sPyNNaker8

### DIFF
--- a/spinn_front_end_common/utilities/helpful_functions.py
+++ b/spinn_front_end_common/utilities/helpful_functions.py
@@ -287,13 +287,16 @@ def convert_vertices_to_core_subset(vertices, placements):
 
 
 def _emergency_state_check(txrx, app_id):
-    rte_count = txrx.get_core_state_count(app_id, CPUState.RUN_TIME_EXCEPTION)
-    watchdog_count = txrx.get_core_state_count(app_id, CPUState.WATCHDOG)
-    if rte_count or watchdog_count:
-        logger.warning(
-            "unexpected core states (rte={}, wdog={})",
-            txrx.get_cores_in_state(None, CPUState.RUN_TIME_EXCEPTION),
-            txrx.get_cores_in_state(None, CPUState.WATCHDOG))
+    try:
+        rte_count = txrx.get_core_state_count(app_id, CPUState.RUN_TIME_EXCEPTION)
+        watchdog_count = txrx.get_core_state_count(app_id, CPUState.WATCHDOG)
+        if rte_count or watchdog_count:
+            logger.warning(
+                "unexpected core states (rte={}, wdog={})",
+                txrx.get_cores_in_state(None, CPUState.RUN_TIME_EXCEPTION),
+                txrx.get_cores_in_state(None, CPUState.WATCHDOG))
+    except Exception:  # pylint: disable=broad-except
+        logger.warning("failed to read core states", exc_info=True)
 
 
 # TRICKY POINT: Have to delay the import to here because of import circularity

--- a/spinn_front_end_common/utilities/helpful_functions.py
+++ b/spinn_front_end_common/utilities/helpful_functions.py
@@ -288,7 +288,8 @@ def convert_vertices_to_core_subset(vertices, placements):
 
 def _emergency_state_check(txrx, app_id):
     try:
-        rte_count = txrx.get_core_state_count(app_id, CPUState.RUN_TIME_EXCEPTION)
+        rte_count = txrx.get_core_state_count(
+            app_id, CPUState.RUN_TIME_EXCEPTION)
         watchdog_count = txrx.get_core_state_count(app_id, CPUState.WATCHDOG)
         if rte_count or watchdog_count:
             logger.warning(


### PR DESCRIPTION
* Writes to SDRAM a word at a time
  * `spin1_memcpy()` writes a byte at a time; this is _bad_ for SDRAM!
* Ensure that failures in core crash detection don't stop IOBUF retrieve