### PR TITLE
move all uses of the application_generated_data_files to reports

### DIFF
--- a/fec_integration_tests/interface/interface_functions/test_memory_io.py
+++ b/fec_integration_tests/interface/interface_functions/test_memory_io.py
@@ -147,7 +147,7 @@ def test_memory_io():
         "MemoryMachineGraph": graph,
         "MemoryPlacements": placements,
         "IPAddress": "testing",
-        "ApplicationDataFolder": temp,
+        "ReportFolder": temp,
         "APPID": 30
     }
     algorithms = ["WriteMemoryIOData"]

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1500,7 +1500,6 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
             inputs['MemoryMachineGraph'] = self._machine_graph
 
         inputs['ReportFolder'] = self._report_default_directory
-        inputs["ApplicationDataFolder"] = self._app_data_runtime_folder
         inputs["ProvenanceFilePath"] = self._provenance_file_path
         inputs["AppProvenanceFilePath"] = self._app_provenance_file_path
         inputs["SystemProvenanceFilePath"] = self._system_provenance_file_path

--- a/spinn_front_end_common/interface/config_handler.py
+++ b/spinn_front_end_common/interface/config_handler.py
@@ -41,11 +41,6 @@ class ConfigHandler(object):
     """
 
     __slots__ = [
-        #
-        "_app_data_runtime_folder",
-
-        #
-        "_app_data_top_simulation_folder",
 
         # the interface to the cfg files. supports get get_int etc
         "_config",
@@ -110,8 +105,6 @@ class ConfigHandler(object):
         if max_machine_core is not None:
             Machine.set_max_cores_per_chip(max_machine_core)
 
-        self._app_data_runtime_folder = None
-        self._app_data_top_simulation_folder = None
         self._json_folder = None
         self._provenance_file_path = None
         self._report_default_directory = None
@@ -306,39 +299,6 @@ class ConfigHandler(object):
             now.year, now.month, now.day,
             now.hour, now.minute, now.second, now.microsecond)
 
-    def set_up_output_application_data_specifics(self, n_calls_to_run):
-        """
-        :param int n_calls_to_run:
-            the counter of how many times run has been called.
-        """
-        where_to_write_application_data_files = self._config.get(
-            "Reports", "default_application_data_file_path")
-        if where_to_write_application_data_files == "DEFAULT":
-            where_to_write_application_data_files = os.getcwd()
-
-        application_generated_data_file_folder = self.child_folder(
-            where_to_write_application_data_files, APP_DIRNAME)
-        # add time stamped folder for this run
-        self._app_data_top_simulation_folder = self.child_folder(
-            application_generated_data_file_folder, self._this_run_time_string)
-
-        # remove folders that are old and above the limit
-        self._remove_excess_folders(
-            self._config.getint("Reports", "max_application_binaries_kept"),
-            application_generated_data_file_folder)
-
-        # store timestamp in latest/time_stamp
-        time_of_run_file_name = os.path.join(
-            self._app_data_top_simulation_folder, TIMESTAMP_FILENAME)
-        with open(time_of_run_file_name, "w") as f:
-            f.writelines(str(self._this_run_time_string))
-
-        # create sub folder within reports for sub runs
-        # (where changes need to be recorded)
-        self._app_data_runtime_folder = self.child_folder(
-            self._app_data_top_simulation_folder, "run_{}".format(
-                n_calls_to_run))
-
     def _set_up_output_folders(self, n_calls_to_run):
         """ Sets up all outgoing folders by creating a new timestamp folder
             for each and clearing
@@ -350,9 +310,6 @@ class ConfigHandler(object):
 
         # set up reports default folder
         self._set_up_report_specifics(n_calls_to_run)
-
-        # set up application report folder
-        self.set_up_output_application_data_specifics(n_calls_to_run)
 
         if self._read_config_boolean("Reports",
                                      "writePacmanExecutorProvenance"):
@@ -387,14 +344,9 @@ class ConfigHandler(object):
         """ Write a finished file that allows file removal to only remove
             folders that are finished.
         """
-        app_file_name = os.path.join(self._app_data_top_simulation_folder,
-                                     FINISHED_FILENAME)
-        with open(app_file_name, "w") as f:
-            f.writelines("finished")
-
-        app_file_name = os.path.join(self._report_simulation_top_directory,
-                                     FINISHED_FILENAME)
-        with open(app_file_name, "w") as f:
+        report_file_name = os.path.join(self._report_simulation_top_directory,
+                                        FINISHED_FILENAME)
+        with open(report_file_name, "w") as f:
             f.writelines("finished")
 
     def _read_config(self, section, item):

--- a/spinn_front_end_common/interface/interface_functions/database_interface.py
+++ b/spinn_front_end_common/interface/interface_functions/database_interface.py
@@ -45,11 +45,11 @@ class DatabaseInterface(object):
             self, machine_graph, user_create_database, tags,
             runtime, machine, data_n_timesteps, time_scale_factor,
             machine_time_step, placements, routing_infos, router_tables,
-            database_directory, create_atom_to_event_id_mapping=False,
+            report_folder, create_atom_to_event_id_mapping=False,
             application_graph=None, graph_mapper=None):
         # pylint: disable=too-many-arguments
 
-        self._writer = DatabaseWriter(database_directory)
+        self._writer = DatabaseWriter(report_folder)
         self._user_create_database = user_create_database
         # add database generation if requested
         self._needs_db = self._writer.auto_detect_database(machine_graph)

--- a/spinn_front_end_common/interface/interface_functions/dsg_region_reloader.py
+++ b/spinn_front_end_common/interface/interface_functions/dsg_region_reloader.py
@@ -37,7 +37,7 @@ class DSGRegionReloader(object):
 
     def __call__(
             self, transceiver, placements, hostname, report_directory,
-            write_text_specs, application_data_file_path, graph_mapper=None):
+            write_text_specs, graph_mapper=None):
         """
         :param transceiver: SpiNNMan transceiver for communication
         :param placements: the list of placements of the machine graph to cores
@@ -45,8 +45,6 @@ class DSGRegionReloader(object):
         :param report_directory: the location where reports are stored
         :param write_text_specs:\
             True if the textual version of the specification is to be written
-        :param application_data_file_path:\
-            Folder where data specifications should be written to
         :param graph_mapper:\
             the mapping between application and machine graph
         """
@@ -54,7 +52,7 @@ class DSGRegionReloader(object):
 
         # build file paths for reloaded stuff
         app_data_dir = generate_unique_folder_name(
-            application_data_file_path, "reloaded_data_regions", "")
+            report_directory, "reloaded_data_regions", "")
         if not os.path.exists(app_data_dir):
             os.makedirs(app_data_dir)
 

--- a/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
@@ -498,10 +498,6 @@
                 <param_type>WriteTextSpecsFlag</param_type>
             </parameter>
             <parameter>
-                <param_name>application_data_file_path</param_name>
-                <param_type>ApplicationDataFolder</param_type>
-            </parameter>
-            <parameter>
                 <param_name>graph_mapper</param_name>
                 <param_type>MemoryGraphMapper</param_type>
             </parameter>
@@ -512,7 +508,6 @@
             <param_name>hostname</param_name>
             <param_name>report_directory</param_name>
             <param_name>write_text_specs</param_name>
-            <param_name>application_data_file_path</param_name>
         </required_inputs>
         <optional_inputs>
             <token part="DSGDataLoaded">DataLoaded</token>
@@ -1392,8 +1387,8 @@
                 <param_type>MemoryTags</param_type>
             </parameter>
             <parameter>
-                <param_name>database_directory</param_name>
-                <param_type>ApplicationDataFolder</param_type>
+                <param_name>report_folder</param_name>
+                <param_type>ReportFolder</param_type>
             </parameter>
             <parameter>
                 <param_name>runtime</param_name>
@@ -1445,7 +1440,7 @@
             <param_name>machine_graph</param_name>
             <param_name>user_create_database</param_name>
             <param_name>tags</param_name>
-            <param_name>database_directory</param_name>
+            <param_name>report_folder</param_name>
             <param_name>runtime</param_name>
             <param_name>machine</param_name>
             <param_name>data_n_timesteps</param_name>
@@ -1940,8 +1935,8 @@
                 <param_type>APPID</param_type>
             </parameter>
             <parameter>
-                <param_name>app_data_runtime_folder</param_name>
-                <param_type>ApplicationDataFolder</param_type>
+                <param_name>report_folder</param_name>
+                <param_type>ReportFolder</param_type>
             </parameter>
             <parameter>
                 <param_name>hostname</param_name>
@@ -1976,7 +1971,7 @@
             <param_name>graph</param_name>
             <param_name>placements</param_name>
             <param_name>app_id</param_name>
-            <param_name>app_data_runtime_folder</param_name>
+            <param_name>report_folder</param_name>
             <param_name>hostname</param_name>
         </required_inputs>
         <optional_inputs>

--- a/spinn_front_end_common/interface/interface_functions/write_memory_io_data.py
+++ b/spinn_front_end_common/interface/interface_functions/write_memory_io_data.py
@@ -74,7 +74,7 @@ class WriteMemoryIOData(object):
         self._use_monitors = False
 
     def __call__(
-            self, graph, placements, app_id, app_data_runtime_folder, hostname,
+            self, graph, placements, app_id, report_folder, hostname,
             transceiver=None, graph_mapper=None, uses_advanced_monitors=False,
             extra_monitor_cores_to_ethernet_connection_map=None,
             processor_to_app_data_base_address=None, machine=None):
@@ -82,7 +82,7 @@ class WriteMemoryIOData(object):
         :param graph: The graph to process
         :param placements: The placements of vertices of the graph
         :param app_id: The ID of the application
-        :param app_data_runtime_folder: The location of data files
+        :param report_folder: The location of data files
         :param hostname: The host name of the machine
         :param transceiver:\
             The transceiver to write data using; if None only data files\
@@ -102,7 +102,7 @@ class WriteMemoryIOData(object):
         self._txrx = transceiver
         self._use_monitors = uses_advanced_monitors
         self._monitor_map = extra_monitor_cores_to_ethernet_connection_map
-        self._data_folder = app_data_runtime_folder
+        self._data_folder = report_folder
 
         if isinstance(graph, ApplicationGraph):
             for placement in progress.over(placements.placements):

--- a/spinn_front_end_common/interface/spinnaker.cfg
+++ b/spinn_front_end_common/interface/spinnaker.cfg
@@ -70,10 +70,6 @@ write_json_partition_n_keys_map = False
 # Note for hard coded locations a "reports" sub directory will be added
 default_report_file_path = DEFAULT
 
-# options are DEFAULT, or a file path
-# Note for hard coded locations an "application_generated_data_files" sub directory is created
-default_application_data_file_path = DEFAULT
-
 max_reports_kept = 10
 max_application_binaries_kept = 10
 provenance_format = sql

--- a/spinn_front_end_common/interface/spinnaker.cfg.template
+++ b/spinn_front_end_common/interface/spinnaker.cfg.template
@@ -28,10 +28,6 @@ time_scale_factor = None
 # In all cases oldest folders are automatically deleted to max_reports_kept=
 default_report_file_path = DEFAULT
 
-# options are DEFAULT, or a file path
-# In all cases oldest folders are automatically deleted to max_reports_kept=
-default_application_data_file_path = DEFAULT
-
 [Mode]
 # mode = Production or Debug
 # In Debug mode all report boolean config values are automatically overwritten to True

--- a/unittests/interface/interface_functions/test_front_end_common_dsg_region_reloader.py
+++ b/unittests/interface/interface_functions/test_front_end_common_dsg_region_reloader.py
@@ -173,8 +173,7 @@ class TestFrontEndCommonDSGRegionReloader(unittest.TestCase):
 
         reloader = DSGRegionReloader()
         reloader.__call__(
-            transceiver, placements, "localhost", "test", False, "test",
-            graph_mapper)
+            transceiver, placements, "localhost", "test", False, graph_mapper)
 
         regions_rewritten = transceiver.regions_rewritten
 


### PR DESCRIPTION
The remain few mainly unused uses of the application_generated_data_files have been moved to the report dir and the app dir is now never used or created.

fixes https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/issues/552