### PR TITLE
added stdlib.h needed by unint32_t

### DIFF
--- a/c_common/front_end_common_lib/include/debug.h
+++ b/c_common/front_end_common_lib/include/debug.h
@@ -65,6 +65,7 @@
 #ifndef __DEBUG_H__
 #define __DEBUG_H__
 
+#include <stdint.h>
 #include "spin-print.h"
 #include <assert.h>
 


### PR DESCRIPTION
the uint32-t declaration only work when something else had dragged in stdint.h