### PR TITLE
Report overruns correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
   - git clone https://github.com/SpiNNakerManchester/SupportScripts.git support
   - python support/travis_blocking_stdout.py
   - support/rat.sh download
-  # Bring pip up to date 
+  # Bring pip up to date
   - pip install --upgrade pip setuptools wheel
   - pip install --only-binary=numpy,scipy numpy scipy
   # SpiNNakerManchester internal dependencies; development mode
@@ -68,7 +68,7 @@ script:
   - py.test --cov-report= unittests --cov spinn_front_end_common
   - py.test --cov-report= fec_integration_tests --cov spinn_front_end_common --cov-append
   - flake8 spinn_front_end_common
-  - flake8 unittests integration_tests
+  - flake8 unittests fec_integration_tests
   - ( pylint --output-format=colorized --disable=R,C spinn_front_end_common; exit $(($? & 35)) )
   # XML
   - find spinn_front_end_common -name '*.xml' | xargs -n 1 support/validate-xml.sh

--- a/spinn_front_end_common/interface/provenance/provides_provenance_data_from_machine_impl.py
+++ b/spinn_front_end_common/interface/provenance/provides_provenance_data_from_machine_impl.py
@@ -225,7 +225,7 @@ class ProvidesProvenanceDataFromMachineImpl(
         data_items.append(ProvenanceDataItem(
             self._add_name(names, "max_number_of_times_timer_tic_over_ran"),
             max_number_of_times_timer_tic_over_ran,
-            report=max_number_of_times_timer_tic_over_ran > 4,
+            report=max_number_of_times_timer_tic_over_ran != 0,
             message=(
                 "The timer for {} on {}, {}, {} fell behind by up to {} "
                 "ticks. This is a sign of the system being overloaded and "


### PR DESCRIPTION
Changes the code so that it reports when overruns are not 0 rather than > 4.  We used to do > 4 as we didn't realise that the code "overran" at the end of simulation whilst writing to SDRAM.  It doesn't do this any more, as the timer is disabled early, so we should report the overruns correctly too.