### PR TITLE
Dont require params and then insist they are None!

### DIFF
--- a/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
@@ -962,9 +962,14 @@
             </parameter>
         </input_definitions>
         <required_inputs>
-            <param_name>width</param_name>
-            <param_name>height</param_name>
-        </required_inputs>
+            <one_of>
+                <all_of>
+                   <param_name>width</param_name>
+                   <param_name>height</param_name>
+                </all_of>
+                <param_name>json_path</param_name>
+            </one_of>
+       </required_inputs>
         <optional_inputs>
             <param_name>version</param_name>
             <param_name>down_chips</param_name>


### PR DESCRIPTION
When I added an option to get a virtual machine from json I forgot to say width and height are not required.

Especially as the algorithm requires then to be None!