### PR TITLE
avoid passing paths only used in error get from simulator

### DIFF
--- a/spinn_front_end_common/interface/interface_functions/chip_iobuf_extractor.py
+++ b/spinn_front_end_common/interface/interface_functions/chip_iobuf_extractor.py
@@ -25,6 +25,7 @@ from spinn_front_end_common.utilities.helpful_functions import (
     convert_string_into_chip_and_core_subset)
 from spinn_machine.core_subsets import CoreSubsets
 from spinnman.model.io_buffer import IOBuffer
+from spinn_front_end_common.utilities.globals_variables import get_simulator
 
 logger = FormatAdapter(logging.getLogger(__name__))
 ERROR_ENTRY = re.compile(r"\[ERROR\]\s+\((.*)\):\s+(.*)")
@@ -46,9 +47,20 @@ class ChipIOBufExtractor(object):
         self._recovery_mode = bool(recovery_mode)
 
     def __call__(
-            self, transceiver, executable_targets, executable_finder,
-            app_provenance_file_path, system_provenance_file_path,
-            binary_executable_types, from_cores="ALL", binary_types=None):
+            self, transceiver, executable_targets, executable_finder=None,
+            app_provenance_file_path=None, system_provenance_file_path=None,
+            binary_executable_types=None, from_cores="ALL", binary_types=None):
+
+        sim = get_simulator()
+        if executable_finder is None:
+            executable_finder = sim._executable_finder
+        if app_provenance_file_path is None:
+            app_provenance_file_path = sim._app_provenance_file_path
+        if system_provenance_file_path is None:
+            system_provenance_file_path = sim._system_provenance_file_path
+        if binary_executable_types is None:
+            binary_executable_types = \
+                sim._mapping_outputs["BinaryToExecutableType"]
 
         error_entries = list()
         warn_entries = list()

--- a/spinn_front_end_common/mapping_algorithms/front_end_common_mapping_algorithms.xml
+++ b/spinn_front_end_common/mapping_algorithms/front_end_common_mapping_algorithms.xml
@@ -38,17 +38,12 @@
                 <param_name>app_id</param_name>
                 <param_type>APPID</param_type>
             </parameter>
-            <parameter>
-                <param_name>system_provenance_folder</param_name>
-                <param_type>SystemProvenanceFilePath</param_type>
-            </parameter>
         </input_definitions>
         <required_inputs>
             <param_name>routing_tables</param_name>
             <param_name>transceiver</param_name>
             <param_name>machine</param_name>
             <param_name>app_id</param_name>
-            <param_name>system_provenance_folder</param_name>
         </required_inputs>
         <outputs>
             <token part="MulticastRoutesLoaded">DataLoaded</token>
@@ -77,10 +72,6 @@
                 <param_name>app_id</param_name>
                 <param_type>APPID</param_type>
             </parameter>
-            <parameter>
-                <param_name>provenance_file_path</param_name>
-                <param_type>ProvenanceFilePath</param_type>
-            </parameter>
         </input_definitions>
         <required_inputs>
             <param_name>routing_tables</param_name>
@@ -88,7 +79,6 @@
             <param_name>executable_finder</param_name>
             <param_name>machine</param_name>
             <param_name>app_id</param_name>
-            <param_name>provenance_file_path</param_name>
         </required_inputs>
         <outputs>
             <token part="MulticastRoutesLoaded">DataLoaded</token>

--- a/spinn_front_end_common/mapping_algorithms/on_chip_router_table_compression/compression.py
+++ b/spinn_front_end_common/mapping_algorithms/on_chip_router_table_compression/compression.py
@@ -34,7 +34,7 @@ _SDRAM_TAG = 1
 
 def mundy_on_chip_router_compression(
         routing_tables, transceiver, machine, app_id,
-        system_provenance_folder, compress_only_when_needed=True,
+        compress_only_when_needed=True,
         compress_as_much_as_possible=False):
     """
     Load routing tables and compress then using Mundy's algorithm
@@ -43,7 +43,6 @@ def mundy_on_chip_router_compression(
     :param transceiver: the spinnman interface
     :param machine: the SpiNNaker machine representation
     :param app_id: the application ID used by the main application
-    :param system_provenance_folder: the path to where to write the data
     :param compress_as_much_as_possible:\
         If False, the compressor will only reduce the table until it fits\
         in the router space, otherwise it will try to reduce until it\
@@ -60,15 +59,13 @@ def mundy_on_chip_router_compression(
     binary_path = os.path.join(os.path.dirname(__file__), "rt_minimise.aplx")
     compression = _Compression(
         app_id, binary_path, compress_as_much_as_possible,
-        compress_only_when_needed, machine, system_provenance_folder,
-        routing_tables, transceiver)
+        compress_only_when_needed, machine, routing_tables, transceiver)
     compression._compress()
 
 
 def pair_compression(
         routing_tables, transceiver, executable_finder,
-        machine, app_id, provenance_file_path,
-        compress_only_when_needed=False,
+        machine, app_id, compress_only_when_needed=False,
         compress_as_much_as_possible=True):
     """
     Load routing tables and compress then using Pair Algorithm
@@ -81,7 +78,6 @@ def pair_compression(
     :param executable_finder:
     :param machine: the SpiNNaker machine representation
     :param app_id: the application ID used by the main application
-    :param provenance_file_path: the path to where to write the data
     :param compress_as_much_as_possible:\
         If False, the compressor will only reduce the table until it fits\
         in the router space, otherwise it will try to reduce until it\
@@ -98,8 +94,7 @@ def pair_compression(
         "simple_minimise.aplx")
     compression = _Compression(
         app_id, binary_path, compress_as_much_as_possible,
-        compress_only_when_needed, machine, provenance_file_path,
-        routing_tables, transceiver)
+        compress_only_when_needed, machine, routing_tables, transceiver)
     compression._compress()
 
 
@@ -113,21 +108,18 @@ class _Compression(object):
                  "_compress_only_when_needed",
                  "_compressor_app_id",
                  "_machine",
-                 "_provenance_file_path",
                  "_transceiver",
                  "_routing_tables",
                  ]
 
     def __init__(
             self, app_id, binary_path, compress_as_much_as_possible,
-            compress_only_when_needed, machine, provenance_file_path,
-            routing_tables, transceiver):
+            compress_only_when_needed, machine, routing_tables, transceiver):
         self._app_id = app_id
         self._binary_path = binary_path
         self._compress_as_much_as_possible = compress_as_much_as_possible
         self._compress_only_when_needed = compress_only_when_needed
         self._machine = machine
-        self._provenance_file_path = provenance_file_path
         self._transceiver = transceiver
         self._routing_tables = routing_tables
 
@@ -217,8 +209,8 @@ class _Compression(object):
         iobuf_extractor = ChipIOBufExtractor()
         executable_finder = ExecutableFinder(binary_search_paths=[])
         io_errors, io_warnings = iobuf_extractor(
-            self._transceiver, executable_targets, executable_finder,
-            self._provenance_file_path)
+            self._transceiver, executable_targets, executable_finder)
+
         for warning in io_warnings:
             logger.warning(warning)
         for error in io_errors:

--- a/spinn_front_end_common/utilities/helpful_functions.py
+++ b/spinn_front_end_common/utilities/helpful_functions.py
@@ -367,12 +367,9 @@ def _emergency_iobuf_extract(txrx, executable_targets):
     # pylint: disable=protected-access
     from spinn_front_end_common.interface.interface_functions import (
         ChipIOBufExtractor)
-    sim = get_simulator()
     extractor = ChipIOBufExtractor(
         recovery_mode=True, filename_template="emergency_iobuf_{}_{}_{}.txt")
-    extractor(txrx, executable_targets, sim._executable_finder,
-              sim._app_provenance_file_path, sim._system_provenance_file_path,
-              sim._mapping_outputs["BinaryToExecutableType"])
+    extractor(txrx, executable_targets)
 
 
 def emergency_recover_state_from_failure(txrx, app_id, vertex, placement):

--- a/unittests/interface/interface_functions/test_router_compressor.py
+++ b/unittests/interface/interface_functions/test_router_compressor.py
@@ -75,5 +75,4 @@ def test_router_compressor_on_error():
     transceiver = MockTransceiverError()
     machine = virtual_machine(width=8, height=8)
     mundy_on_chip_router_compression(
-        routing_tables, transceiver, machine, app_id=17,
-        system_provenance_folder="")
+        routing_tables, transceiver, machine, app_id=17)


### PR DESCRIPTION
Why pass lots of variable in case there is an error.

Get them from where they are stored! the simulator!