### PR TITLE
Don't clear out the iobuf during initialisation steps

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1974,7 +1974,8 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
             algorithms.append("SdramUsageReportPerChip")
 
         # Clear iobuf from machine
-        if (not self._use_virtual_board and not self._empty_graphs and
+        if (self._has_ran and
+            not self._use_virtual_board and not self._empty_graphs and
                 self._config.getboolean("Reports", "clear_iobuf_during_run")):
             algorithms.append("ChipIOBufClearer")
 

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1974,8 +1974,7 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
             algorithms.append("SdramUsageReportPerChip")
 
         # Clear iobuf from machine
-        if (self._has_ran and
-            not self._use_virtual_board and not self._empty_graphs and
+        if (not self._use_virtual_board and not self._empty_graphs and
                 self._config.getboolean("Reports", "clear_iobuf_during_run")):
             algorithms.append("ChipIOBufClearer")
 

--- a/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
@@ -1585,7 +1585,11 @@
         <required_inputs>
             <param_name>transceiver</param_name>
             <param_name>executable_types</param_name>
+            <token>ApplicationRun</token>
         </required_inputs>
+        <optional_inputs>
+        	<token>ReadIOBuf</token>
+        </optional_inputs>
         <outputs>
             <token>ClearedIOBuf</token>
         </outputs>


### PR DESCRIPTION
Oops - previous fix to this was over-zealous and cleared the initial iobuf (i.e. anything written prior to the first timer tick) out.  This should fix it. 

Tested by https://github.com/SpiNNakerManchester/sPyNNaker8/pull/400