### PR TITLE
Don't kill the machine on the first run

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -694,7 +694,7 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
         """
         self._run(run_time)
 
-    def _build_graphs_for_usege(self):
+    def _build_graphs_for_usage(self):
         # sort out app graph
         self._application_graph = ApplicationGraph(
             label=self._original_application_graph.label)
@@ -786,7 +786,7 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
 
         # build the graphs to modify with system requirements
         if not self._has_ran or graph_changed:
-            self._build_graphs_for_usege()
+            self._build_graphs_for_usage()
             self._add_dependent_verts_and_edges_for_application_graph()
             self._add_commands_to_command_sender()
 
@@ -796,7 +796,7 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
                 self._graph_mapper = None
 
             # Reset the machine if the graph has changed
-            if not self._use_virtual_board:
+            if not self._use_virtual_board and self._n_calls_to_run > 1:
 
                 # wipe out stuff associated with a given machine, as these need
                 # to be rebuilt.


### PR DESCRIPTION
The standard method of running using GFE at the moment is:

1) sim.setup(...)
2) sim.get_number_of_available_cores_on_machine(...) or sim.get_machine(...)
3) something to do with adding vertices to machine, e.g. sim.add_machine_vertex_instance(...)
4) sim.run(runtime) or sim.run_until_complete() or whatever

The recent changes to help with run(), reset(), run() in PyNN mean that currently if you run like this then the machine created in the second step will be killed in the fourth step because you have changed the graph in the third step.  This means that get_machine() will be called twice, which wasn't happening prior to the changes.  This is a quick fix to deal with this scenario given functionality that was already available in abstract_spinnaker_base but I'd be happy for a better solution to replace it if one exists.  

(I'm running tests to see if this change affects anything else in the meantime...)