### PR TITLE
Deal with empty send_buffer_times properly when installing

### DIFF
--- a/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
@@ -190,7 +190,15 @@ class ReverseIPTagMulticastSourceMachineVertex(
         self._send_buffer = None
         self._send_buffer_partition_id = send_buffer_partition_id
         self._send_buffer_size = 0
-        if send_buffer_times is None:
+        n_buffer_times = 0
+        if send_buffer_times is not None:
+            for i in send_buffer_times:
+                if hasattr(i, "__len__"):
+                    n_buffer_times += len(i)
+                else:
+                    # assuming this must be a single integer
+                    n_buffer_times += 1
+        if n_buffer_times == 0:
             self._send_buffer_times = None
             self._send_buffers = None
         else:


### PR DESCRIPTION
Accompanying fix on installation for empty send_buffer_times, otherwise machine gets into an unclean state in terms of memory when collecting data afterwards.

sPyNNaker: https://github.com/SpiNNakerManchester/sPyNNaker/pull/731
sPyNNaker8: https://github.com/SpiNNakerManchester/sPyNNaker8/pull/303