### PR TITLE
router diagnositcs misleading

### DIFF
--- a/spinn_front_end_common/interface/interface_functions/application_runner.py
+++ b/spinn_front_end_common/interface/interface_functions/application_runner.py
@@ -53,7 +53,7 @@ class ApplicationRunner(object):
     def __call__(
             self, buffer_manager, notification_interface, executable_types,
             app_id, txrx, runtime, time_scale_factor, no_sync_changes,
-            time_threshold, run_until_complete=False):
+            time_threshold, machine, run_until_complete=False):
         # pylint: disable=too-many-arguments
         logger.info("*** Running simulation... *** ")
 
@@ -71,6 +71,12 @@ class ApplicationRunner(object):
 
         # every thing is in sync0 so load the initial buffers
         buffer_manager.load_initial_buffers()
+
+        # clear away any router diagnostics that have been set due to all
+        # loading applications
+        for chip in machine.chips:
+            if not chip.virtual:
+                txrx.clear_router_diagnostic_counters(chip.x, chip.y)
 
         # wait till external app is ready for us to start if required
         notification_interface.wait_for_confirmation()

--- a/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
@@ -1524,6 +1524,11 @@
                 <param_name>run_until_complete</param_name>
                 <param_type>RunUntilCompleteFlag</param_type>
             </parameter>
+            <parameter>
+                <param_name>machine</param_name>
+                <param_type>MemoryExtendedMachine</param_type>
+                <param_type>MemoryMachine</param_type>
+            </parameter>
         </input_definitions>
         <required_inputs>
             <param_name>buffer_manager</param_name>
@@ -1535,6 +1540,7 @@
             <param_name>time_scale_factor</param_name>
             <param_name>no_sync_changes</param_name>
             <param_name>time_threshold</param_name>
+            <param_name>machine</param_name>
             <token>DataLoaded</token>
             <token>BinariesLoaded</token>
         </required_inputs>


### PR DESCRIPTION
this clears them the moment before app runner sends the signal to run. anytime before this is counter productive as otehr loading algorithms could end up producing packet drops. 