### PR TITLE
run round up to nearest machine_time_step with info and warn if needed

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -792,7 +792,7 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
         if run_time is None:
             return None, None
         machine_time_step_ms = self.machine_time_step / \
-                               MICRO_TO_MILLISECOND_CONVERSION
+            MICRO_TO_MILLISECOND_CONVERSION
         n_machine_time_steps = math.ceil(run_time / machine_time_step_ms)
         calc_run_time = n_machine_time_steps * machine_time_step_ms
 
@@ -852,7 +852,7 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
 
         logger.info("Starting execution process")
 
-        n_machine_time_steps, total_run_time = self._calc_run_time( run_time)
+        n_machine_time_steps, total_run_time = self._calc_run_time(run_time)
         if self._machine_allocation_controller is not None:
             self._machine_allocation_controller.extend_allocation(
                 total_run_time)

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -56,6 +56,8 @@ from spinn_front_end_common.abstract_models import (
     AbstractCanReset)
 from spinn_front_end_common.utilities import (
     globals_variables, SimulatorInterface)
+from spinn_front_end_common.utilities.constants import (
+    MICRO_TO_MILLISECOND_CONVERSION)
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from spinn_front_end_common.utilities.function_list import (
     get_front_end_common_pacman_xml_paths)
@@ -771,6 +773,55 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
                 self._machine_graph.add_edge(
                     edge, outgoing_partition.identifier)
 
+    def _calc_run_time(self, run_time):
+        """
+        Calculates n_machine_time_steps and total_run_time based on run_time\
+        and machine_time_step
+
+        This method rounds the run up to the next timestep as discussed in\
+        https://github.com/SpiNNakerManchester/sPyNNaker/issues/149
+
+        If run_time is None (run forever) both values will be None
+
+        :param run_time: time user requested to run for in milliseconds
+        :type run_time: float or None
+        :return: n_machine_time_steps as a whole int and\
+            total_run_time in milliseconds
+        :rtype: (int,float) or (None, None)
+        """
+        if run_time is None:
+            return None, None
+        machine_time_step_ms = self.machine_time_step / \
+                               MICRO_TO_MILLISECOND_CONVERSION
+        n_machine_time_steps = math.ceil(run_time / machine_time_step_ms)
+        calc_run_time = n_machine_time_steps * machine_time_step_ms
+
+        # Allow for minor float errors
+        if abs(run_time - calc_run_time) > 0.00001:
+            logger.warning(
+                "Your requested runtime of {}ms "
+                "is not a multiple of the machine time step of {}ms "
+                "and has therefor been rounded up to {}ms",
+                run_time, machine_time_step_ms, calc_run_time)
+
+        total_run_timesteps = (
+            self._current_run_timesteps + n_machine_time_steps)
+        total_run_time = (
+            total_run_timesteps * machine_time_step_ms *
+            self.time_scale_factor)
+
+        # Convert dt into microseconds and divide by
+        # realtime proportion to get hardware timestep
+        hardware_timestep_us = int(round(
+            float(self.machine_time_step) / float(self.timescale_factor)))
+
+        logger.info(
+            "Simulating for {} {}ms timesteps "
+            "using a hardware timestep of {}us",
+            n_machine_time_steps,  machine_time_step_ms, hardware_timestep_us)
+
+        return n_machine_time_steps, total_run_time
+
     def _run(self, run_time, run_until_complete=False):
         """ The main internal run function
 
@@ -801,17 +852,7 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
 
         logger.info("Starting execution process")
 
-        n_machine_time_steps = None
-        total_run_time = None
-        if run_time is not None:
-            n_machine_time_steps = int(
-                (run_time * 1000.0) / self.machine_time_step)
-            total_run_timesteps = (
-                self._current_run_timesteps + n_machine_time_steps)
-            total_run_time = (
-                total_run_timesteps *
-                (float(self.machine_time_step) / 1000.0) *
-                self.time_scale_factor)
+        n_machine_time_steps, total_run_time = self._calc_run_time( run_time)
         if self._machine_allocation_controller is not None:
             self._machine_allocation_controller.extend_allocation(
                 total_run_time)


### PR DESCRIPTION
Fix for https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/issues/524
Based on choices made in https://github.com/SpiNNakerManchester/sPyNNaker/issues/149

Also moved the run log message so all runs with a time benefit.
Removed elsewhere in https://github.com/SpiNNakerManchester/sPyNNaker8/pull/315