### PR TITLE
Deal with compiler warnings in minimise functions

### DIFF
--- a/c_common/models/minimise/src/minimise.h
+++ b/c_common/models/minimise/src/minimise.h
@@ -202,7 +202,7 @@ void compress_start() {
         } else {
             // Otherwise remove default routes.
             log_debug("remove default routes from minimiser");
-            remove_default_routes_minimise(&table);
+            remove_default_routes_minimise(table);
             if (load_routing_table(header->app_id)){
                 cleanup_and_exit(header);
             } else {

--- a/c_common/models/minimise/src/platform.h
+++ b/c_common/models/minimise/src/platform.h
@@ -34,7 +34,8 @@ static inline void * safe_malloc(uint bytes)
 }
 
 static inline void safe_xfree(void *ptr){
-  if (ptr >= DTCM_BASE && ptr <= DTCM_TOP) {
+  uint ptr_int = (uint) ptr;
+  if (ptr_int >= DTCM_BASE && ptr_int <= DTCM_TOP) {
       sark_xfree(sark.heap, ptr, 0);
   } else {
       sark_xfree(sv->sdram_heap, ptr, ALLOC_LOCK);

--- a/c_common/models/minimise/src/simple_minimise.c
+++ b/c_common/models/minimise/src/simple_minimise.c
@@ -17,6 +17,7 @@
 
 #include <spin1_api.h>
 #include <debug.h>
+#include <common-typedefs.h>
 #include "platform.h"
 #include "unordered_remove_default_routes.h"
 #include "minimise.h"
@@ -102,7 +103,7 @@ static inline int compare_routes(uint32_t route_a, uint32_t route_b){
     if (route_a == route_b) {
         return 0;
     }
-    for (int i = 0; i < routes_count; i++) {
+    for (uint i = 0; i < routes_count; i++) {
         if (routes[i] == route_a){
             return 1;
         }
@@ -114,6 +115,8 @@ static inline int compare_routes(uint32_t route_a, uint32_t route_b){
     // set the failed flag and exit
     sark.vcpu->user0 = 1;
     spin1_exit(0);
+
+    return 0;
 }
 
 static void quicksort_table(int low, int high){
@@ -200,7 +203,7 @@ static void quicksort_route(int low, int high){
 
     if (low < high - 1) {
         // pick low entry for the pivot
-        int pivot = routes_frequency[low];
+        uint pivot = routes_frequency[low];
         //Start at low + 1 as entry low is the pivot
         check = low + 1;
         // If we find any less than swap with the first pivot
@@ -231,9 +234,9 @@ static void quicksort_route(int low, int high){
     }
 }
 
-static inline update_frequency(index){
+static inline void update_frequency(int index){
     uint32_t route = routing_table_sdram_stores_get_entry(index)->route;
-    for (int i = 0; i < routes_count; i++) {
+    for (uint i = 0; i < routes_count; i++) {
         if (routes[i] == route) {
             routes_frequency[i] += 1;
             return;
@@ -251,6 +254,7 @@ static inline update_frequency(index){
 }
 
 static inline void simple_minimise(uint32_t target_length){
+	use(target_length);
     int left, right;
 
     int table_size = Routing_table_sdram_get_n_entries();
@@ -262,14 +266,14 @@ static inline void simple_minimise(uint32_t target_length){
     }
 
     log_info("before sort %u", routes_count);
-    for (int i = 0; i < routes_count; i++) {
+    for (uint i = 0; i < routes_count; i++) {
         log_debug("%u", routes[i]);
     }
 
     quicksort_route(0, routes_count);
 
     log_info("after sort %u", routes_count);
-    for (int i = 0; i < routes_count; i++) {
+    for (uint i = 0; i < routes_count; i++) {
         log_debug("%u", routes[i]);
     }
 


### PR DESCRIPTION
Noticed after the recent merges that this code was giving out a lot of compiler warnings.  This is an attempt to fix them, though I don't see or have anything to test whether this still works or not (is there a unit/integration test that uses this?).