### PR TITLE
Real bitfields in C

### DIFF
--- a/c_common/models/system_models/src/common.h
+++ b/c_common/models/system_models/src/common.h
@@ -21,9 +21,9 @@
 //
 // ------------------------------------------------------------------------
 
-#ifndef __COMMON_H__
-#define __COMMON_H__
-#include "common-typedefs.h"
+#ifndef __FEC_COMMON_H__
+#define __FEC_COMMON_H__
+#include <common-typedefs.h>
 
 // Dropped packet re-injection internal control commands (RC of SCP message)
 enum reinjector_command_codes {
@@ -44,10 +44,10 @@ typedef enum {
     REINJECTOR_CLEAR_QUEUE_OFFSET = 2,
 } reinjector_key_offsets;
 
-enum {
+typedef enum {
     //! How many payload words are in an SDP packet.
     ITEMS_PER_DATA_PACKET = 68
-};
+} packet_sizes;
 
 // ------------------------------------------------------------------------
 // structs used in system
@@ -116,4 +116,4 @@ static inline void reflect_sdp_message(sdp_msg_t *msg, uint body_length) {
     msg->srce_addr = dest_addr;
 }
 
-#endif  // __COMMON_H__
+#endif  // __FEC_COMMON_H__

--- a/c_common/models/system_models/src/data_speed_up_packet_gatherer.c
+++ b/c_common/models/system_models/src/data_speed_up_packet_gatherer.c
@@ -78,7 +78,7 @@ enum {
 #define ALL_MISSING_FLAG 0xFFFFFFFE
 
 // mask needed by router timeout
-#define ROUTER_TIMEOUT_MASK 0xFF
+#define ROUTER_TIMEOUT_MAX 0xFF
 
 enum {
     //! offset with just command transaction id and seq in bytes
@@ -212,7 +212,7 @@ typedef struct data_in_config_t {
 
 //! \brief writes the updated transaction id to the user1
 static void set_transaction_id_to_user_1(int transaction_id) {
-// Get pointer to 1st virtual processor info struct in SRAM
+    // Get pointer to 1st virtual processor info struct in SRAM
     vcpu_t *virtual_processor_table = (vcpu_t*) SV_VCPU;
 
     // Get the address this core's DTCM data starts at from the user data
@@ -576,7 +576,7 @@ static void data_in_receive_sdp_data(sdp_msg_pure_data *msg) {
 //! \param[in] key: the mc key to use here
 //! \return the length of extra data put into the message for return
 static void send_timeout(sdp_msg_t* msg, uint32_t key) {
-    if (msg->arg1 > ROUTER_TIMEOUT_MASK) {
+    if (msg->arg1 > ROUTER_TIMEOUT_MAX) {
         msg->cmd_rc = RC_ARG;
         return;
     }

--- a/c_common/models/system_models/src/extra_monitor_support.c
+++ b/c_common/models/system_models/src/extra_monitor_support.c
@@ -230,14 +230,6 @@ enum missing_seq_num_sdp_data_positions {
     START_OF_MISSING_SEQ_NUMS = 3,
 };
 
-//! flag positions for packet types being reinjected
-enum reinjection_flag_positions {
-    DPRI_PACKET_TYPE_MC = 1 << PKT_TYPE_MC,
-    DPRI_PACKET_TYPE_PP = 1 << PKT_TYPE_PP,
-    DPRI_PACKET_TYPE_NN = 1 << PKT_TYPE_NN,
-    DPRI_PACKET_TYPE_FR = 1 << PKT_TYPE_FR
-};
-
 //! defintion of response packet for reinjector status
 typedef struct reinjector_status_response_packet_t {
     uint router_timeout;

--- a/c_common/models/system_models/src/extra_monitor_support.c
+++ b/c_common/models/system_models/src/extra_monitor_support.c
@@ -406,7 +406,7 @@ static inline void vic_set_callback(
     vic_interrupt_control[slot] = (vic_vector_control_t) {
         // Enable a particular interrupt source
         .source = type,
-        .enable = true
+        .enable = true,
     };
 }
 
@@ -430,13 +430,13 @@ static inline void vic_signal_interrupt_done(void) {
 
 static inline void enable_comms_ready_to_send_interrupt(void) {
     vic_control->int_enable = (vic_mask_t) {
-        .cc_tx_not_full = true
+        .cc_tx_not_full = true,
     };
 }
 
 static inline void disable_comms_ready_to_send_interrupt(void) {
     vic_control->int_disable = (vic_mask_t) {
-        .cc_tx_not_full = true
+        .cc_tx_not_full = true,
     };
 }
 
@@ -1094,13 +1094,12 @@ static inline void send_fixed_route_packet(uint32_t key, uint32_t data) {
     while (!comms_control->tx_control.not_full) {
         // Empty body; comms_controller is volatile
     }
-    spinnaker_packet_control_byte_t fixed_route_payload =
-            (spinnaker_packet_control_byte_t) {
+    spinnaker_packet_control_byte_t fixed_route_payload = {
         .parity = 0,
         .payload = true,
         .timestamp = 0,
         .fr.emergency_routing = 0,
-        .type = SPINNAKER_PACKET_TYPE_FR
+        .type = SPINNAKER_PACKET_TYPE_FR,
     };
     comms_control->tx_control.control_byte = fixed_route_payload.value;
     comms_control->tx_data = data;
@@ -1133,10 +1132,10 @@ static void data_out_send_data_block(
 static inline void data_out_dma_read(
         uint32_t dma_tag, void *source, void *destination, uint n_words) {
     dma_description_t desc = {
-            .width = DMA_WIDTH,
-            .burst = DMA_BURST_SIZE,
-            .direction = DMA_READ,
-            .length_words = n_words
+        .width = DMA_WIDTH,
+        .burst = DMA_BURST_SIZE,
+        .direction = DMA_READ,
+        .length_words = n_words,
     };
     dma_port_last_used = dma_tag;
     dma_controller->sdram_address = source;
@@ -1574,7 +1573,7 @@ void __wrap_sark_int(void *pc) {
     system_control->clear_cpu_irq = (sc_magic_proc_map_t) {
         // Clear this interrupt; we've assumed control now
         .security_code = SYSTEM_CONTROLLER_MAGIC_NUMBER,
-        .select = 1 << sark.phys_cpu
+        .select = 1 << sark.phys_cpu,
     };
     if (msg == NULL) {
         return;
@@ -1628,7 +1627,7 @@ static void reinjection_initialise(void) {
     // Setup the CPU interrupt for WDOG
     vic_interrupt_control[sark_vec->sark_slot] = (vic_vector_control_t) {
         .source = 0,
-        .enable = false
+        .enable = false,
     };
     vic_set_callback(CPU_SLOT, CPU_INT, sark_int_han);
 
@@ -1640,8 +1639,8 @@ static void reinjection_initialise(void) {
 
     // Setup the router interrupt as a fast interrupt
     sark_vec->fiq_vec = reinjection_dropped_packet_callback;
-    const vic_mask_t fast_router_dump = (vic_mask_t) {
-        .router_dump = true
+    const vic_mask_t fast_router_dump = {
+        .router_dump = true,
     };
     vic_control->int_select = fast_router_dump;
 }
@@ -1675,7 +1674,7 @@ static void data_out_initialise(void) {
         .restart = true,
         .clear_done_int = true,
         .clear_timeout_int = true,
-        .clear_write_buffer_int = true
+        .clear_write_buffer_int = true,
     };
     // clear possible transfer done and restart
     dma_controller->control = (dma_control_t) {
@@ -1693,7 +1692,7 @@ static void data_out_initialise(void) {
         .axi_error_interrupt = true, // SDRAM error?
         .user_abort_interrupt = true,
         .soft_reset_interrupt = true,
-        .write_buffer_error_interrupt = true
+        .write_buffer_error_interrupt = true,
     };
 }
 
@@ -1743,7 +1742,7 @@ void c_main(void) {
 
     // set up VIC callbacks and interrupts accordingly
     // Disable the interrupts that we are configuring (except CPU for WDOG)
-    const vic_mask_t interrupts = (vic_mask_t) {
+    const vic_mask_t interrupts = {
         .timer1 = true,
         .router_dump = true,
         .dma_done = true,
@@ -1768,7 +1767,7 @@ void c_main(void) {
         .size = 1,                // 32-bit mode
         .interrupt_enable = true, // we want to be interrupted
         .periodic_mode = true,    // repeat countdown
-        .enable = true            // turn on!
+        .enable = true,           // turn on!
     };
 
     // Run until told to exit

--- a/c_common/models/system_models/src/spinn_extra.h
+++ b/c_common/models/system_models/src/spinn_extra.h
@@ -1,0 +1,496 @@
+/*
+ * Copyright (c) 2019-2020 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// ------------------------------------------------------------------------
+//
+// Extra definitions of things on SpiNNaker chips that aren't already mentioned
+// in spinnaker.h, or where the description is miserable.
+//
+// ------------------------------------------------------------------------
+
+#ifndef __SPINN_EXTRA_H__
+#define __SPINN_EXTRA_H__
+
+#include <spinnaker.h>
+
+// ---------------------------------------------------------------------
+
+typedef void (*vic_interrupt_handler_t) (void);
+
+typedef struct {
+    const uint irq_status;
+    const uint fiq_status;
+    const uint raw_status;
+    uint int_select;
+    uint int_enable;
+    uint int_disable;
+    uint soft_int_enable;
+    uint soft_int_disable;
+    bool protection;
+    const uint _padding[3];
+    vic_interrupt_handler_t vector_address;
+    vic_interrupt_handler_t default_vector_address;
+} vic_control_t;
+
+typedef struct {
+    uint source : 5;
+    uint enable : 1;
+    const uint _padding : 27;
+} vic_vector_control_t;
+
+// ---------------------------------------------------------------------
+
+typedef struct {
+    uint one_shot : 1;
+    uint size : 1;
+    uint pre_divide : 2;
+    const uint _padding1 : 1;
+    uint interrupt_enable : 1;
+    uint periodic_mode : 1;
+    uint enable : 1;
+    const uint _padding2 : 24;
+} timer_control_t;
+
+enum timer_pre_divide {
+    TIMER_PRE_DIVIDE_1 = 0,
+    TIMER_PRE_DIVIDE_16 = 1,
+    TIMER_PRE_DIVIDE_256 = 2
+};
+
+typedef struct {
+    uint status : 1;
+    const uint _padding : 31;
+} timer_interrupt_status_t;
+
+typedef struct {
+    uint load_value;
+    const uint current_value;
+    timer_control_t control;
+    uint interrupt_clear;
+    const timer_interrupt_status_t raw_interrupt_status;
+    const timer_interrupt_status_t masked_interrupt_status;
+    uint background_load_value;
+    uint _dummy;
+} timer_t;
+
+// ---------------------------------------------------------------------
+
+typedef struct {
+    uint _zeroes : 2;
+    uint length_words : 15;
+    const uint _padding : 2;
+    uint direction : 1; // 0 = write to TCM, 1 = write to SDRAM
+    uint crc : 1;
+    uint burst : 3;
+    uint width : 1; // 0 = word, 1 = double-word
+    uint privilege : 1;
+    uint transfer_id : 6;
+} dma_description_t;
+
+typedef struct {
+    uint uncommit : 1;
+    uint abort : 1;
+    uint restart : 1;
+    uint clear_done_int : 1;
+    uint clear_timeout_int : 1;
+    uint clear_write_buffer_int : 1;
+    const uint _padding : 26;
+} dma_control_t;
+
+typedef struct {
+    uint transferring : 1;
+    uint paused : 1;
+    uint queued : 1;
+    uint write_buffer_full : 1;
+    uint write_buffer_active : 1;
+    const uint _padding1 : 5;
+    uint transfer_done : 1;
+    uint transfer2_done : 1;
+    uint timeout : 1;
+    uint crc_error : 1;
+    uint tcm_error : 1;
+    uint axi_error : 1;
+    uint user_abort : 1;
+    uint soft_reset : 1;
+    const uint _padding2 : 2;
+    uint write_buffer_error : 1;
+    const uint _padding3 : 3;
+    uint processor_id : 8;
+} dma_status_t;
+
+typedef struct {
+    uint bridge_buffer_enable : 1;
+    const uint _padding1 : 9;
+    uint transfer_done_interrupt : 1;
+    uint transfer2_done_interrupt : 1;
+    uint timeout_interrupt : 1;
+    uint crc_error_interrupt : 1;
+    uint tcm_error_interrupt : 1;
+    uint axi_error_interrupt : 1;
+    uint user_abort_interrupt : 1;
+    uint soft_reset_interrupt : 1;
+    const uint _padding2 : 2;
+    uint write_buffer_error_interrupt : 1;
+    const uint _padding3 : 10;
+    uint timer : 1;
+} dma_global_control_t;
+
+typedef struct {
+    uint _zeroes : 5;
+    uint value : 5;
+    const uint _padding : 22;
+} dma_timeout_t;
+
+typedef struct {
+    uint enable : 1;
+    uint clear : 1;
+    const uint _padding : 30;
+} dma_stats_control_t;
+
+typedef struct {
+    const uint _unused1[1];
+    void *sdram_address;
+    void *tcm_address;
+    dma_description_t description;
+    dma_control_t control;
+    const dma_status_t status;
+    dma_global_control_t global_control;
+    const uint crcc;
+    const uint crcr;
+    dma_timeout_t timeout;
+    dma_stats_control_t statistics_control;
+    const uint _unused2[5];
+    const uint statistics[8];
+    // TODO: current state
+} dma_t;
+
+// ---------------------------------------------------------------------
+
+typedef struct {
+    const uint _padding1 : 16;
+    uint control_byte : 8;
+    const uint _padding2 : 4;
+    const uint not_full : 1;
+    uint overrun : 1;
+    uint full : 1;
+    const uint empty : 1;
+} comms_tx_control_t;
+
+typedef struct {
+    const uint multicast : 1;
+    const uint point_to_point : 1;
+    const uint nearest_neighbour : 1;
+    const uint fixed_route : 1;
+    const uint _padding1 : 12;
+    const uint control_byte : 8;
+    const uint route : 3;
+    const uint _padding2 : 1;
+    const uint error_free : 1;
+    uint framing_error : 1;
+    uint parity_error : 1;
+    const uint received : 1;
+} comms_rx_status_t;
+
+typedef struct {
+    uint p2p_source_id : 16;
+    const uint _padding1 : 8;
+    uint route : 3;
+    const uint _padding2 : 5;
+} comms_source_addr_t;
+
+typedef struct {
+    comms_tx_control_t tx_control;
+    uint tx_data;
+    uint tx_key;
+    comms_rx_status_t rx_status;
+    const uint rx_data;
+    const uint rx_key;
+    comms_source_addr_t source_addr;
+    const uint _test;
+} comms_ctl_t;
+
+// ---------------------------------------------------------------------
+
+typedef struct {
+    uint route_packets_enable : 1;
+    uint error_interrupt_enable : 1;
+    uint dump_interrupt_enable : 1;
+    uint count_timestamp_errors : 1;
+    uint count_framing_errors : 1;
+    uint count_parity_errors : 1;
+    uint time_phase : 2;
+    uint monitor_processor : 5;
+    const uint _padding : 2;
+    uint reinit_wait_counters : 1;
+    uint emergency_wait_time : 8;
+    uint drop_wait_time : 8;
+} router_control_t;
+
+typedef struct {
+    uint interrupt_active_for_diagnostic_counter : 16;
+    uint busy : 1;
+    const uint _padding1 : 7;
+    uint output_stage : 2;
+    const uint _padding2 : 3;
+    uint interrupt_active_dump : 1;
+    uint interrupt_active_error : 1;
+    uint interrupt_active : 1;
+} router_status_t;
+
+enum output_stage {
+    output_stage_empty,
+    output_stage_full,
+    output_stage_wait1,
+    output_stage_wait2
+};
+
+typedef union {
+    struct {
+        const uint _padding1 : 6;
+        uint time_phase : 2;
+        const uint _padding2 : 8;
+        uint control : 8;
+        uint route : 3;
+        uint time_phase_error : 1;
+        uint framing_error : 1;
+        uint parity_error : 1;
+        const uint _padding3 : 2;
+    };
+    struct {
+        const uint _padding4 : 17;
+        uint payload : 1;
+        const uint _padding5 : 4;
+        uint type : 2;
+    };
+    uint word;
+} router_packet_header_t;
+
+typedef struct {
+    uint error_count : 16;
+    const uint _padding : 11;
+    uint time_phase_error : 1;
+    uint framing_error : 1;
+    uint parity_error : 1;
+    uint overflow : 1;
+    uint error : 1;
+} router_error_status_t;
+
+typedef struct {
+    uint link : 6;
+    uint processor : 18;
+    const uint _padding : 8;
+} router_dump_outputs_t;
+
+typedef struct {
+    uint link : 6;
+    uint processor : 18;
+    const uint _padding : 6;
+    uint overflow : 1;
+    uint dumped : 1;
+} router_dump_status_t;
+
+typedef struct {
+    ushort enable;
+    ushort reset;
+} diagnostic_counter_ctrl_t;
+
+typedef struct {
+    uint enable_cycle_count : 1;
+    uint enable_emergency_active_count : 1;
+    uint enable_histogram : 1;
+    const uint _padding1 : 13;
+    uint reset_cycle_count : 1;
+    uint reset_emergency_active_count : 1;
+    uint reset_histogram : 1;
+    const uint _padding2 : 13;
+} router_timing_counter_ctrl_t;
+
+typedef struct {
+    uint L0 : 2;
+    uint L1 : 2;
+    uint L2 : 2;
+    uint L3 : 2;
+    uint L4 : 2;
+    uint L5 : 2;
+    const uint _padding : 20;
+} router_diversion_t;
+
+typedef struct {
+    uint fixed_route_vector : 24;
+    const uint _padding : 2;
+    uint nearest_neighbour_broadcast : 6;
+} router_fixed_route_routing_t;
+
+typedef struct {
+    // r0
+    router_control_t control;
+    // r1
+    const router_status_t status;
+    struct {
+        // r2
+        router_packet_header_t header;
+        // r3
+        uint key;
+        // r4
+        uint payload;
+        // r5
+        const router_error_status_t status;
+    } error;
+    struct {
+        // r6
+        router_packet_header_t header;
+        // r7
+        uint key;
+        // r8
+        uint payload;
+        // r9
+        router_dump_outputs_t outputs;
+        // r10
+        const router_dump_status_t status;
+    } dump;
+    // r11
+    diagnostic_counter_ctrl_t diagnostic_counter_control;
+    // r12
+    router_timing_counter_ctrl_t timing_counter_control;
+    // r13
+    uint cycle_count;
+    // r14
+    uint emergency_active_cycle_count;
+    // r15
+    uint unblocked_count;
+    // r16-31
+    uint delay_histogram[16];
+    // r32
+    router_diversion_t diversion;
+    // r33
+    router_fixed_route_routing_t fixed_route;
+} router_t;
+
+typedef struct {
+    uint type : 4;
+    uint emergency_routing : 4;
+    uint emergency_routing_mode : 1;
+    const uint _padding1 : 1;
+    uint pattern_default : 2;
+    uint pattern_payload : 2;
+    uint pattern_local : 2;
+    uint pattern_destination : 9;
+    const uint _padding2 : 4;
+    uint counter_event_occurred : 1;
+    uint enable_counter_event_interrupt : 1;
+    uint counter_event_interrupt_active : 1;
+} router_diagnostic_filter_t;
+
+// ---------------------------------------------------------------------
+
+typedef struct {
+    uint select : 18;
+    const uint _padding : 2;
+    uint security_code : 12; // NB: see documentation!
+} sc_magic_proc_map_t;
+
+typedef struct {
+    uint reset_code : 3;
+    const uint _padding : 29;
+} sc_reset_code_t;
+
+typedef struct {
+    uint monitor_id : 5;
+    const uint _padding1 : 3;
+    uint arbitrate_request : 1;
+    const uint _padding2 : 7;
+    uint reset_on_watchdog : 1;
+    const uint _padding3 : 3;
+    uint security_code : 12; // NB: see documentation!
+} sc_monitor_id_t;
+
+typedef struct {
+    uint boot_area_map : 1;
+    const uint _padding1 : 14;
+    uint jtag_on_chip : 1;
+    const uint test : 1;
+    const uint ethermux : 1;
+    const uint clk32 : 1;
+    const uint jtag_tdo : 1;
+    const uint jtag_rtck : 1;
+    const uint _padding2 : 11;
+} sc_misc_control_t;
+
+typedef struct {
+    const uint chip_id;
+    sc_magic_proc_map_t processor_disable;
+    sc_magic_proc_map_t set_cpu_irq;
+    sc_magic_proc_map_t clear_cpu_irq;
+    uint set_cpu_ok;
+    uint clear_cpu_ok;
+    sc_magic_proc_map_t cpu_reset_level;
+    sc_magic_proc_map_t node_reset_level;
+    sc_magic_proc_map_t subsystem_reset_level;
+    sc_magic_proc_map_t cpu_reset_pulse;
+    sc_magic_proc_map_t node_reset_pulse;
+    sc_magic_proc_map_t subsystem_reset_pulse;
+    const sc_reset_code_t reset_code;
+    sc_monitor_id_t monitor_id;
+    sc_misc_control_t misc_control;
+    uint gpio_pull_up_down_enable;
+    uint io_port;
+    uint io_direction;
+    uint io_set;
+    uint io_clear;
+    uint pll1_freq_control;
+    uint pll2_freq_control;
+    uint set_flags;
+    uint reset_flags;
+    uint clock_mux_control;
+    const uint cpu_sleep;
+    uint temperature[3];
+    const uint _padding[3];
+    const uint arbiter[32];
+    const uint test_and_set[32];
+    const uint test_and_clear[32];
+    uint link_disable;
+} system_controller_t;
+
+// ---------------------------------------------------------------------
+
+static volatile vic_control_t *const vic_control =
+        (vic_control_t *) VIC_BASE_UNBUF; // NB unbuffered!
+static volatile vic_interrupt_handler_t *const vic_interrupt_vectors =
+        (vic_interrupt_handler_t *) (VIC_BASE + 0x100);
+static volatile vic_vector_control_t *const vic_interrupt_control =
+        (vic_vector_control_t *) (VIC_BASE + 0x200);
+
+static volatile timer_t *const timer1 = (timer_t *) TIMER1_BASE;
+static volatile timer_t *const timer2 = (timer_t *) TIMER2_BASE;
+
+static volatile dma_t *const dma_controller = (dma_t *) DMA_BASE;
+
+static volatile comms_ctl_t *const comms_controller = (comms_ctl_t *) CC_BASE;
+
+static volatile router_t *const router = (router_t *) RTR_BASE;
+static volatile router_diagnostic_filter_t *const router_diagnostic_filter =
+        (router_diagnostic_filter_t *) (RTR_BASE + 0x200);
+static volatile uint *const router_diagnostic_counter =
+        (uint *) (RTR_BASE + 0x300);
+
+// memory controller explicitly not exposed; too dangerous!
+
+static volatile system_controller_t *const system_controller =
+        (system_controller_t *) SYSCTL_BASE;
+
+// ---------------------------------------------------------------------
+#endif // !__SPINN_EXTRA_H__

--- a/c_common/models/system_models/src/spinn_extra.h
+++ b/c_common/models/system_models/src/spinn_extra.h
@@ -465,6 +465,10 @@ typedef struct {
     uint link_disable;
 } system_controller_t;
 
+enum {
+    SYSTEM_CONTROLLER_MAGIC_NUMBER = 0x5ec
+};
+
 // ---------------------------------------------------------------------
 
 static volatile vic_control_t *const vic_control =

--- a/c_common/models/system_models/src/spinn_extra.h
+++ b/c_common/models/system_models/src/spinn_extra.h
@@ -636,9 +636,9 @@ typedef struct {
     uint incing : 1;
     uint locked : 1;
     uint : 1;
-    uint r : 1;
-    uint m : 1;
-    uint l : 1;
+    uint R : 1;
+    uint M : 1;
+    uint L : 1;
     uint : 9;
 } sdram_dll_status_t;
 
@@ -654,9 +654,9 @@ typedef struct {
     uint test_incing : 1;
     uint enable_force_inc_dec : 1;
     uint test_5 : 1;
-    uint r : 1;
-    uint m : 1;
-    uint l : 1;
+    uint R : 1;
+    uint M : 1;
+    uint L : 1;
     uint enable_force_lmr : 1;
     uint enable : 1;
     uint : 7;

--- a/c_common/models/system_models/src/spinn_extra.h
+++ b/c_common/models/system_models/src/spinn_extra.h
@@ -49,7 +49,7 @@ typedef struct {
 typedef struct {
     uint source : 5;
     uint enable : 1;
-    const uint _padding : 27;
+    uint : 27;
 } vic_vector_control_t;
 
 // ---------------------------------------------------------------------
@@ -58,11 +58,11 @@ typedef struct {
     uint one_shot : 1;
     uint size : 1;
     uint pre_divide : 2;
-    const uint _padding1 : 1;
+    uint : 1;
     uint interrupt_enable : 1;
     uint periodic_mode : 1;
     uint enable : 1;
-    const uint _padding2 : 24;
+    uint : 24;
 } timer_control_t;
 
 enum timer_pre_divide {
@@ -73,7 +73,7 @@ enum timer_pre_divide {
 
 typedef struct {
     uint status : 1;
-    const uint _padding : 31;
+    uint : 31;
 } timer_interrupt_status_t;
 
 typedef struct {
@@ -85,14 +85,14 @@ typedef struct {
     const timer_interrupt_status_t masked_interrupt_status;
     uint background_load_value;
     uint _dummy;
-} timer_t;
+} timer_controller_t;
 
 // ---------------------------------------------------------------------
 
 typedef struct {
     uint _zeroes : 2;
     uint length_words : 15;
-    const uint _padding : 2;
+    uint : 2;
     uint direction : 1; // 0 = write to TCM, 1 = write to SDRAM
     uint crc : 1;
     uint burst : 3;
@@ -108,7 +108,7 @@ typedef struct {
     uint clear_done_int : 1;
     uint clear_timeout_int : 1;
     uint clear_write_buffer_int : 1;
-    const uint _padding : 26;
+    uint : 26;
 } dma_control_t;
 
 typedef struct {
@@ -117,7 +117,7 @@ typedef struct {
     uint queued : 1;
     uint write_buffer_full : 1;
     uint write_buffer_active : 1;
-    const uint _padding1 : 5;
+    uint : 5;
     uint transfer_done : 1;
     uint transfer2_done : 1;
     uint timeout : 1;
@@ -126,15 +126,15 @@ typedef struct {
     uint axi_error : 1;
     uint user_abort : 1;
     uint soft_reset : 1;
-    const uint _padding2 : 2;
+    uint : 2;
     uint write_buffer_error : 1;
-    const uint _padding3 : 3;
+    uint : 3;
     uint processor_id : 8;
 } dma_status_t;
 
 typedef struct {
     uint bridge_buffer_enable : 1;
-    const uint _padding1 : 9;
+    uint : 9;
     uint transfer_done_interrupt : 1;
     uint transfer2_done_interrupt : 1;
     uint timeout_interrupt : 1;
@@ -143,22 +143,22 @@ typedef struct {
     uint axi_error_interrupt : 1;
     uint user_abort_interrupt : 1;
     uint soft_reset_interrupt : 1;
-    const uint _padding2 : 2;
+    uint : 2;
     uint write_buffer_error_interrupt : 1;
-    const uint _padding3 : 10;
+    uint : 10;
     uint timer : 1;
 } dma_global_control_t;
 
 typedef struct {
     uint _zeroes : 5;
     uint value : 5;
-    const uint _padding : 22;
+    uint : 22;
 } dma_timeout_t;
 
 typedef struct {
     uint enable : 1;
     uint clear : 1;
-    const uint _padding : 30;
+    uint : 30;
 } dma_stats_control_t;
 
 typedef struct {
@@ -181,35 +181,35 @@ typedef struct {
 // ---------------------------------------------------------------------
 
 typedef struct {
-    const uint _padding1 : 16;
+    uint : 16;
     uint control_byte : 8;
-    const uint _padding2 : 4;
-    const uint not_full : 1;
+    uint : 4;
+    uint const not_full : 1;
     uint overrun : 1;
     uint full : 1;
-    const uint empty : 1;
+    uint const empty : 1;
 } comms_tx_control_t;
 
 typedef struct {
-    const uint multicast : 1;
-    const uint point_to_point : 1;
-    const uint nearest_neighbour : 1;
-    const uint fixed_route : 1;
-    const uint _padding1 : 12;
-    const uint control_byte : 8;
-    const uint route : 3;
-    const uint _padding2 : 1;
-    const uint error_free : 1;
+    uint const multicast : 1;
+    uint const point_to_point : 1;
+    uint const nearest_neighbour : 1;
+    uint const fixed_route : 1;
+    uint : 12;
+    uint const control_byte : 8;
+    uint const route : 3;
+    uint : 1;
+    uint const error_free : 1;
     uint framing_error : 1;
     uint parity_error : 1;
-    const uint received : 1;
+    uint const received : 1;
 } comms_rx_status_t;
 
 typedef struct {
     uint p2p_source_id : 16;
-    const uint _padding1 : 8;
+    uint : 8;
     uint route : 3;
-    const uint _padding2 : 5;
+    uint : 5;
 } comms_source_addr_t;
 
 typedef struct {
@@ -234,7 +234,7 @@ typedef struct {
     uint count_parity_errors : 1;
     uint time_phase : 2;
     uint monitor_processor : 5;
-    const uint _padding : 2;
+    uint : 2;
     uint reinit_wait_counters : 1;
     uint emergency_wait_time : 8;
     uint drop_wait_time : 8;
@@ -243,9 +243,9 @@ typedef struct {
 typedef struct {
     uint interrupt_active_for_diagnostic_counter : 16;
     uint busy : 1;
-    const uint _padding1 : 7;
+    uint : 7;
     uint output_stage : 2;
-    const uint _padding2 : 3;
+    uint : 3;
     uint interrupt_active_dump : 1;
     uint interrupt_active_error : 1;
     uint interrupt_active : 1;
@@ -260,20 +260,20 @@ enum output_stage {
 
 typedef union {
     struct {
-        const uint _padding1 : 6;
+        uint : 6;
         uint time_phase : 2;
-        const uint _padding2 : 8;
+        uint : 8;
         uint control : 8;
         uint route : 3;
         uint time_phase_error : 1;
         uint framing_error : 1;
         uint parity_error : 1;
-        const uint _padding3 : 2;
+        uint : 2;
     };
     struct {
-        const uint _padding4 : 17;
+        uint : 17;
         uint payload : 1;
-        const uint _padding5 : 4;
+        uint : 4;
         uint type : 2;
     };
     uint word;
@@ -281,7 +281,7 @@ typedef union {
 
 typedef struct {
     uint error_count : 16;
-    const uint _padding : 11;
+    uint : 11;
     uint time_phase_error : 1;
     uint framing_error : 1;
     uint parity_error : 1;
@@ -292,13 +292,13 @@ typedef struct {
 typedef struct {
     uint link : 6;
     uint processor : 18;
-    const uint _padding : 8;
+    uint : 8;
 } router_dump_outputs_t;
 
 typedef struct {
     uint link : 6;
     uint processor : 18;
-    const uint _padding : 6;
+    uint : 6;
     uint overflow : 1;
     uint dumped : 1;
 } router_dump_status_t;
@@ -312,11 +312,11 @@ typedef struct {
     uint enable_cycle_count : 1;
     uint enable_emergency_active_count : 1;
     uint enable_histogram : 1;
-    const uint _padding1 : 13;
+    uint : 13;
     uint reset_cycle_count : 1;
     uint reset_emergency_active_count : 1;
     uint reset_histogram : 1;
-    const uint _padding2 : 13;
+    uint : 13;
 } router_timing_counter_ctrl_t;
 
 typedef struct {
@@ -326,12 +326,12 @@ typedef struct {
     uint L3 : 2;
     uint L4 : 2;
     uint L5 : 2;
-    const uint _padding : 20;
+    uint : 20;
 } router_diversion_t;
 
 typedef struct {
     uint fixed_route_vector : 24;
-    const uint _padding : 2;
+    uint : 2;
     uint nearest_neighbour_broadcast : 6;
 } router_fixed_route_routing_t;
 
@@ -384,12 +384,12 @@ typedef struct {
     uint type : 4;
     uint emergency_routing : 4;
     uint emergency_routing_mode : 1;
-    const uint _padding1 : 1;
+    uint : 1;
     uint pattern_default : 2;
     uint pattern_payload : 2;
     uint pattern_local : 2;
     uint pattern_destination : 9;
-    const uint _padding2 : 4;
+    uint : 4;
     uint counter_event_occurred : 1;
     uint enable_counter_event_interrupt : 1;
     uint counter_event_interrupt_active : 1;
@@ -399,35 +399,35 @@ typedef struct {
 
 typedef struct {
     uint select : 18;
-    const uint _padding : 2;
+    uint : 2;
     uint security_code : 12; // NB: see documentation!
 } sc_magic_proc_map_t;
 
 typedef struct {
     uint reset_code : 3;
-    const uint _padding : 29;
+    uint : 29;
 } sc_reset_code_t;
 
 typedef struct {
     uint monitor_id : 5;
-    const uint _padding1 : 3;
+    uint : 3;
     uint arbitrate_request : 1;
-    const uint _padding2 : 7;
+    uint : 7;
     uint reset_on_watchdog : 1;
-    const uint _padding3 : 3;
+    uint : 3;
     uint security_code : 12; // NB: see documentation!
 } sc_monitor_id_t;
 
 typedef struct {
     uint boot_area_map : 1;
-    const uint _padding1 : 14;
+    uint : 14;
     uint jtag_on_chip : 1;
-    const uint test : 1;
-    const uint ethermux : 1;
-    const uint clk32 : 1;
-    const uint jtag_tdo : 1;
-    const uint jtag_rtck : 1;
-    const uint _padding2 : 11;
+    uint const test : 1;
+    uint const ethermux : 1;
+    uint const clk32 : 1;
+    uint const jtag_tdo : 1;
+    uint const jtag_rtck : 1;
+    uint : 11;
 } sc_misc_control_t;
 
 typedef struct {
@@ -474,8 +474,10 @@ static volatile vic_interrupt_handler_t *const vic_interrupt_vectors =
 static volatile vic_vector_control_t *const vic_interrupt_control =
         (vic_vector_control_t *) (VIC_BASE + 0x200);
 
-static volatile timer_t *const timer1 = (timer_t *) TIMER1_BASE;
-static volatile timer_t *const timer2 = (timer_t *) TIMER2_BASE;
+static volatile timer_controller_t *const timer1 =
+        (timer_controller_t *) TIMER1_BASE;
+static volatile timer_controller_t *const timer2 =
+        (timer_controller_t *) TIMER2_BASE;
 
 static volatile dma_t *const dma_controller = (dma_t *) DMA_BASE;
 

--- a/c_common/models/system_models/src/spinn_extra.h
+++ b/c_common/models/system_models/src/spinn_extra.h
@@ -25,21 +25,79 @@
 #ifndef __SPINN_EXTRA_H__
 #define __SPINN_EXTRA_H__
 
-#include <spinnaker.h>
+// ---------------------------------------------------------------------
+// 1. Chip Organization
+
+// No registers
 
 // ---------------------------------------------------------------------
+// 2. System Architecture
+
+// No registers
+
+// ---------------------------------------------------------------------
+// 3. ARM968 Processing Subsystem
+
+#include <spinnaker.h>
+// No registers
+
+// ---------------------------------------------------------------------
+// 4. ARM 968
+
+// No special registers here
+
+// ---------------------------------------------------------------------
+// 5. Vectored Interrupt Controller
 
 typedef void (*vic_interrupt_handler_t) (void);
 
+typedef union {
+    struct {
+        uint watchdog : 1;
+        uint software : 1;
+        uint comm_rx : 1;
+        uint comm_tx : 1;
+        uint timer1 : 1;
+        uint timer2 : 1;
+        uint cc_rx_ready : 1;
+        uint cc_rx_parity_error : 1;
+        uint cc_rx_framing_error : 1;
+        uint cc_tx_full : 1;
+        uint cc_tx_overflow : 1;
+        uint cc_tx_empty : 1;
+        uint dma_done : 1;
+        uint dma_error : 1;
+        uint dma_timeout : 1;
+        uint router_diagnostic : 1;
+        uint router_dump : 1;
+        uint router_error : 1;
+        uint cpu : 1;
+        uint ethernet_tx : 1;
+        uint ethernet_rx : 1;
+        uint ethernet_phy : 1;
+        uint slow_clock : 1;
+        uint cc_tx_not_full : 1;
+        uint cc_rx_mc : 1;
+        uint cc_rx_p2p : 1;
+        uint cc_rx_nn : 1;
+        uint cc_rx_fr : 1;
+        uint int0 : 1;
+        uint int1 : 1;
+        uint gpio8 : 1;
+        uint gpio9 : 1;
+    };
+    uint value;
+} vic_mask_t;
+
 typedef struct {
-    const uint irq_status;
-    const uint fiq_status;
-    const uint raw_status;
-    uint int_select;
-    uint int_enable;
-    uint int_disable;
-    uint soft_int_enable;
-    uint soft_int_disable;
+    const vic_mask_t irq_status;
+    const vic_mask_t fiq_status;
+    const vic_mask_t raw_status;
+    vic_mask_t int_select;
+    vic_mask_t int_enable;
+    vic_mask_t int_disable;
+    vic_mask_t soft_int_enable;
+    vic_mask_t soft_int_disable;
     bool protection;
     const uint _padding[3];
     vic_interrupt_handler_t vector_address;
@@ -53,6 +111,7 @@ typedef struct {
 } vic_vector_control_t;
 
 // ---------------------------------------------------------------------
+// 6. Counter/Timer
 
 typedef struct {
     uint one_shot : 1;
@@ -88,6 +147,7 @@ typedef struct {
 } timer_controller_t;
 
 // ---------------------------------------------------------------------
+// 7. DMA Controller
 
 typedef struct {
     uint _zeroes : 2;
@@ -176,9 +236,50 @@ typedef struct {
     const uint _unused2[5];
     const uint statistics[8];
     // TODO: current state
+    // TODO: CRC polynomial
 } dma_t;
 
 // ---------------------------------------------------------------------
+// 8. Communications controller
+
+typedef union {
+    struct {
+        uchar parity : 1;
+        uchar payload : 1;
+        uchar timestamp : 2;
+        uchar : 2;
+        uchar type : 2;
+    };
+    struct {
+        uchar : 4;
+        uchar emergency_routing : 2;
+        uchar : 2;
+    } mc;
+    struct {
+        uchar : 4;
+        uchar seq_code : 2;
+        uchar : 2;
+    } p2p;
+    struct {
+        uchar : 2;
+        uchar route : 3;
+        uchar mem_or_normal : 1;
+        uchar : 2;
+    } nn;
+    struct {
+        uchar : 4;
+        uchar emergency_routing : 2;
+        uchar : 2;
+    } fr;
+    uchar value;
+} spinnaker_packet_control_byte_t;
+
+enum {
+    SPINNAKER_PACKET_TYPE_MC = 0,
+    SPINNAKER_PACKET_TYPE_P2P = 1,
+    SPINNAKER_PACKET_TYPE_NN = 2,
+    SPINNAKER_PACKET_TYPE_FR = 3,
+};
 
 typedef struct {
     uint : 16;
@@ -224,6 +325,12 @@ typedef struct {
 } comms_ctl_t;
 
 // ---------------------------------------------------------------------
+// 9. Communications NoC
+
+// No registers
+
+// ---------------------------------------------------------------------
+// 10. SpiNNaker Router
 
 typedef struct {
     uint route_packets_enable : 1;
@@ -396,6 +503,186 @@ typedef struct {
 } router_diagnostic_filter_t;
 
 // ---------------------------------------------------------------------
+// 11. Inter-chip transmit and receive interfaces
+
+// No registers
+
+// ---------------------------------------------------------------------
+// 12. System NoC
+
+// No registers
+
+// ---------------------------------------------------------------------
+// 13. SDRAM interface
+
+// Do not use these structures without talking to Luis!
+
+typedef struct {
+    uint status : 2;
+    uint width : 2;
+    uint ddr : 3;
+    uint chips : 2;
+    uint banks : 1;
+    uint monitors : 2;
+    uint : 20;
+} sdram_status_t;
+
+typedef struct {
+    uint command : 3;
+} sdram_command_t;
+
+enum sdram_command {
+    SDRAM_CTL_GO,
+    SDRAM_CTL_SLEEP,            // TODO: verify this value
+    SDRAM_CTL_WAKE,             // TODO: verify this value
+    SDRAM_CTL_PAUSE,
+    SDRAM_CTL_CONFIG,
+    SDRAM_CTL_ACTIVE_PAUSE      // TODO: verify this value
+};
+
+typedef struct {
+    uint address : 14;
+    uint : 2;
+    uint bank : 2;
+    uint cmd : 2;
+    uint chip : 2;
+    uint : 10;
+} sdram_direct_command_t;
+
+enum sdram_direct_command {
+    // Codes from SARK (sark_hw.c, pl340_init)
+    SDRAM_DIRECT_PRECHARGE = 0,
+    SDRAM_DIRECT_AUTOREFRESH = 1,
+    SDRAM_DIRECT_MODEREG = 2,
+    SDRAM_DIRECT_NOP = 3,
+};
+
+typedef struct {
+    uint column : 3;
+    uint row : 3;
+    uint auto_precharge_position : 1;
+    uint power_down_delay : 6;
+    uint auto_power_down : 1;
+    uint stop_clock : 1;
+    uint burst : 3;
+    uint qos : 3;
+    uint active : 2;
+    uint : 9;
+} sdram_ram_config_t;
+
+typedef struct {
+    uint period : 15;
+    uint : 17;
+} sdram_refresh_t;
+
+typedef struct {
+    // See datasheet for meanings
+    uint cas_latency;
+    uint t_dqss;
+    uint t_mrd;
+    uint t_ras;
+    uint t_rc;
+    uint t_rcd;
+    uint t_rfc;
+    uint t_rp;
+    uint t_rrd;
+    uint t_wr;
+    uint t_wtr;
+    uint t_xp;
+    uint t_xsr;
+    uint t_esr;
+} sdram_timing_config_t;
+
+typedef struct {
+    const sdram_status_t status;
+    sdram_command_t command;
+    sdram_direct_command_t direct;
+    sdram_ram_config_t mem_config;
+    sdram_refresh_t refresh;
+    sdram_timing_config_t timing_config; // 14 words
+} sdram_controller_t;
+
+typedef struct {
+    uint enable : 1;
+    uint minimum : 1;
+    uint maximum : 8;
+    uint : 22;
+} sdram_qos_t;
+
+typedef struct {
+    uint mask : 8;
+    uint match : 8;
+    uint orientation : 1;
+    uint : 15;
+} sdram_chip_t;
+
+enum {
+    SDRAM_QOS_MAX = 15,
+    SDRAM_CHIP_MAX = 3
+};
+
+typedef struct {
+    uint meter : 7;
+    uint : 1;
+    uint s0 : 1;
+    uint c0 : 1;
+    uint s1 : 1;
+    uint c1 : 1;
+    uint s2 : 1;
+    uint c2 : 1;
+    uint s3 : 1;
+    uint c3 : 1;
+    uint decing : 1;
+    uint incing : 1;
+    uint locked : 1;
+    uint : 1;
+    uint r : 1;
+    uint m : 1;
+    uint l : 1;
+    uint : 9;
+} sdram_dll_status_t;
+
+typedef struct {
+    uint s0 : 2;
+    uint s1 : 2;
+    uint s2 : 2;
+    uint s3 : 2;
+    uint s4 : 2;
+    uint s5 : 2;
+    uint : 4;
+    uint test_decing : 1;
+    uint test_incing : 1;
+    uint enable_force_inc_dec : 1;
+    uint test_5 : 1;
+    uint r : 1;
+    uint m : 1;
+    uint l : 1;
+    uint enable_force_lmr : 1;
+    uint enable : 1;
+    uint : 7;
+} sdram_dll_user_config0_t;
+
+typedef union {
+    struct {
+        uint tune_0 : 4;
+        uint tune_1 : 4;
+        uint tune_2 : 4;
+        uint tune_3 : 4;
+        uint tune_4 : 4;
+        uint tune_5 : 4;
+        uint : 8;
+    };
+    uint word;
+} sdram_dll_user_config1_t;
+
+typedef struct {
+    const sdram_dll_status_t status;
+    sdram_dll_user_config0_t config0;
+    sdram_dll_user_config1_t config1;
+} sdram_dll_t;
+
+// ---------------------------------------------------------------------
+// 14. System Controller
 
 typedef struct {
     uint select : 18;
@@ -430,6 +717,83 @@ typedef struct {
     uint : 11;
 } sc_misc_control_t;
 
+typedef union {
+    struct {
+        uint : 16;
+        uint ethernet_receive : 4;
+        uint ethernet_transmit : 4;
+        uint jtag : 4;
+        uint : 1;
+        uint sdram : 3;
+    };
+    uint gpio;
+} sc_io_t;
+
+typedef struct {
+    uint input_multiplier : 6;
+    uint : 2;
+    uint output_divider : 6;
+    uint : 2;
+    uint freq_range : 2;
+    uint power_up : 1;
+    uint : 5;
+    uint _test : 1;
+    uint : 7;
+} sc_pll_control_t;
+
+enum frequency_range {
+    FREQ_25_50,
+    FREQ_50_100,
+    FREQ_100_200,
+    FREQ_200_400
+};
+
+typedef struct {
+    uint pa : 2;
+    uint adiv : 2;
+    uint : 1;
+    uint pb : 2;
+    uint bdiv : 2;
+    uint : 1;
+    uint mem : 2;
+    uint mdiv : 2;
+    uint : 1;
+    uint rtr : 2;
+    uint rdiv : 2;
+    uint : 1;
+    uint sys : 2;
+    uint sdiv : 2;
+    uint : 7;
+    uint invert_b : 1;
+} sc_clock_mux_t;
+
+typedef struct {
+    uint status : 18;
+    uint : 14;
+} sc_sleep_status_t;
+
+typedef struct {
+    uint const temperature : 24;
+    uint const sample_finished : 1;
+    uint : 6;
+    uint start : 1;
+} sc_temperature_t;
+
+typedef struct {
+    uint : 31;
+    uint bit : 1;
+} sc_mutex_bit_t;
+
+typedef struct {
+    uint rx_disable : 6;
+    uint : 2;
+    uint tx_disable : 6;
+    uint : 2;
+    uint parity_control : 1;
+    uint : 3;
+    uint security_code : 12; // NB: see documentation!
+} sc_link_disable_t;
+
 typedef struct {
     const uint chip_id;
     sc_magic_proc_map_t processor_disable;
@@ -446,28 +810,170 @@ typedef struct {
     const sc_reset_code_t reset_code;
     sc_monitor_id_t monitor_id;
     sc_misc_control_t misc_control;
-    uint gpio_pull_up_down_enable;
-    uint io_port;
-    uint io_direction;
-    uint io_set;
-    uint io_clear;
-    uint pll1_freq_control;
-    uint pll2_freq_control;
+    sc_io_t gpio_pull_up_down_enable; // NB: see documentation!
+    sc_io_t io_port;                  // NB: see documentation!
+    sc_io_t io_direction;
+    sc_io_t io_set;
+    sc_io_t io_clear;
+    sc_pll_control_t pll1_freq_control;
+    sc_pll_control_t pll2_freq_control;
     uint set_flags;
     uint reset_flags;
-    uint clock_mux_control;
-    const uint cpu_sleep;
-    uint temperature[3];
+    sc_clock_mux_t clock_mux_control;
+    const sc_sleep_status_t cpu_sleep;
+    sc_temperature_t temperature[3];
     const uint _padding[3];
-    const uint arbiter[32];
-    const uint test_and_set[32];
-    const uint test_and_clear[32];
-    uint link_disable;
+    const sc_mutex_bit_t monitor_arbiter[32];
+    const sc_mutex_bit_t test_and_set[32];
+    const sc_mutex_bit_t test_and_clear[32];
+    sc_link_disable_t link_disable;
 } system_controller_t;
 
 enum {
     SYSTEM_CONTROLLER_MAGIC_NUMBER = 0x5ec
 };
+
+// ---------------------------------------------------------------------
+// 15. Ethernet MII Interface
+
+typedef struct {
+    uint transmit : 1;
+    uint receive : 1;
+    uint loopback : 1;
+    uint receive_error_filter : 1;
+    uint receive_unicast: 1;
+    uint receive_multicast : 1;
+    uint receive_broadcast : 1;
+    uint receive_promiscuous : 1;
+    uint receive_vlan : 1;
+    uint reset_drop_counter : 1;
+    uint hardware_byte_reorder_disable : 1;
+    uint : 21;
+} ethernet_general_command_t;
+
+typedef struct {
+    uint transmit_active : 1;
+    uint unread_counter : 6;
+    uint : 9;
+    uint drop_counter : 16;
+} ethernet_general_status_t;
+
+typedef struct {
+    uint reset : 1; // Active low
+    uint const smi_input : 1;
+    uint smi_output : 1;
+    uint smi_out_enable : 1;
+    uint smi_clock : 1; // Active rising
+    uint irq_invert_disable : 1;
+    uint : 26;
+} ethernet_phy_control_t;
+
+typedef struct {
+    uint transmit : 1;
+    uint : 3;
+    uint receive : 1;
+    uint : 27;
+} ethernet_interrupt_clear_t;
+
+typedef struct {
+    uint ptr : 12;
+    uint rollover : 1;
+    uint : 19;
+} receive_pointer_t;
+
+typedef struct {
+    uint ptr : 6;
+    uint rollover : 1;
+    uint : 25;
+} receive_descriptor_pointer_t;
+
+typedef struct {
+    ethernet_general_command_t command;
+    const ethernet_general_status_t status;
+    uint transmit_length;
+    uint transmit_command;
+    uint receive_command;
+    uint64 mac_address; // Low 48 bits only
+    ethernet_phy_control_t phy_control;
+    ethernet_interrupt_clear_t interrupt_clear;
+    const receive_pointer_t receive_read;
+    const receive_pointer_t receive_write;
+    const receive_descriptor_pointer_t receive_desc_read;
+    const receive_descriptor_pointer_t receive_desc_write;
+} ethernet_controller_t;
+
+// Cannot find description of rest of this structure; SCAMP only uses one field
+typedef struct {
+    uint length : 11;
+    uint : 21; // ???
+} ethernet_receive_descriptor_t;
+
+// ---------------------------------------------------------------------
+// 16. Watchdog timer
+
+typedef struct {
+    uint interrupt_enable : 1;
+    uint reset_enable : 1;
+    uint : 30;
+} watchdog_control_t;
+
+typedef struct {
+    uint interrupted : 1;
+} watchdog_status_t;
+
+typedef union {
+    struct {
+        uint lock : 1;
+        uint magic : 31;
+    };
+    uint whole_value;
+} watchdog_lock_t;
+
+enum {
+    WATCHDOG_LOCK_RESET = 0,
+    WATCHDOG_LOCK_MAGIC = WD_CODE
+};
+
+typedef struct {
+    uint load;
+    const uint value;
+    watchdog_control_t control;
+    uint interrupt_clear;
+    const watchdog_status_t raw_status;
+    const watchdog_status_t masked_status;
+    const uint _padding[0x2fa]; // Lots of padding!
+    watchdog_lock_t lock;
+} watchdog_controller_t;
+
+// ---------------------------------------------------------------------
+// 17. System RAM
+
+// No registers
+
+// ---------------------------------------------------------------------
+// 18. Boot ROM
+
+// No registers
+
+// ---------------------------------------------------------------------
+// 19. JTAG
+
+// No registers
+
+// ---------------------------------------------------------------------
+// 20. Input and Output Signals
+
+// No registers
+
+// ---------------------------------------------------------------------
+// 21. Packaging
+
+// No registers
+
+// ---------------------------------------------------------------------
+// 22. Application Notes
+
+// No registers
 
 // ---------------------------------------------------------------------
 
@@ -485,7 +991,7 @@ static volatile timer_controller_t *const timer2 =
 
 static volatile dma_t *const dma_controller = (dma_t *) DMA_BASE;
 
-static volatile comms_ctl_t *const comms_controller = (comms_ctl_t *) CC_BASE;
+static volatile comms_ctl_t *const comms_control = (comms_ctl_t *) CC_BASE;
 
 static volatile router_t *const router = (router_t *) RTR_BASE;
 static volatile router_diagnostic_filter_t *const router_diagnostic_filter =
@@ -493,10 +999,24 @@ static volatile router_diagnostic_filter_t *const router_diagnostic_filter =
 static volatile uint *const router_diagnostic_counter =
         (uint *) (RTR_BASE + 0x300);
 
-// memory controller explicitly not exposed; too dangerous!
+static volatile sdram_controller_t *const sdram_control =
+        (sdram_controller_t *) PL340_BASE;
+static volatile sdram_qos_t *const sdram_qos_control =
+        (sdram_qos_t *) (PL340_BASE + 0x100);
+static volatile sdram_chip_t *const sdram_chip_control =
+        (sdram_chip_t *) (PL340_BASE + 0x200);
+static volatile sdram_dll_t *const sdram_dll_control =
+        (sdram_dll_t *) (PL340_BASE + 0x300);
 
-static volatile system_controller_t *const system_controller =
+static volatile system_controller_t *const system_control =
         (system_controller_t *) SYSCTL_BASE;
+
+static volatile uchar *const ethernet_tx_buffer = (uchar *) ETH_TX_BASE;
+static volatile uchar *const ethernet_rx_buffer = (uchar *) ETH_RX_BASE;
+static volatile ethernet_receive_descriptor_t *const ethernet_desc_buffer =
+        (ethernet_receive_descriptor_t *) ETH_RX_DESC_RAM;
+static volatile ethernet_controller_t *const ethernet =
+        (ethernet_controller_t *) ETH_REGS;
 
 // ---------------------------------------------------------------------
 #endif // !__SPINN_EXTRA_H__

--- a/c_common/models/system_models/src/spinn_extra.h
+++ b/c_common/models/system_models/src/spinn_extra.h
@@ -25,6 +25,13 @@
 #ifndef __SPINN_EXTRA_H__
 #define __SPINN_EXTRA_H__
 
+#include <spinnaker.h>
+#if defined(__GNUC__) && __GNUC__ < 6
+// This particular warning (included in -Wextra) is retarded wrong for client
+// code of this file. Only really a problem on Travis.
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif // __GNUC__
+
 // ---------------------------------------------------------------------
 // 1. Chip Organization
 
@@ -38,7 +45,6 @@
 // ---------------------------------------------------------------------
 // 3. ARM968 Processing Subsystem
 
-#include <spinnaker.h>
 // No registers
 
 // ---------------------------------------------------------------------


### PR DESCRIPTION
This uses real C bitfields (**NB:** not the ones that Alan is struggling with! Not a close relation at all!) to make scrobbling around in the SpiNNaker hardware nicer, which reduces the nastiness of the extra monitor quite a bit. C bitfields are not particularly well known because they're rather non-portable, but the ARM ABI locks them down more (definitely little endian!) and as long as all the bitfield-structs are word sized, use uints for all members, and cover all 32 bits, things should be fine.

This does not make using the hardware *much* easier. You still need to read the datasheet if you're going to do very much.