### PR TITLE
Move logic into query

### DIFF
--- a/spinn_front_end_common/interface/ds/ds_sqllite_database.py
+++ b/spinn_front_end_common/interface/ds/ds_sqllite_database.py
@@ -42,7 +42,6 @@ class DsSqlliteDatabase(object):
         :type init: bool or None
         """
         self._machine = machine
-        self._root_ethernet_id = None
         database_file = os.path.join(report_folder, DB_NAME)
 
         if init is None:

--- a/spinn_front_end_common/interface/provenance/sqllite_database.py
+++ b/spinn_front_end_common/interface/provenance/sqllite_database.py
@@ -31,7 +31,7 @@ class SqlLiteDatabase(object):
     """ Specific implementation of the Database for SQLite 3.
 
     .. note::
-        NOT THREAD SAFE ON THE SAME DB. \
+        NOT THREAD SAFE ON THE SAME DB.
         Threads can access different DBs just fine.
 
     .. note::
@@ -97,18 +97,25 @@ class SqlLiteDatabase(object):
         """
         with self._db:
             self._db.executemany(
-                "INSERT OR IGNORE INTO source(source_name) VALUES(?)",
-                self.__unique_names(items, 0))
+                """
+                INSERT OR IGNORE INTO source(source_name) VALUES(?)
+                """, self.__unique_names(items, 0))
             self._db.executemany(
-                "INSERT OR IGNORE INTO description(description_name) "
-                "VALUES(?)",
-                self.__unique_names(items, -1))
+                """
+                INSERT OR IGNORE INTO description(description_name)
+                VALUES(?)
+                """, self.__unique_names(items, -1))
             self._db.executemany(
-                "INSERT INTO provenance(source_id, description_id, the_value) "
-                "VALUES((SELECT source_id FROM source WHERE source_name = ?), "
-                "(SELECT description_id FROM description "
-                "WHERE description_name = ?), ?)",
-                map(self.__condition_row, items))
+                """
+                INSERT INTO provenance(
+                    source_id, description_id, the_value)
+                VALUES((
+                    SELECT source_id FROM source WHERE source_name = ?
+                ), (
+                    SELECT description_id FROM description
+                    WHERE description_name = ?
+                ), ?)
+                """, map(self.__condition_row, items))
 
     @staticmethod
     def __unique_names(items, index):

--- a/spinn_front_end_common/utilities/database/database_reader.py
+++ b/spinn_front_end_common/utilities/database/database_reader.py
@@ -65,8 +65,10 @@ class DatabaseReader(object):
         """
         return {row["event"]: row["atom"]
                 for row in self.__exec_all(
-                    "SELECT * FROM label_event_atom_view"
-                    " WHERE label = ?", label)}
+                    """
+                    SELECT * FROM label_event_atom_view
+                    WHERE label = ?
+                    """, label)}
 
     def get_atom_id_to_key_mapping(self, label):
         """ Get a mapping of atom ID to event key for a given vertex
@@ -77,22 +79,26 @@ class DatabaseReader(object):
         """
         return {row["atom"]: row["event"]
                 for row in self.__exec_all(
-                    "SELECT * FROM label_event_atom_view"
-                    " WHERE label = ?", label)}
+                    """
+                    SELECT * FROM label_event_atom_view
+                    WHERE label = ?
+                    """, label)}
 
     def get_live_output_details(self, label, receiver_label):
         """ Get the IP address, port and whether the SDP headers are to be\
             stripped from the output from a vertex
 
         :param str label: The label of the vertex
-        :return: tuple of (IP address, port, strip SDP)
-        :rtype: tuple(str, int, bool)
+        :return: tuple of (IP address, port, strip SDP, board address, tag)
+        :rtype: tuple(str, int, bool, str, int)
         """
         return self.__r2t(
             self.__exec_one(
-                "SELECT * FROM app_output_tag_view"
-                " WHERE pre_vertex_label = ? AND post_vertex_label LIKE ?",
-                label, str(receiver_label) + "%"),
+                """
+                SELECT * FROM app_output_tag_view
+                WHERE pre_vertex_label = ?
+                    AND post_vertex_label LIKE ?
+                """, label, str(receiver_label) + "%"),
             "ip_address", "port", "strip_sdp", "board_address", "tag")
 
     def get_live_input_details(self, label):
@@ -105,8 +111,10 @@ class DatabaseReader(object):
         """
         return self.__r2t(
             self.__exec_one(
-                "SELECT * FROM app_input_tag_view"
-                " WHERE application_label = ?", label),
+                """
+                SELECT * FROM app_input_tag_view
+                WHERE application_label = ?
+                """, label),
             "board_address", "port")
 
     def get_machine_live_output_details(self, label, receiver_label):
@@ -115,14 +123,16 @@ class DatabaseReader(object):
 
         :param str label: The label of the vertex
         :param str receiver_label:
-        :return: tuple of (IP address, port, strip SDP)
-        :rtype: tuple(str, int, bool)
+        :return: tuple of (IP address, port, strip SDP, board address, tag)
+        :rtype: tuple(str, int, bool, str, int)
         """
         return self.__r2t(
             self.__exec_one(
-                "SELECT * FROM machine_output_tag_view"
-                " WHERE pre_vertex_label = ? AND post_vertex_label LIKE ?",
-                label, str(receiver_label) + "%"),
+                """
+                SELECT * FROM machine_output_tag_view
+                WHERE pre_vertex_label = ?
+                    AND post_vertex_label LIKE ?
+                """, label, str(receiver_label) + "%"),
             "ip_address", "port", "strip_sdp", "board_address", "tag")
 
     def get_machine_live_input_details(self, label):
@@ -135,8 +145,10 @@ class DatabaseReader(object):
         """
         return self.__r2t(
             self.__exec_one(
-                "SELECT * FROM machine_input_tag_view"
-                " WHERE machine_label = ?", label),
+                """
+                SELECT * FROM machine_input_tag_view
+                WHERE machine_label = ?
+                """, label),
             "board_address", "port")
 
     def get_machine_live_output_key(self, label, receiver_label):
@@ -147,9 +159,11 @@ class DatabaseReader(object):
         """
         return self.__r2t(
             self.__exec_one(
-                "SELECT * FROM machine_edge_key_view"
-                " WHERE pre_vertex_label = ? AND post_vertex_label LIKE ?",
-                label, str(receiver_label) + "%"),
+                """
+                SELECT * FROM machine_edge_key_view
+                WHERE pre_vertex_label = ?
+                    AND post_vertex_label LIKE ?
+                """, label, str(receiver_label) + "%"),
             "key", "mask")
 
     def get_machine_live_input_key(self, label):
@@ -159,8 +173,10 @@ class DatabaseReader(object):
         """
         return self.__r2t(
             self.__exec_one(
-                "SELECT * FROM machine_edge_key_view"
-                " WHERE pre_vertex_label = ?", label),
+                """
+                SELECT * FROM machine_edge_key_view
+                WHERE pre_vertex_label = ?
+                """, label),
             "key", "mask")
 
     def get_n_atoms(self, label):
@@ -171,8 +187,10 @@ class DatabaseReader(object):
         :rtype: int
         """
         row = self.__exec_one(
-            "SELECT no_atoms FROM Application_vertices "
-            "WHERE vertex_label = ?", label)
+            """
+            SELECT no_atoms FROM Application_vertices
+            WHERE vertex_label = ?
+            """, label)
         return 0 if row is None else row["no_atoms"]
 
     def get_configuration_parameter_value(self, parameter_name):
@@ -183,8 +201,10 @@ class DatabaseReader(object):
         :rtype: float or None
         """
         row = self.__exec_one(
-            "SELECT value FROM configuration_parameters"
-            " WHERE parameter_id = ?", parameter_name)
+            """
+            SELECT value FROM configuration_parameters
+            WHERE parameter_id = ?
+            """, parameter_name)
         return None if row is None else float(row["value"])
 
     @staticmethod
@@ -199,8 +219,10 @@ class DatabaseReader(object):
         :rtype: tuple(int, int, int)
         """
         row = self.__exec_one(
-            "SELECT x, y, p FROM machine_vertex_placement"
-            " WHERE vertex_label = ?", label)
+            """
+            SELECT x, y, p FROM machine_vertex_placement
+            WHERE vertex_label = ?
+            """, label)
         return (None, None, None) if row is None else self.__xyp(row)
 
     def get_placements(self, label):
@@ -212,8 +234,10 @@ class DatabaseReader(object):
         """
 
         return [self.__xyp(row) for row in self.__exec_all(
-            "SELECT x, y, p FROM application_vertex_placements"
-            " WHERE vertex_label = ?", label)]
+            """
+            SELECT x, y, p FROM application_vertex_placements
+            WHERE vertex_label = ?
+            """, label)]
 
     def get_ip_address(self, x, y):
         """ Get an IP address to contact a chip
@@ -224,9 +248,11 @@ class DatabaseReader(object):
         :rtype: str or None
         """
         row = self.__exec_one(
-            "SELECT eth_ip_address FROM chip_eth_info"
-            " WHERE x = ? AND y = ? OR x = 0 AND y = 0"
-            " ORDER BY x DESC", x, y)
+            """
+            SELECT eth_ip_address FROM chip_eth_info
+            WHERE x = ? AND y = ? OR x = 0 AND y = 0
+            ORDER BY x DESC
+            """, x, y)
         # Should only fail if no machine is present!
         return None if row is None else row["eth_ip_address"]
 

--- a/spinn_front_end_common/utilities/database/database_writer.py
+++ b/spinn_front_end_common/utilities/database/database_writer.py
@@ -15,11 +15,8 @@
 
 import logging
 import os
-import sys
 import sqlite3
 from spinn_utilities.log import FormatAdapter
-from pacman.model.graphs.application.application_vertex import (
-    ApplicationVertex)
 from pacman.model.graphs.common import EdgeTrafficType
 from spinn_front_end_common.abstract_models import (
     AbstractProvidesKeyToAtomMapping, AbstractRecordable,
@@ -54,16 +51,16 @@ class DatabaseWriter(object):
         "_connection",
 
         # Mappings used to accelerate inserts
-        "_machine_to_id", "_vertex_to_id", "_edge_to_id"
+        "__machine_to_id", "__vertex_to_id", "__edge_to_id"
     ]
 
     def __init__(self, database_directory):
         self._done = False
         self._database_path = os.path.join(database_directory, DB_NAME)
         self._connection = None
-        self._machine_to_id = dict()
-        self._vertex_to_id = dict()
-        self._edge_to_id = dict()
+        self.__machine_to_id = dict()
+        self.__vertex_to_id = dict()
+        self.__edge_to_id = dict()
 
         # delete any old database
         if os.path.isfile(self._database_path):
@@ -114,234 +111,96 @@ class DatabaseWriter(object):
             sql = f.read()
             self._connection.executescript(sql)
 
-    def __insert_machine_layout(self, x_dimension, y_dimension):
-        return self.__insert(
-            "INSERT INTO Machine_layout("
-            "  x_dimension, y_dimension) "
-            "VALUES(?, ?)",
-            int(x_dimension), int(y_dimension))
-
-    def __insert_machine_chip(self, no_processors, chip, machine_id):
-        if not chip.virtual:
-            return self.__insert(
-                "INSERT INTO Machine_chip("
-                "  no_processors, chip_x, chip_y, machine_id,"
-                "  ip_address, nearest_ethernet_x, nearest_ethernet_y) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?)",
-                int(no_processors), int(chip.x), int(chip.y), int(machine_id),
-                chip.ip_address,
-                int(chip.nearest_ethernet_x), int(chip.nearest_ethernet_y))
-        else:
-            return self.__insert(
-                "INSERT INTO Machine_chip("
-                "  no_processors, chip_x, chip_y, machine_id) "
-                "VALUES (?, ?, ?, ?)",
-                int(no_processors), int(chip.x), int(chip.y), int(machine_id))
-
-    def __insert_processor(self, chip, machine_id, available_DTCM,
-                           available_CPU, physical_id):
-        # pylint: disable=too-many-arguments
-        return self.__insert(
-            "INSERT INTO Processor("
-            "  chip_x, chip_y, machine_id, available_DTCM, "
-            "  available_CPU, physical_id) "
-            "VALUES(?, ?, ?, ?, ?, ?)",
-            int(chip.x), int(chip.y), int(machine_id),
-            int(available_DTCM), int(available_CPU), int(physical_id))
-
-    def __insert_app_vertex(self, vertex, max_atoms, is_recording):
-        v_id = self.__insert(
-            "INSERT INTO Application_vertices("
-            "  vertex_label, vertex_class, no_atoms, max_atom_constrant,"
-            "  recorded) "
-            "VALUES(?, ?, ?, ?, ?)",
-            str(vertex.label), vertex.__class__.__name__,
-            int(vertex.n_atoms), int(max_atoms), int(is_recording))
-        self._vertex_to_id[vertex] = v_id
-        return v_id
-
-    def __insert_app_edge(self, edge):
-        e_id = self.__insert(
-            "INSERT INTO Application_edges ("
-            "  pre_vertex, post_vertex, edge_label, edge_class) "
-            "VALUES(?, ?, ?, ?)",
-            int(self._vertex_to_id[edge.pre_vertex]),
-            int(self._vertex_to_id[edge.post_vertex]),
-            str(edge.label), edge.__class__.__name__)
-        self._edge_to_id[edge] = e_id
-        return e_id
-
-    def __insert_app_graph_element(self, vertex, edge):
-        return self.__insert(
-            "INSERT INTO Application_graph ("
-            "  vertex_id, edge_id) "
-            "VALUES(?, ?)",
-            int(self._vertex_to_id[vertex]),
-            int(self._edge_to_id[edge]))
-
-    def __insert_cfg(self, parameter_id, value):
-        # NB: No type constraints on value; this is SQLite (not Sparta!)
-        return self.__insert(
-            "INSERT INTO configuration_parameters ("
-            "  parameter_id, value) "
-            "VALUES (?, ?)",
-            str(parameter_id), value)
-
-    def __insert_machine_vertex(self, vertex, cpu_used, sdram_used, dtcm_used):
-        v_id = self.__insert(
-            "INSERT INTO Machine_vertices ("
-            "  label, class, cpu_used, sdram_used, dtcm_used) "
-            "VALUES(?, ?, ?, ?, ?)",
-            str(vertex.label), vertex.__class__.__name__,
-            _extract_int(cpu_used.get_value()),
-            _extract_int(sdram_used),
-            _extract_int(dtcm_used))
-        self._vertex_to_id[vertex] = v_id
-        return v_id
-
-    def __insert_machine_edge(self, edge):
-        e_id = self.__insert(
-            "INSERT INTO Machine_edges ("
-            "  pre_vertex, post_vertex, label, class) "
-            "VALUES(?, ?, ?, ?)",
-            int(self._vertex_to_id[edge.pre_vertex]),
-            int(self._vertex_to_id[edge.post_vertex]),
-            str(edge.label), edge.__class__.__name__)
-        self._edge_to_id[edge] = e_id
-        return e_id
-
-    def __insert_machine_graph_element(self, vertex, edge):
-        return self.__insert(
-            "INSERT INTO Machine_graph ("
-            "  vertex_id, edge_id) "
-            "VALUES(?, ?)",
-            int(self._vertex_to_id[vertex]), int(self._edge_to_id[edge]))
-
-    def __insert_graph_mapper_vertex(
-            self, app_vertex, machine_vertex, vertex_slice):
-        return self.__insert(
-            "INSERT INTO graph_mapper_vertex ("
-            "  application_vertex_id, machine_vertex_id, "
-            "  lo_atom, hi_atom) "
-            "VALUES(?, ?, ?, ?)",
-            int(self._vertex_to_id[app_vertex]),
-            int(self._vertex_to_id[machine_vertex]),
-            int(vertex_slice.lo_atom), int(vertex_slice.hi_atom))
-
-    def __insert_graph_mapper_edge(self, app_edge, machine_edge):
-        return self.__insert(
-            "INSERT INTO graph_mapper_edges ("
-            "  application_edge_id, machine_edge_id) "
-            "VALUES(?, ?)",
-            int(self._edge_to_id[app_edge]),
-            int(self._edge_to_id[machine_edge]))
-
-    def __insert_placement(self, placement, machine_id):
-        return self.__insert(
-            "INSERT INTO Placements("
-            "  vertex_id, chip_x, chip_y, chip_p, machine_id) "
-            "VALUES(?, ?, ?, ?, ?)",
-            int(self._vertex_to_id[placement.vertex]),
-            int(placement.x), int(placement.y), int(placement.p),
-            int(machine_id))
-
-    def __insert_routing_info(self, edge, key_mask):
-        return self.__insert(
-            "INSERT INTO Routing_info("
-            "  edge_id, \"key\", mask) "
-            "VALUES(?, ?, ?)",
-            int(self._edge_to_id[edge]), int(key_mask.key), int(key_mask.mask))
-
-    def __insert_routing_entry(self, routing_table, counter, entry, route):
-        return self.__insert(
-            "INSERT INTO Routing_table("
-            "  chip_x, chip_y, position, key_combo, mask, route) "
-            "VALUES(?, ?, ?, ?, ?, ?)",
-            int(routing_table.x), int(routing_table.y), int(counter),
-            int(entry.routing_entry_key), int(entry.mask), int(route))
-
-    def __insert_ip_tag(self, vertex, ip_tag):
-        port = ip_tag.port
-        if port is None:
-            port = 0
-        return self.__insert(
-            "INSERT INTO IP_tags("
-            "  vertex_id, tag, board_address, ip_address,"
-            "  port, strip_sdp) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            int(self._vertex_to_id[vertex]),
-            int(ip_tag.tag), str(ip_tag.board_address),
-            str(ip_tag.ip_address), int(port),
-            1 if ip_tag.strip_sdp else 0)
-
-    def __insert_reverse_ip_tag(self, vertex, reverse_ip_tag):
-        port = reverse_ip_tag.port
-        if port is None:
-            port = 0
-        return self.__insert(
-            "INSERT INTO Reverse_IP_tags("
-            "  vertex_id, tag, board_address, port) "
-            "VALUES (?, ?, ?, ?)",
-            int(self._vertex_to_id[vertex]), int(reverse_ip_tag.tag),
-            str(reverse_ip_tag.board_address), int(port))
-
-    def __insert_event_atom_mapping(self, vertex, event_id, atom_id):
-        return self.__insert(
-            "INSERT INTO event_to_atom_mapping("
-            "  vertex_id, event_id, atom_id) "
-            "VALUES (?, ?, ?)",
-            int(self._vertex_to_id[vertex]), int(event_id), int(atom_id))
-
     def add_machine_objects(self, machine):
         """ Store the machine object into the database
 
-        :param machine: the machine object.
+        :param ~spinn_machine.Machine machine: the machine object.
         :rtype: None
         """
         with self._connection:
-            self._machine_to_id[machine] = self.__insert_machine_layout(
-                machine.max_chip_x + 1, machine.max_chip_y + 1)
-            self._machine_id += 1
-            for chip in machine.chips:
-                self.__insert_machine_chip(
-                    len(list(chip.processors)), chip, self._machine_id)
-                for processor in chip.processors:
-                    self.__insert_processor(
-                        chip, self._machine_id,
-                        processor.dtcm_available,
-                        processor.cpu_cycles_available,
-                        processor.processor_id)
+            self.__machine_to_id[machine] = self._machine_id = self.__insert(
+                """
+                INSERT INTO Machine_layout(
+                    x_dimension, y_dimension)
+                VALUES(?, ?)
+                """, machine.width, machine.height)
+            self._connection.executemany(
+                """
+                INSERT INTO Machine_chip(
+                    no_processors, chip_x, chip_y, machine_id)
+                VALUES (?, ?, ?, ?)
+                """, (
+                    (chip.n_processors, chip.x, chip.y, self._machine_id)
+                    for chip in machine.chips if chip.virtual))
+            self._connection.executemany(
+                """
+                INSERT INTO Machine_chip(
+                    no_processors, chip_x, chip_y, machine_id,
+                    ip_address, nearest_ethernet_x, nearest_ethernet_y)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """, (
+                    (chip.n_processors, chip.x, chip.y, self._machine_id,
+                     chip.ip_address,
+                     chip.nearest_ethernet_x, chip.nearest_ethernet_y)
+                    for chip in machine.chips if not chip.virtual))
+            self._connection.insertmany(
+                """
+                INSERT INTO Processor(
+                    chip_x, chip_y, machine_id, available_DTCM,
+                    available_CPU, physical_id)
+                VALUES(?, ?, ?, ?, ?, ?)
+                """, (
+                    (chip.x, chip.y, self._machine_id, proc.dtcm_available,
+                     proc.cpu_cycles_available, proc.processor_id)
+                    for chip in machine.chips
+                    for proc in chip.processors))
 
     def add_application_vertices(self, application_graph):
         """
 
-        :param application_graph:
+        :param application_graph: not None
+        :type application_graph:
+            ~pacman.model.graphs.application.ApplicationGraph
         :rtype: None
         """
         with self._connection:
             # add vertices
             for vertex in application_graph.vertices:
-                if isinstance(vertex, AbstractRecordable):
-                    self.__insert_app_vertex(
-                        vertex, vertex.get_max_atoms_per_core(),
-                        vertex.is_recording_spikes())
-                elif isinstance(vertex, ApplicationVertex):
-                    self.__insert_app_vertex(
-                        vertex, vertex.get_max_atoms_per_core(), 0)
-                else:
-                    self.__insert_app_vertex(vertex, sys.maxsize, 0)
+                self.__vertex_to_id[vertex] = self.__insert(
+                    """
+                    INSERT INTO Application_vertices(
+                        vertex_label, vertex_class, no_atoms,
+                        max_atom_constrant, recorded)
+                    VALUES(?, ?, ?, ?, ?)
+                    """,
+                    vertex.label, vertex.__class__.__name__, vertex.n_atoms,
+                    vertex.get_max_atoms_per_core(), int(
+                        isinstance(vertex, AbstractRecordable) and
+                        vertex.is_recording()))
 
             # add edges
-            for vertex in application_graph.vertices:
-                for edge in application_graph.\
-                        get_edges_starting_at_vertex(vertex):
-                    self.__insert_app_edge(edge)
+            for edge in application_graph.edges:
+                self.__edge_to_id[edge] = self.__insert(
+                    """
+                    INSERT INTO Application_edges (
+                        pre_vertex, post_vertex, edge_label, edge_class)
+                    VALUES(?, ?, ?, ?)
+                    """,
+                    self.__vertex_to_id[edge.pre_vertex],
+                    self.__vertex_to_id[edge.post_vertex],
+                    edge.label, edge.__class__.__name__)
 
             # update graph
-            for vertex in application_graph.vertices:
-                for edge in application_graph.\
-                        get_edges_starting_at_vertex(vertex):
-                    self.__insert_app_graph_element(vertex, edge)
+            self._connection.executemany(
+                """
+                INSERT INTO Application_graph (
+                    vertex_id, edge_id)
+                VALUES(?, ?)
+                """, (
+                    (self.__vertex_to_id[vertex], self.__edge_to_id[edge])
+                    for vertex in application_graph.vertices
+                    for edge in application_graph.get_edges_starting_at_vertex(
+                        vertex)))
 
     def add_system_params(self, time_scale_factor, machine_time_step, runtime):
         """ Write system params into the database
@@ -351,14 +210,16 @@ class DatabaseWriter(object):
         :param runtime: the amount of time the application is to run for
         """
         with self._connection:
-            self.__insert_cfg("machine_time_step", machine_time_step)
-            self.__insert_cfg("time_scale_factor", time_scale_factor)
-            if runtime is not None:
-                self.__insert_cfg("infinite_run", "False")
-                self.__insert_cfg("runtime", runtime)
-            else:
-                self.__insert_cfg("infinite_run", "True")
-                self.__insert_cfg("runtime", -1)
+            self._connection.executemany(
+                """
+                INSERT INTO configuration_parameters (
+                    parameter_id, value)
+                VALUES (?, ?)
+                """, [
+                    ("machine_time_step", machine_time_step),
+                    ("time_scale_factor", time_scale_factor),
+                    ("infinite_run", str(runtime is None)),
+                    ("runtime", -1 if runtime is None else runtime)])
 
     def add_vertices(self, machine_graph, data_n_timesteps, graph_mapper,
                      application_graph):
@@ -375,32 +236,67 @@ class DatabaseWriter(object):
         with self._connection:
             for vertex in machine_graph.vertices:
                 req = vertex.resources_required
-                self.__insert_machine_vertex(
-                    vertex, req.cpu_cycles,
-                    req.sdram.get_total_sdram(data_n_timesteps),
-                    req.dtcm.get_value())
+                self.__vertex_to_id[vertex] = self.__insert(
+                    """
+                    INSERT INTO Machine_vertices (
+                        label, class, cpu_used, sdram_used, dtcm_used)
+                    VALUES(?, ?, ?, ?, ?)
+                    """,
+                    str(vertex.label), vertex.__class__.__name__,
+                    _extract_int(req.cpu_cycles.get_value()),
+                    _extract_int(req.sdram.get_total_sdram(data_n_timesteps)),
+                    _extract_int(req.dtcm.get_value()))
 
             # add machine edges
             for edge in machine_graph.edges:
-                self.__insert_machine_edge(edge)
+                self.__edge_to_id[edge] = self.__insert(
+                    """
+                    INSERT INTO Machine_edges (
+                        pre_vertex, post_vertex, label, class)
+                    VALUES(?, ?, ?, ?)
+                    """,
+                    self.__vertex_to_id[edge.pre_vertex],
+                    self.__vertex_to_id[edge.post_vertex],
+                    edge.label, edge.__class__.__name__)
 
             # add to machine graph
-            for vertex in machine_graph.vertices:
-                for edge in machine_graph.get_edges_starting_at_vertex(vertex):
-                    self.__insert_machine_graph_element(vertex, edge)
+            self._connection.executemany(
+                """
+                INSERT INTO Machine_graph (
+                    vertex_id, edge_id)
+                VALUES(?, ?)
+                """, (
+                    (self.__vertex_to_id[vertex], self.__edge_to_id[edge])
+                    for vertex in machine_graph.vertices
+                    for edge in machine_graph.get_edges_starting_at_vertex(
+                        vertex)))
 
             if application_graph is not None:
-                for machine_vertex in machine_graph.vertices:
-                    app_vertex = graph_mapper.get_application_vertex(
-                        machine_vertex)
-                    self.__insert_graph_mapper_vertex(
-                        app_vertex, machine_vertex,
-                        graph_mapper.get_slice(machine_vertex))
+                self._connection.executemany(
+                    """
+                    INSERT INTO graph_mapper_vertex (
+                        application_vertex_id, machine_vertex_id, lo_atom,
+                        hi_atom)
+                    VALUES(?, ?, ?, ?)
+                    """, (
+                        (self.__vertex_to_id[
+                             graph_mapper.get_application_vertex(vertex)],
+                         self.__vertex_to_id[vertex],
+                         graph_mapper.get_slice(vertex).lo_atom,
+                         graph_mapper.get_slice(vertex).hi_atom)
+                        for vertex in machine_graph.vertices))
 
                 # add graph_mapper edges
-                for edge in machine_graph.edges:
-                    self.__insert_graph_mapper_edge(
-                        graph_mapper.get_application_edge(edge), edge)
+                self._connection.executemany(
+                    """
+                    INSERT INTO graph_mapper_edges (
+                        application_edge_id, machine_edge_id)
+                    VALUES(?, ?)
+                    """, (
+                        (self.__edge_to_id[
+                             graph_mapper.get_application_edge(edge)],
+                         self.__edge_to_id[edge])
+                        for edge in machine_graph.edges))
 
     def add_placements(self, placements):
         """ Adds the placements objects into the database
@@ -411,8 +307,15 @@ class DatabaseWriter(object):
         """
         with self._connection:
             # add records
-            for placement in placements.placements:
-                self.__insert_placement(placement, self._machine_id)
+            self._connection.executemany(
+                """
+                INSERT INTO Placements(
+                    vertex_id, chip_x, chip_y, chip_p, machine_id)
+                VALUES(?, ?, ?, ?, ?)
+                """, (
+                    (self.__vertex_to_id[placement.vertex],
+                     placement.x, placement.y, placement.p, self._machine_id)
+                    for placement in placements.placements))
 
     def add_routing_infos(self, routing_infos, machine_graph):
         """ Adds the routing information (key masks etc) into the database
@@ -421,14 +324,23 @@ class DatabaseWriter(object):
         :param machine_graph: the machine graph object
         :rtype: None:
         """
+        # Filter just the MULTICAST partitions first
+        partitions_and_routing_info = (
+            (partition, routing_infos.get_routing_info_from_partition(
+                partition))
+            for partition in machine_graph.outgoing_edge_partitions
+            if partition.traffic_type == EdgeTrafficType.MULTICAST)
         with self._connection:
-            for partition in machine_graph.outgoing_edge_partitions:
-                if partition.traffic_type == EdgeTrafficType.MULTICAST:
-                    rinfo = routing_infos.get_routing_info_from_partition(
-                        partition)
-                    for edge in partition.edges:
-                        for key_mask in rinfo.keys_and_masks:
-                            self.__insert_routing_info(edge, key_mask)
+            self._connection.executemany(
+                """
+                INSERT INTO Routing_info(
+                    edge_id, "key", mask)
+                VALUES(?, ?, ?)
+                """, (
+                    (self.__edge_to_id[edge], key_mask.key, key_mask.mask)
+                    for partition, rinfo in partitions_and_routing_info
+                    for edge in partition.edges
+                    for key_mask in rinfo.keys_and_masks))
 
     def add_routing_tables(self, routing_tables):
         """ Adds the routing tables into the database
@@ -437,16 +349,18 @@ class DatabaseWriter(object):
         :rtype: None
         """
         with self._connection:
-            for routing_table in routing_tables.routing_tables:
-                for counter, entry in \
-                        enumerate(routing_table.multicast_routing_entries):
-                    route_entry = 0
-                    for processor_id in entry.processor_ids:
-                        route_entry |= 1 << (6 + processor_id)
-                    for link_id in entry.link_ids:
-                        route_entry |= 1 << link_id
-                    self.__insert_routing_entry(
-                        routing_table, counter, entry, route_entry)
+            self._connection.executemany(
+                """
+                INSERT INTO Routing_table(
+                    chip_x, chip_y, position, key_combo, mask, route)
+                VALUES(?, ?, ?, ?, ?, ?)
+                """, (
+                    (routing_table.x, routing_table.y, counter,
+                     entry.routing_entry_key, entry.mask,
+                     entry.spinnaker_route)
+                    for routing_table in routing_tables.routing_tables
+                    for counter, entry in
+                    enumerate(routing_table.multicast_routing_entries)))
 
     def add_tags(self, machine_graph, tags):
         """ Adds the tags into the database
@@ -457,15 +371,26 @@ class DatabaseWriter(object):
         """
         with self._connection:
             for vertex in machine_graph.vertices:
-                ip_tags = tags.get_ip_tags_for_vertex(vertex)
-                if ip_tags is not None:
-                    for ip_tag in ip_tags:
-                        self.__insert_ip_tag(vertex, ip_tag)
-                reverse_ip_tags = tags.get_reverse_ip_tags_for_vertex(
-                    vertex)
-                if reverse_ip_tags is not None:
-                    for reverse_ip_tag in reverse_ip_tags:
-                        self.__insert_reverse_ip_tag(vertex, reverse_ip_tag)
+                v_id = self.__vertex_to_id[vertex]
+                self._connection.executemany(
+                    """
+                    INSERT INTO IP_tags(
+                        vertex_id, tag, board_address, ip_address, port,
+                        strip_sdp)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """, (
+                        (v_id, ipt.tag, ipt.board_address, ipt.ip_address,
+                         ipt.port or 0, 1 if ipt.strip_sdp else 0)
+                        for ipt in tags.get_ip_tags_for_vertex(vertex) or []))
+                self._connection.executemany(
+                    """
+                    INSERT INTO Reverse_IP_tags(
+                        vertex_id, tag, board_address, port)
+                    VALUES (?, ?, ?, ?)
+                    """, (
+                        (v_id, ript.tag, ript.board_address, ript.port or 0)
+                        for ript in tags.get_reverse_ip_tags_for_vertex(
+                            vertex) or ()))
 
     def create_atom_to_event_id_mapping(
             self, application_graph, machine_graph, routing_infos,
@@ -478,33 +403,33 @@ class DatabaseWriter(object):
         :param graph_mapper:
         :rtype: None
         """
-        have_app_graph = (application_graph is not None and
-                          application_graph.n_vertices != 0)
-        with self._connection:
-            for vertex in machine_graph.vertices:
+        if application_graph is not None and application_graph.n_vertices:
+            # We will be asking application vertices for key/atom mappings
+            vertices_and_partitions = (
+                (graph_mapper.get_application_vertex(vertex), partition)
+                for vertex in machine_graph.vertices
                 for partition in machine_graph.\
-                        get_outgoing_edge_partitions_starting_at_vertex(
-                            vertex):
-                    if have_app_graph:
-                        self._insert_vertex_atom_to_key_map(
-                            graph_mapper.get_application_vertex(vertex),
-                            partition, routing_infos)
-                    else:
-                        self._insert_vertex_atom_to_key_map(
-                            vertex, partition, routing_infos)
+                    get_outgoing_edge_partitions_starting_at_vertex(vertex))
+        else:
+            # We will be asking machine vertices for key/atom mappings
+            vertices_and_partitions = (
+                (vertex, partition)
+                for vertex in machine_graph.vertices
+                for partition in machine_graph.\
+                    get_outgoing_edge_partitions_starting_at_vertex(vertex))
 
-    def _insert_vertex_atom_to_key_map(
-            self, vertex, partition, routing_infos):
-        """
-
-        :param vertex:
-        :param partition:
-        :param routing_infos:
-        :rtype: None
-        """
-        if isinstance(vertex, AbstractProvidesKeyToAtomMapping):
-            routing_info = routing_infos.get_routing_info_from_partition(
-                partition)
-            for atom_id, key in vertex.routing_key_partition_atom_mapping(
-                    routing_info, partition):
-                self.__insert_event_atom_mapping(vertex, key, atom_id)
+        vtxids_keys_atomids = (
+            (self.__vertex_to_id[vertex], key, atom_id)
+            for vertex, partition in vertices_and_partitions
+            if isinstance(vertex, AbstractProvidesKeyToAtomMapping)
+            for atom_id, key in vertex.\
+                routing_key_partition_atom_mapping(
+                    routing_infos.get_routing_info_from_partition(
+                        partition), partition))
+        with self._connection:
+            self._connection.executemany(
+                """
+                INSERT INTO event_to_atom_mapping(
+                    vertex_id, event_id, atom_id)
+                VALUES (?, ?, ?)
+                """, vtxids_keys_atomids)

--- a/spinn_front_end_common/utilities/database/database_writer.py
+++ b/spinn_front_end_common/utilities/database/database_writer.py
@@ -425,7 +425,7 @@ class DatabaseWriter(object):
                     vertex_id, event_id, atom_id)
                 VALUES (?, ?, ?)
                 """, (
-                    (self.__vertex_to_id[vtx], key, a_id)
+                    (self.__vertex_to_id[vtx], int(key), int(a_id))
                     for vtx, prtn in vertices_and_partitions
                     if isinstance(vtx, AbstractProvidesKeyToAtomMapping)
                     for a_id, key in vtx.routing_key_partition_atom_mapping(

--- a/spinn_front_end_common/utilities/database/database_writer.py
+++ b/spinn_front_end_common/utilities/database/database_writer.py
@@ -143,7 +143,7 @@ class DatabaseWriter(object):
                      chip.ip_address,
                      chip.nearest_ethernet_x, chip.nearest_ethernet_y)
                     for chip in machine.chips if not chip.virtual))
-            self._connection.insertmany(
+            self._connection.executemany(
                 """
                 INSERT INTO Processor(
                     chip_x, chip_y, machine_id, available_DTCM,

--- a/spinn_front_end_common/utilities/utility_objs/data_written.py
+++ b/spinn_front_end_common/utilities/utility_objs/data_written.py
@@ -49,3 +49,7 @@ class DataWritten(object):
         return (self._start_address == other.start_address and
                 self._memory_used == other.memory_used and
                 self._memory_written == other.memory_written)
+
+    def __repr__(self):
+        return "DataWritten(start={},used={},written={})".format(
+            self._start_address, self._memory_used, self.memory_written)


### PR DESCRIPTION
This avoids a two-stage query for inserting data by moving the lookup of ethernet IDs into the relevant inserts.