### PR TITLE
check buffer times at app level as machine level does not pick up too long

### DIFF
--- a/spinn_front_end_common/utility_models/reverse_ip_tag_multi_cast_source.py
+++ b/spinn_front_end_common/utility_models/reverse_ip_tag_multi_cast_source.py
@@ -29,6 +29,7 @@ from .reverse_ip_tag_multicast_source_machine_vertex import (
     ReverseIPTagMulticastSourceMachineVertex)
 from spinn_front_end_common.abstract_models import (
     AbstractGeneratesDataSpecification, AbstractHasAssociatedBinary)
+from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from spinn_front_end_common.utilities.utility_objs import ExecutableType
 from spinn_front_end_common.utilities import globals_variables
 
@@ -134,7 +135,8 @@ class ReverseIpTagMultiCastSource(
                 self.add_constraint(BoardConstraint(board_address))
 
         # Store the send buffering details
-        self._send_buffer_times = send_buffer_times
+        self._send_buffer_times = self._validate_send_buffer_times(
+            n_keys, send_buffer_times)
         self._send_buffer_partition_id = send_buffer_partition_id
 
         # Store the buffering details
@@ -145,6 +147,17 @@ class ReverseIpTagMultiCastSource(
 
         # Keep the vertices for resuming runs
         self._machine_vertices = list()
+
+    def _validate_send_buffer_times(self, n_keys, send_buffer_times):
+        if send_buffer_times is None:
+            return
+        if len(send_buffer_times) and hasattr(send_buffer_times[0], "__len__"):
+            if len(send_buffer_times) != n_keys:
+                raise ConfigurationException(
+                    "The array or arrays of times {} does not have the "
+                    "expected length of {}".format(
+                        send_buffer_times, n_keys))
+        return send_buffer_times
 
     @property
     @overrides(ApplicationVertex.n_atoms)

--- a/spinn_front_end_common/utility_models/reverse_ip_tag_multi_cast_source.py
+++ b/spinn_front_end_common/utility_models/reverse_ip_tag_multi_cast_source.py
@@ -136,7 +136,7 @@ class ReverseIpTagMultiCastSource(
 
         # Store the send buffering details
         self._send_buffer_times = self._validate_send_buffer_times(
-            n_keys, send_buffer_times)
+            send_buffer_times)
         self._send_buffer_partition_id = send_buffer_partition_id
 
         # Store the buffering details
@@ -148,15 +148,15 @@ class ReverseIpTagMultiCastSource(
         # Keep the vertices for resuming runs
         self._machine_vertices = list()
 
-    def _validate_send_buffer_times(self, n_keys, send_buffer_times):
+    def _validate_send_buffer_times(self, send_buffer_times):
         if send_buffer_times is None:
-            return
+            return None
         if len(send_buffer_times) and hasattr(send_buffer_times[0], "__len__"):
-            if len(send_buffer_times) != n_keys:
+            if len(send_buffer_times) != self._n_atoms:
                 raise ConfigurationException(
                     "The array or arrays of times {} does not have the "
                     "expected length of {}".format(
-                        send_buffer_times, n_keys))
+                        send_buffer_times, self._n_atoms))
         return send_buffer_times
 
     @property


### PR DESCRIPTION
import spynnaker8 as sim
sim.setup(timestep=1.0)
input1 = sim.Population(3, sim.SpikeSourceArray(spike_times=[[1], [2], [3], [4]]), label="input1")

This never raises an error as the current check is at the machine level which gets its slice of the full spike times.

requested by @pabogdan 