### PR TITLE
Use bulk inserts for faster DB generation

### DIFF
--- a/spinn_front_end_common/interface/interface_functions/provenance_sql_writer.py
+++ b/spinn_front_end_common/interface/interface_functions/provenance_sql_writer.py
@@ -35,5 +35,4 @@ class ProvenanceSQLWriter(object):
         database_file = os.path.join(
             provenance_data_path, "provenance.sqlite3")
         with SqlLiteDatabase(database_file) as db:
-            for item in provenance_data_items:
-                db.insert_item(item)
+            db.insert_items(provenance_data_items)

--- a/spinn_front_end_common/interface/provenance/db.sql
+++ b/spinn_front_end_common/interface/provenance/db.sql
@@ -19,30 +19,42 @@ PRAGMA main.synchronous = OFF;
 -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -- A table assigning ids to sourcex names
 CREATE TABLE IF NOT EXISTS source(
-  source_id INTEGER PRIMARY KEY AUTOINCREMENT,
-	source_name STRING NOT NULL);
+    source_id INTEGER PRIMARY KEY AUTOINCREMENT,
+	source_name STRING UNIQUE NOT NULL);
 
 -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -- A table assigning ids to description names
 CREATE TABLE IF NOT EXISTS description(
-  description_id INTEGER PRIMARY KEY AUTOINCREMENT,
-	description_name STRING NOT NULL);
-
+    description_id INTEGER PRIMARY KEY AUTOINCREMENT,
+	description_name STRING UNIQUE NOT NULL);
 
 -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -- A table holding the values
 CREATE TABLE IF NOT EXISTS provenance(
-  provenance_id INTEGER PRIMARY KEY AUTOINCREMENT,
-  source_id INTEGER NOT NULL,
-  description_id INTEGER NOT NULL,
+    provenance_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_id INTEGER NOT NULL,
+    description_id INTEGER NOT NULL,
 	the_value INTEGER NOT NULL);
 
-
+-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+-- Glue the bits together to show the information that people think is here
 CREATE VIEW IF NOT EXISTS provenance_view AS
     SELECT source_id, description_id, provenance_id, source_name, description_name, the_value
     FROM source NATURAL JOIN description NATURAL JOIN provenance;
 
+-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+-- Compute some basic statistics over the provenance
 CREATE VIEW IF NOT EXISTS stats_view AS
-    SELECT case count(DISTINCT source_name) when 1 then source_name else "" end as source, description_name, min(the_value) as min, max(the_value) as max, avg(the_value) as avg, sum(the_value) as total, count(the_value) as count
+    SELECT
+    	CASE count(DISTINCT source_name)
+    	    WHEN 1 THEN source_name
+			ELSE ""
+		END AS source,
+    	description_name AS description,
+    	min(the_value) AS min,
+    	max(the_value) AS max,
+    	avg(the_value) AS avg,
+    	sum(the_value) AS total,
+    	count(the_value) AS count
     FROM source NATURAL JOIN description NATURAL JOIN provenance
-    group by description_name
+    GROUP BY description;

--- a/spinn_front_end_common/interface/provenance/sqllite_database.py
+++ b/spinn_front_end_common/interface/provenance/sqllite_database.py
@@ -88,7 +88,8 @@ class SqlLiteDatabase(object):
                 "INSERT OR IGNORE INTO source(source_name) VALUES(?)",
                 ((s,) for s in set(item.names[0] for item in items)))
             self._db.executemany(
-                "INSERT OR IGNORE INTO description(description_name) VALUES(?)",
+                "INSERT OR IGNORE INTO description(description_name) "
+                "VALUES(?)",
                 ((d,) for d in set(item.names[-1] for item in items)))
             self._db.executemany(
                 "INSERT INTO provenance(source_id, description_id, the_value) "

--- a/spinn_front_end_common/interface/provenance/sqllite_database.py
+++ b/spinn_front_end_common/interface/provenance/sqllite_database.py
@@ -17,6 +17,7 @@ import datetime
 import os
 import sqlite3
 import sys
+from spinn_utilities.ordered_set import OrderedSet
 
 
 if sys.version_info < (3,):
@@ -32,6 +33,10 @@ class SqlLiteDatabase(object):
     .. note::
         NOT THREAD SAFE ON THE SAME DB. \
         Threads can access different DBs just fine.
+
+    .. note::
+        This totally relies on the way SQLite's type affinities function.
+        You can't port to a different database engine without a lot of work.
     """
 
     __slots__ = [
@@ -41,7 +46,7 @@ class SqlLiteDatabase(object):
 
     def __init__(self, database_file=None):
         """
-        :param database_file: The name of a file that contains (or will\
+        :param str database_file: The name of a file that contains (or will\
             contain) an SQLite database holding the data. If omitted, an\
             unshared in-memory database will be used.
         :type database_file: str
@@ -55,13 +60,13 @@ class SqlLiteDatabase(object):
         self.close()
 
     def __enter__(self):
-        """ Start mehod is use in a with statement
+        """ Start method is use in a ``with`` statement
         """
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        """
-        End method if used in a with statement
+        """ End method if used in a ``with`` statement.
+
         :param exc_type:
         :param exc_val:
         :param exc_tb:
@@ -70,12 +75,15 @@ class SqlLiteDatabase(object):
         self.close()
 
     def close(self):
+        """ Finalises and closes the database.
+        """
         if self._db is not None:
             self._db.close()
             self._db = None
 
     def __init_db(self):
-        """ Set up the database if required. """
+        """ Set up the database if required.
+        """
         self._db.row_factory = sqlite3.Row
         self._db.text_factory = memoryview
         with open(_DDL_FILE) as f:
@@ -83,59 +91,50 @@ class SqlLiteDatabase(object):
         self._db.executescript(sql)
 
     def insert_items(self, items):
+        """ Does a bulk insert of the items into the database.
+
+        :param list(ProvenanceDataItem) items: The items to insert
+        """
         with self._db:
             self._db.executemany(
                 "INSERT OR IGNORE INTO source(source_name) VALUES(?)",
-                ((s,) for s in set(item.names[0] for item in items)))
+                self.__unique_names(items, 0))
             self._db.executemany(
                 "INSERT OR IGNORE INTO description(description_name) "
                 "VALUES(?)",
-                ((d,) for d in set(item.names[-1] for item in items)))
+                self.__unique_names(items, -1))
             self._db.executemany(
                 "INSERT INTO provenance(source_id, description_id, the_value) "
                 "VALUES((SELECT source_id FROM source WHERE source_name = ?), "
                 "(SELECT description_id FROM description "
                 "WHERE description_name = ?), ?)",
-                (self.__condition_row(item) for item in items))
+                map(self.__condition_row, items))
+
+    @staticmethod
+    def __unique_names(items, index):
+        """ Produces an iterable of 1-tuples of the *unique* names in at \
+            particular index into the provenance items' names.
+
+        :param iterable(ProvenanceDataItem) items: The prov items
+        :param int index: The index into the names
+        :rtype: iterable(tuple(str))
+        """
+        return ((name,) for name in OrderedSet(
+            item.names[index] for item in items))
 
     @staticmethod
     def __condition_row(item):
+        """ Converts a provenance item into the form ready for insert.
+
+        .. note::
+            This totally relies on the way SQLite's type affinities work.
+            In particular, we can store any old item type, which is very
+            convenient!
+
+        :param ProvenanceDataItem item: The prov item
+        :rtype: tuple(str, str, int or float or str)
+        """
         value = item.value
         if isinstance(value, datetime.timedelta):
             value = value.microseconds
         return item.names[0], item.names[-1], value
-
-    def insert_item(self, item):
-        with self._db:
-            cursor = self._db.cursor()
-            source_id = self.__get_source_id(cursor, item.names[0])
-            description_id = self.__get_description_id(cursor, item.names[-1])
-            value = item.value
-            if isinstance(value, datetime.timedelta):
-                value = value.microseconds
-            cursor.execute(
-                "INSERT INTO provenance(source_id, description_id, the_value) "
-                "VALUES(?, ?, ?)",
-                (source_id, description_id, str(value)))
-
-    def __get_source_id(self, cursor, source_name):
-        for row in cursor.execute(
-                "SELECT source_id FROM source "
-                + "WHERE source_name = ? ",
-                (source_name, )):
-            return row["source_id"]
-        cursor.execute(
-            "INSERT INTO source(source_name) VALUES(?)",
-            (source_name, ))
-        return cursor.lastrowid
-
-    def __get_description_id(self, cursor, description_name):
-        for row in cursor.execute(
-                "SELECT description_id FROM description "
-                + "WHERE description_name = ? ",
-                (description_name, )):
-            return row["description_id"]
-        cursor.execute(
-            "INSERT INTO description(description_name) VALUES(?)",
-            (description_name, ))
-        return cursor.lastrowid


### PR DESCRIPTION
This uses `insertmany` to do the insertions very quickly and hoists as much of the computation into the DB as possible. It also ensures that we perform the insertions within a single transaction, rather than using one transaction per insertion.