### PR TITLE
End without run bug

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1995,6 +1995,7 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
             logger.warning(
                 "Application will not actually be run as there is nothing to "
                 "actually run")
+            tokens.append("ApplicationRun")
         else:
             algorithms.append("ApplicationRunner")
 

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -2508,7 +2508,8 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
         self._state = Simulator_State.SHUTDOWN
 
         try:
-            if "NotificationInterface" in self._last_run_outputs:
+            if self._last_run_outputs and \
+                    "NotificationInterface" in self._last_run_outputs:
                 self._last_run_outputs["NotificationInterface"].close()
         except Exception:
             logger.exception(


### PR DESCRIPTION
This adds two small fixes.

self._last_run_outputs is only set by run so if it is is None we can assume not run so need for the confusing error.

Append token "ApplicationRun" if not running due to empty graph.
For some reason my system all of a sudden started giving token missing errors when trying to run BufferExtractor.
Unsure why this happened but this fixes it.