### PR TITLE
Cheaper disable/enable of interrupts in logging

### DIFF
--- a/c_common/front_end_common_lib/include/debug.h
+++ b/c_common/front_end_common_lib/include/debug.h
@@ -110,11 +110,11 @@ static inline uint32_t double_to_upper(double d) {
 //! \param[in] message The user-defined part of the debug message.
 #define __log_mini(level, message, ...) \
     do {                                                  \
-	    uint _debug_cpsr = spin1_int_disable();           \
 	    if (level <= LOG_LEVEL) {                         \
+	        uint _debug_cpsr = spin1_int_disable();       \
 	        fprintf(stderr, message "\n", ##__VA_ARGS__); \
+	        spin1_mode_restore(_debug_cpsr);              \
 	    }                                                 \
-	    spin1_mode_restore(_debug_cpsr);                  \
     } while (0)
 
 //! \brief This macro logs errors.


### PR DESCRIPTION
Because interrupt manipulation *cannot* be optimised out by the compiler (as it doesn't really understand it) the placement of calls outside the check of whether a logging call would be done meant that every log call, even the disabled ones, resulted in two expensive calls being inserted. We really don't want that!

Was caused by insufficient caution in the review of #577