### PR TITLE
Routing compression checker from a report to an Algorithm

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1822,10 +1822,6 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
                     algorithms.append("comparisonOfRoutingTablesReport")
                     algorithms.append("CompressedRouterSummaryReport")
                     algorithms.append("RoutingTableFromMachineReport")
-            if self._config.getboolean(
-                    "Reports", "write_routing_compression_checker_report"):
-                routing_tables_needed = True
-                algorithms.append("routingCompressionCheckerReport")
 
         # handle extra monitor functionality
         enable_advanced_monitor = self._config.getboolean(

--- a/spinn_front_end_common/interface/spinnaker.cfg
+++ b/spinn_front_end_common/interface/spinnaker.cfg
@@ -49,7 +49,6 @@ write_application_graph_placer_report = True
 write_machine_graph_placer_report = False
 write_router_info_report = True
 write_routing_table_reports = True
-write_routing_compression_checker_report = False
 write_routing_tables_from_machine_reports = True
 write_routing_table_compression_bit_field_summary = True
 write_memory_map_report = False


### PR DESCRIPTION
No longer check for cfg routing_compression_checker_report as it is no longer a report.

Must be done after or at the same time as: https://github.com/SpiNNakerManchester/sPyNNaker8/pull/411