### PR TITLE
Fix sizes of messages written and add a timeout to the gatherer

### DIFF
--- a/c_common/models/data_speed_up_packet_gatherer/src/data_speed_up_packet_gatherer.c
+++ b/c_common/models/data_speed_up_packet_gatherer/src/data_speed_up_packet_gatherer.c
@@ -367,7 +367,7 @@ static void process_missing_seq_nums_and_request_retransmission(void) {
 
     uint sr;
     sr = spin1_irq_disable();
-    if (++access_lock == 1) {
+    if (++access_lock > 1) {
         access_lock--;
         spin1_mode_restore(sr);
         return;

--- a/c_common/models/data_speed_up_packet_gatherer/src/data_speed_up_packet_gatherer.c
+++ b/c_common/models/data_speed_up_packet_gatherer/src/data_speed_up_packet_gatherer.c
@@ -367,7 +367,7 @@ static void process_missing_seq_nums_and_request_retransmission(void) {
 
     uint sr;
     sr = spin1_irq_disable();
-    if (++access_lock == 0) {
+    if (++access_lock == 1) {
         access_lock--;
         spin1_mode_restore(sr);
         return;


### PR DESCRIPTION
Timeouts are good. Timeouts mean that even if a bunch of messages get lost _including the last message in a stream_, we'll eventually recover.

Writing the correct size of message is even better! Using the right message sizes (instead of their negation) means that we don't crash SCAMP when we send response messages asking for some packets to be resent.