### PR TITLE
corrected faulty docstring in `spinn_front_end_common/abstract_models/abstract_provides_n_keys_for_partition.py`

### DIFF
--- a/spinn_front_end_common/abstract_models/abstract_provides_n_keys_for_partition.py
+++ b/spinn_front_end_common/abstract_models/abstract_provides_n_keys_for_partition.py
@@ -33,6 +33,6 @@ class AbstractProvidesNKeysForPartition(object):
         :type partition: ~pacman.model.graphs.AbstractOutgoingEdgePartition
         :param graph_mapper: A mapper between the graphs
         :type graph_mapper: :py:class:`~pacman.model.graph.GraphMapper`
-        :return: A list of constraints
-        :rtype: list(~pacman.model.constraints.AbstractConstraint)
+        :return: The number of keys required
+        :rtype: int
         """


### PR DESCRIPTION
Hi all,

talked with @alan-stokes today about `AbstractProvidesNKeysForPartition` and I found a missleading docstring, saying the `get_n_keys_for_partition` method would return a list of objects inheriting from `pacman.model.constraint.AbstractConstraint` when in fact the method should just return the number of keys as an integer (according to @alan-stokes ).

Kind regards,
Jonas