### PR TITLE
Make IOBuf clearer work with run_until_complete

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ script:
   - py.test --cov-report= unittests --cov spinn_front_end_common
   - py.test --cov-report= fec_integration_tests --cov spinn_front_end_common --cov-append
   - flake8 spinn_front_end_common
-  - flake8 unittests integration_tests
+  - flake8 unittests fec_integration_tests
   - ( pylint --output-format=colorized --disable=R,C spinn_front_end_common; exit $(($? & 35)) )
   # XML
   - find spinn_front_end_common -name '*.xml' | xargs -n 1 support/validate-xml.sh

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1974,7 +1974,8 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
             algorithms.append("SdramUsageReportPerChip")
 
         # Clear iobuf from machine
-        if (not self._use_virtual_board and not self._empty_graphs and
+        if (not run_until_complete and
+            not self._use_virtual_board and not self._empty_graphs and
                 self._config.getboolean("Reports", "clear_iobuf_during_run")):
             algorithms.append("ChipIOBufClearer")
 
@@ -2034,8 +2035,7 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
         if (self._config.getboolean("Reports", "extract_iobuf") and
                 self._config.getboolean(
                     "Reports", "extract_iobuf_during_run") and
-                not self._use_virtual_board and
-                n_machine_time_steps is not None):
+                not self._use_virtual_board):
             algorithms.append("ChipIOBufExtractor")
 
         # add in the timing finalisation

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -2035,7 +2035,8 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
         if (self._config.getboolean("Reports", "extract_iobuf") and
                 self._config.getboolean(
                     "Reports", "extract_iobuf_during_run") and
-                not self._use_virtual_board):
+                not self._use_virtual_board and
+                not run_until_complete):
             algorithms.append("ChipIOBufExtractor")
 
         # add in the timing finalisation

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -280,6 +280,9 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
         "_minimum_auto_time_steps",
 
         #
+        "_run_until_complete",
+
+        #
         "_app_id",
 
         #
@@ -492,6 +495,7 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
         self._no_machine_time_steps = None
         self._minimum_auto_time_steps = self._config.getint(
                 "Buffers", "minimum_auto_time_steps")
+        self._run_until_complete = False
 
         self._app_id = self._read_config_int("Machine", "app_id")
 
@@ -749,6 +753,7 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
     def run_until_complete(self):
         """ Run a simulation until it completes
         """
+        self._run_until_complete = True
         self._run(None, run_until_complete=True)
 
     @overrides(SimulatorInterface.run)
@@ -2035,8 +2040,7 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
         if (self._config.getboolean("Reports", "extract_iobuf") and
                 self._config.getboolean(
                     "Reports", "extract_iobuf_during_run") and
-                not self._use_virtual_board and
-                not run_until_complete):
+                not self._use_virtual_board):
             algorithms.append("ChipIOBufExtractor")
 
         # add in the timing finalisation
@@ -2605,7 +2609,7 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
 
         # If we have run forever, stop the binaries
         if (self._has_ran and self._current_run_timesteps is None and
-                not self._use_virtual_board):
+                not self._use_virtual_board and not self._run_until_complete):
             executor = self._create_stop_workflow()
             run_complete = False
             try:

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -279,7 +279,7 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
         # The lowest values auto pause resume may use as steps
         "_minimum_auto_time_steps",
 
-        #
+        # Set when run_until_complete is specified by the user
         "_run_until_complete",
 
         #
@@ -483,7 +483,8 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
         self._database_interface = None
         self._create_database = None
 
-        # holder for timing related values
+        # holder for timing and running related values
+        self._run_until_complete = False
         self._has_ran = False
         self._state = Simulator_State.INIT
         self._state_condition = Condition()
@@ -495,7 +496,6 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
         self._no_machine_time_steps = None
         self._minimum_auto_time_steps = self._config.getint(
                 "Buffers", "minimum_auto_time_steps")
-        self._run_until_complete = False
 
         self._app_id = self._read_config_int("Machine", "app_id")
 
@@ -1933,8 +1933,7 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
             # reraise exception
             reraise(*e_inf)
 
-    def _create_execute_workflow(
-            self, n_machine_time_steps, graph_changed):
+    def _create_execute_workflow(self, n_machine_time_steps, graph_changed):
         # calculate number of machine time steps
         run_until_timesteps = self._calculate_number_of_machine_time_steps(
             n_machine_time_steps)


### PR DESCRIPTION
Another iobuf issue, this time noticed by @lplana in PDP2.  This fixes the issue with the ChipIOBufClearer when using run_until_complete(...) - I think it also works properly with run forever (i.e. run(None)) but it would be good if there are more tests for this other than a single GFE example...

Tested by https://github.com/SpiNNakerManchester/SpiNNakerGraphFrontEnd/pull/143 and https://github.com/SpiNNakerManchester/sPyNNaker8/pull/402