### PR TITLE
Run progress

### DIFF
--- a/spinn_front_end_common/interface/interface_functions/machine_bit_field_router_compressor.py
+++ b/spinn_front_end_common/interface/interface_functions/machine_bit_field_router_compressor.py
@@ -258,9 +258,7 @@ class MachineBitFieldRouterCompressor(object):
         if len(on_host_chips) != 0:
             logger.warning(self._ON_HOST_WARNING_MESSAGE, len(on_host_chips))
             progress_bar = ProgressBar(
-                total_number_of_things_to_do=len(on_host_chips),
-                string_describing_what_being_progressed=
-                self._HOST_PROGRESS_TEXT)
+                len(on_host_chips), self._HOST_PROGRESS_TEXT)
             host_compressor = HostBasedBitFieldRouterCompressor()
             compressed_pacman_router_tables = MulticastRoutingTables()
 

--- a/spinn_front_end_common/utilities/system_control_logic.py
+++ b/spinn_front_end_common/utilities/system_control_logic.py
@@ -84,7 +84,8 @@ def run_system_application(
     # Wait for the executable to finish
     try:
         transceiver.wait_for_cores_to_be_in_state(
-            check_targets.all_core_subsets, app_id, cpu_end_states)
+            check_targets.all_core_subsets, app_id, cpu_end_states,
+            suppress_progress=False)
         succeeded = True
     except (SpinnmanTimeoutException, SpinnmanException):
         if handle_failure_function is not None:

--- a/spinn_front_end_common/utilities/system_control_logic.py
+++ b/spinn_front_end_common/utilities/system_control_logic.py
@@ -100,7 +100,7 @@ def run_system_application(
     if read_algorithm_iobuf or not succeeded:
         iobuf_reader = ChipIOBufExtractor(
             filename_template=filename_template,
-            suppress_progress=succeeded)
+            suppress_progress=False)
         iobuf_reader(
             transceiver, executable_cores, executable_finder,
             system_provenance_file_path=provenance_file_path)

--- a/unittests/interface/interface_functions/test_router_compressor.py
+++ b/unittests/interface/interface_functions/test_router_compressor.py
@@ -49,7 +49,7 @@ class MockTransceiverError(object):
             time_between_polls=0.1,
             error_states=frozenset(
                 {CPUState.RUN_TIME_EXCEPTION, CPUState.WATCHDOG}),
-            counts_between_full_check=100):
+            counts_between_full_check=100, suppress_progress=True):
         # Return immediately
         pass
 


### PR DESCRIPTION
Instead of one tangled progress bars the code using run_system_application will have three bars
1. For the preparing of the run
2., The tranceiver as it finds cores have finished
3. Iobuf extractor

Depends on https://github.com/SpiNNakerManchester/SpiNNUtils/pull/118  https://github.com/SpiNNakerManchester/SpiNNMan/pull/211
Looks better with https://github.com/SpiNNakerManchester/sPyNNaker/pull/837