### PR TITLE
Multirun provenance

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -333,9 +333,6 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
 
         "_vertices_or_edges_added",
 
-        # Set of all seen vertext labels
-        "_vertext_labels",
-
         # Version provenance
         "_version_provenance"
     ]
@@ -514,7 +511,6 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
 
         self._last_except_hook = sys.excepthook
         self._vertices_or_edges_added = False
-        self._vertext_labels = set()
 
     def set_n_boards_required(self, n_boards_required):
         """

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -334,7 +334,10 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
         "_vertices_or_edges_added",
 
         # Set of all seen vertext labels
-        "_vertext_labels"
+        "_vertext_labels",
+
+        # Version provenance
+        "_version_provenance"
     ]
 
     def __init__(
@@ -444,6 +447,7 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
         self._last_run_tokens = None
         self._pacman_provenance = PacmanProvenanceExtractor()
         self._all_provenance_items = list()
+        self._version_provenance = list()
         self._xml_paths = self._create_xml_paths(extra_algorithm_xml_paths)
 
         # extra algorithms and inputs for runs, should disappear in future
@@ -1144,7 +1148,7 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
             for name, value in self._front_end_versions:
                 version_provenance.append(ProvenanceDataItem(
                     names=["version_data", name], value=value))
-        inputs["ProvenanceItems"] = version_provenance
+        self._version_provenance = version_provenance
         inputs["UsingAdvancedMonitorSupport"] = self._config.getboolean(
             "Machine", "enable_advanced_monitor_support")
         inputs["DisableAdvancedMonitorUsageForDataIn"] = \
@@ -1787,9 +1791,16 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
             if (self._config.getboolean(
                     "Reports", "write_provenance_data") and
                     n_machine_time_steps is not None):
-                prov_items = executor.get_item("ProvenanceItems")
+                prov_items = list()
+                prov_items.extend(self._version_provenance)
                 prov_items.extend(self._pacman_provenance.data_items)
+                prov_items.extend(executor.get_item("GraphProvenanceItems"))
+                prov_items.extend(
+                    executor.get_item("PlacementsProvenanceItems"))
+                prov_items.extend(
+                    executor.get_item("RouterProvenanceItems"))
                 self._pacman_provenance.clear()
+                self._version_provenance = list()
                 self._write_provenance(prov_items)
                 self._all_provenance_items.append(prov_items)
 
@@ -1951,7 +1962,6 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
             algorithms.append("PlacementsProvenanceGatherer")
             algorithms.append("RouterProvenanceGatherer")
             algorithms.append("ProfileDataGatherer")
-            outputs.append("ProvenanceItems")
 
         # Decide what needs done
         required_tokens = []
@@ -1999,11 +2009,11 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
                 extra_monitor_vertices = self._last_run_outputs[
                     "MemoryExtraMonitorVertices"]
             router_provenance = RouterProvenanceGatherer()
-            prov_items = router_provenance(
+            prov_items.extend(router_provenance(
                 transceiver=self._txrx, machine=self._machine,
                 router_tables=self._router_tables,
                 extra_monitor_vertices=extra_monitor_vertices,
-                placements=self._placements)
+                placements=self._placements))
         except Exception:
             logger.exception("Error reading router provenance")
 
@@ -2072,7 +2082,7 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
             # Extract any written provenance data
             try:
                 extracter = PlacementsProvenanceGatherer()
-                extracter(self._txrx, placements, prov_items)
+                prov_items.extend(extracter(self._txrx, placements))
             except Exception:
                 logger.exception("Could not read provenance")
 
@@ -2493,11 +2503,22 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
                 self._pacman_provenance.extract_provenance(executor)
                 run_complete = True
 
+                if self._config.getboolean("Reports", "write_energy_report"):
+                    self._do_energy_report()
+
                 # write provenance to file if necessary
                 if self._config.getboolean("Reports", "writeProvenanceData"):
-                    prov_items = executor.get_item("ProvenanceItems")
+                    prov_items = list()
+                    prov_items.extend(self._version_provenance)
                     prov_items.extend(self._pacman_provenance.data_items)
+                    prov_items.extend(
+                        executor.get_item("GraphProvenanceItems"))
+                    prov_items.extend(
+                        executor.get_item("PlacementsProvenanceItems"))
+                    prov_items.extend(
+                        executor.get_item("RouterProvenanceItems"))
                     self._pacman_provenance.clear()
+                    self._version_provenance = list()
                     self._write_provenance(prov_items)
                     self._all_provenance_items.append(prov_items)
             except Exception as e:
@@ -2515,9 +2536,6 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
                     logger.exception(
                         "Error when attempting to recover from error")
 
-        if self._config.getboolean("Reports", "write_energy_report"):
-            self._do_energy_report()
-
         # handle iobuf extraction if never extracted it yet but requested to
         if self._config.getboolean("Reports", "extract_iobuf"):
             self._extract_iobufs()
@@ -2531,6 +2549,9 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
             if len(self._all_provenance_items) > 1:
                 message = "Provenance from run {}".format(i)
             self._check_provenance(provenance_items, message)
+
+            # Reset provenance
+            self._all_provenance_items = list()
 
         self.write_finished_file()
 
@@ -2561,7 +2582,6 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
             algorithms.append("PlacementsProvenanceGatherer")
             algorithms.append("RouterProvenanceGatherer")
             algorithms.append("ProfileDataGatherer")
-            outputs.append("ProvenanceItems")
 
         # Assemble how to run the algorithms
         return PACMANAlgorithmExecutor(
@@ -2581,18 +2601,8 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
 
         # acquire provenance items
         if self._last_run_outputs is not None:
-            prov_items = self._last_run_outputs["ProvenanceItems"]
-            pacman_provenance = list()
-            router_provenance = list()
-
-            # group them by name type
-            grouped_items = sorted(
-                prov_items, key=lambda item: item.names[0])
-            for element in grouped_items:
-                if element.names[0] == 'pacman':
-                    pacman_provenance.append(element)
-                if element.names[0] == 'router_provenance':
-                    router_provenance.append(element)
+            pacman_provenance = self._pacman_provenance.data_items
+            router_provenance = self._last_run_outputs["RouterProvenanceItems"]
 
             # run energy report
             energy_report(

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -2080,8 +2080,8 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
 
             # Extract any written provenance data
             try:
-                extracter = PlacementsProvenanceGatherer()
-                prov_items.extend(extracter(self._txrx, placements))
+                extractor = PlacementsProvenanceGatherer()
+                prov_items.extend(extractor(self._txrx, placements))
             except Exception:
                 logger.exception("Could not read provenance")
 

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1788,8 +1788,7 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
             run_complete = True
 
             # write provenance to file if necessary
-            if (self._config.getboolean(
-                    "Reports", "write_provenance_data") and
+            if (self._config.getboolean("Reports", "write_provenance_data") and
                     n_machine_time_steps is not None):
                 prov_items = list()
                 prov_items.extend(self._version_provenance)
@@ -2507,7 +2506,7 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
                     self._do_energy_report()
 
                 # write provenance to file if necessary
-                if self._config.getboolean("Reports", "writeProvenanceData"):
+                if self._config.getboolean("Reports", "write_provenance_data"):
                     prov_items = list()
                     prov_items.extend(self._version_provenance)
                     prov_items.extend(self._pacman_provenance.data_items)

--- a/spinn_front_end_common/interface/interface_functions/dsg_region_reloader.py
+++ b/spinn_front_end_common/interface/interface_functions/dsg_region_reloader.py
@@ -33,12 +33,7 @@ REGION_STRUCT = struct.Struct("<{}I".format(MAX_MEM_REGIONS))
 class DSGRegionReloader(object):
     """ Regenerates and reloads the data specifications.
     """
-    __slots__ = [
-        "_app_data_dir",
-        "_hostname",
-        "_report_dir",
-        "_txrx",
-        "_write_text"]
+    __slots__ = []
 
     def __call__(
             self, transceiver, placements, hostname, report_directory,
@@ -56,21 +51,19 @@ class DSGRegionReloader(object):
             the mapping between application and machine graph
         """
         # pylint: disable=too-many-arguments, attribute-defined-outside-init
-        self._txrx = transceiver
-        self._hostname = hostname
-        self._write_text = write_text_specs
 
         # build file paths for reloaded stuff
-        self._app_data_dir = generate_unique_folder_name(
+        app_data_dir = generate_unique_folder_name(
             application_data_file_path, "reloaded_data_regions", "")
-        self._report_dir = generate_unique_folder_name(
-            report_directory, "reloaded_data_regions", "")
+        if not os.path.exists(app_data_dir):
+            os.makedirs(app_data_dir)
 
-        # build new folders
-        if not os.path.exists(self._app_data_dir):
-            os.makedirs(self._app_data_dir)
-        if not os.path.exists(self._report_dir):
-            os.makedirs(self._report_dir)
+        report_dir = None
+        if write_text_specs:
+            report_dir = generate_unique_folder_name(
+                report_directory, "reloaded_data_regions", "")
+            if not os.path.exists(report_dir):
+                os.makedirs(report_dir)
 
         application_vertices_to_reset = set()
 
@@ -79,7 +72,8 @@ class DSGRegionReloader(object):
 
             # Try to generate the data spec for the placement
             generated = self._regenerate_data_spec_for_vertices(
-                placement, placement.vertex)
+                placement, placement.vertex, transceiver, hostname, report_dir,
+                write_text_specs, app_data_dir)
 
             # If the region was regenerated, mark it reloaded
             if generated:
@@ -91,7 +85,8 @@ class DSGRegionReloader(object):
                 associated_vertex = graph_mapper.get_application_vertex(
                     placement.vertex)
                 generated = self._regenerate_data_spec_for_vertices(
-                    placement, associated_vertex)
+                    placement, associated_vertex, transceiver, hostname,
+                    report_dir, write_text_specs, app_data_dir)
 
                 # If the region was regenerated, remember the application
                 # vertex for resetting later
@@ -103,7 +98,12 @@ class DSGRegionReloader(object):
         for vertex in application_vertices_to_reset:
             vertex.mark_regions_reloaded()
 
-    def _regenerate_data_spec_for_vertices(self, placement, vertex):
+        # App data directory can be removed as should be empty
+        os.rmdir(app_data_dir)
+
+    def _regenerate_data_spec_for_vertices(
+            self, placement, vertex, txrx, hostname, report_dir, write_text,
+            app_data_dir):
         # If the vertex doesn't regenerate, skip
         if not isinstance(vertex, AbstractRewritesDataSpecification):
             return False
@@ -114,8 +114,8 @@ class DSGRegionReloader(object):
 
         # build the writers for the reports and data
         spec_file, spec = get_data_spec_and_file_writer_filename(
-            placement.x, placement.y, placement.p, self._hostname,
-            self._report_dir, self._write_text, self._app_data_dir)
+            placement.x, placement.y, placement.p, hostname,
+            report_dir, write_text, app_data_dir)
 
         # Execute the regeneration
         vertex.regenerate_data_specification(spec, placement)
@@ -132,19 +132,19 @@ class DSGRegionReloader(object):
             pass
 
         # Read the region table for the placement
-        regions_base_address = self._txrx.get_cpu_information_from_core(
+        regions_base_address = txrx.get_cpu_information_from_core(
             placement.x, placement.y, placement.p).user[0]
         start_region = get_region_base_address_offset(regions_base_address, 0)
         table_size = get_region_base_address_offset(
             regions_base_address, MAX_MEM_REGIONS) - start_region
         offsets = REGION_STRUCT.unpack_from(
-            self._txrx.read_memory(
+            txrx.read_memory(
                 placement.x, placement.y, start_region, table_size))
 
         # Write the regions to the machine
         for i, region in enumerate(data_spec_executor.dsef.mem_regions):
             if region is not None and not region.unfilled:
-                self._txrx.write_memory(
+                txrx.write_memory(
                     placement.x, placement.y, offsets[i],
                     region.region_data[:region.max_write_pointer])
 

--- a/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
@@ -1238,21 +1238,14 @@
                 <param_name>placements</param_name>
                 <param_type>MemoryPlacements</param_type>
             </parameter>
-            <parameter>
-                <param_name>provenance_data_objects</param_name>
-                <param_type>ProvenanceItems</param_type>
-            </parameter>
         </input_definitions>
         <required_inputs>
             <param_name>transceiver</param_name>
             <param_name>placements</param_name>
             <token>ApplicationRun</token>
         </required_inputs>
-        <optional_inputs>
-            <param_name>provenance_data_objects</param_name>
-        </optional_inputs>
         <outputs>
-            <param_type>ProvenanceItems</param_type>
+            <param_type>PlacementsProvenanceItems</param_type>
         </outputs>
     </algorithm>
     <algorithm name="GraphProvenanceGatherer">
@@ -1267,20 +1260,15 @@
                 <param_name>application_graph</param_name>
                 <param_type>MemoryApplicationGraph</param_type>
             </parameter>
-            <parameter>
-                <param_name>provenance_data_objects</param_name>
-                <param_type>ProvenanceItems</param_type>
-            </parameter>
         </input_definitions>
         <required_inputs>
             <param_name>machine_graph</param_name>
         </required_inputs>
         <optional_inputs>
             <param_name>application_graph</param_name>
-            <param_name>provenance_data_objects</param_name>
         </optional_inputs>
         <outputs>
-            <param_type>ProvenanceItems</param_type>
+            <param_type>GraphProvenanceItems</param_type>
         </outputs>
     </algorithm>
     <algorithm name="RouterProvenanceGatherer">
@@ -1301,10 +1289,6 @@
                 <param_type>MemoryRoutingTables</param_type>
             </parameter>
             <parameter>
-                <param_name>provenance_data_objects</param_name>
-                <param_type>ProvenanceItems</param_type>
-            </parameter>
-            <parameter>
                 <param_name>extra_monitor_vertices</param_name>
                 <param_type>MemoryExtraMonitorVertices</param_type>
             </parameter>
@@ -1320,12 +1304,11 @@
             <token>ApplicationRun</token>
         </required_inputs>
         <optional_inputs>
-            <param_name>provenance_data_objects</param_name>
             <param_name>extra_monitor_vertices</param_name>
             <param_name>placements</param_name>
         </optional_inputs>
         <outputs>
-            <param_type>ProvenanceItems</param_type>
+            <param_type>RouterProvenanceItems</param_type>
         </outputs>
     </algorithm>
     <algorithm name="ProvenanceXMLWriter">

--- a/spinn_front_end_common/interface/interface_functions/graph_provenance_gatherer.py
+++ b/spinn_front_end_common/interface/interface_functions/graph_provenance_gatherer.py
@@ -22,18 +22,14 @@ class GraphProvenanceGatherer(object):
     __slots__ = []
 
     def __call__(
-            self, machine_graph, application_graph=None,
-            provenance_data_objects=None):
+            self, machine_graph, application_graph=None):
         """
         :param machine_graph: The machine graph to inspect
         :param application_graph: The optional application graph
         :param provenance_data_objects: Any existing objects to append to
         """
 
-        if provenance_data_objects is not None:
-            prov_items = provenance_data_objects
-        else:
-            prov_items = list()
+        prov_items = list()
 
         progress = ProgressBar(
             machine_graph.n_vertices +

--- a/spinn_front_end_common/interface/interface_functions/placements_provenance_gatherer.py
+++ b/spinn_front_end_common/interface/interface_functions/placements_provenance_gatherer.py
@@ -24,17 +24,13 @@ logger = logging.getLogger(__name__)
 class PlacementsProvenanceGatherer(object):
     __slots__ = []
 
-    def __call__(
-            self, transceiver, placements, provenance_data_objects=None):
+    def __call__(self, transceiver, placements):
         """
         :param transceiver: the SpiNNMan interface object
         :param placements: The placements of the vertices
         """
 
-        if provenance_data_objects is not None:
-            prov_items = provenance_data_objects
-        else:
-            prov_items = list()
+        prov_items = list()
 
         progress = ProgressBar(
             placements.n_placements, "Getting provenance data")

--- a/spinn_front_end_common/interface/interface_functions/router_provenance_gatherer.py
+++ b/spinn_front_end_common/interface/interface_functions/router_provenance_gatherer.py
@@ -51,8 +51,7 @@ class RouterProvenanceGatherer(object):
 
     def __call__(
             self, transceiver, machine, router_tables,
-            provenance_data_objects=None, extra_monitor_vertices=None,
-            placements=None):
+            extra_monitor_vertices=None, placements=None):
         """
         :param transceiver: the SpiNNMan interface object
         :type transceiver: ~spinnman.transceiver.Transceiver
@@ -76,10 +75,7 @@ class RouterProvenanceGatherer(object):
         self._machine = machine
         self._placements = placements
 
-        if provenance_data_objects is not None:
-            prov_items = provenance_data_objects
-        else:
-            prov_items = list()
+        prov_items = list()
 
         prov_items.extend(self._write_router_provenance_data(
             router_tables, extra_monitor_vertices))


### PR DESCRIPTION
Fix for a student having issues with the hard disk filling up.  This is because the current provenance gathering builds up on every run, so you get repeats of the provenance in each file as the runs progress.  This PR fixes this, and also stops the reloading of regions from creating pointless folders.