### PR TITLE
fixes the compressors in a multiude of ways.

### DIFF
--- a/c_common/models/compressors/src/bit_field_common/bit_field_table_generator.h
+++ b/c_common/models/compressors/src/bit_field_common/bit_field_table_generator.h
@@ -142,8 +142,7 @@ static inline uint32_t bit_field_table_generator_max_size(
 }
 
 //! \brief Take a midpoint and read the sorted bitfields up to that point,
-//!     generating bitfield routing tables and loading them into SDRAM for
-//!     transfer to a compressor processor
+//!     generating bitfield routing tables and loading them into SDRAM
 //! \param[in] mid_point: where in the sorted bitfields to go to
 //! \param[in] uncompressed_table: the uncompressed router table
 //! \param[in] sorted_bit_fields: the pointer to the sorted bit field struct.

--- a/c_common/models/compressors/src/bit_field_common/routing_tables.h
+++ b/c_common/models/compressors/src/bit_field_common/routing_tables.h
@@ -151,7 +151,7 @@ void routing_tables_save(multi_table_t *restrict tables) {
     tables->n_entries = multi_table.n_entries;
     tables->max_entries = multi_table.max_entries;
     log_info("saved table with %d entries over %d tables",
-            tables->n_sub_tables, tables->n_entries);
+            tables->n_entries, tables->n_sub_tables);
 }
 
 void routing_table_remove_from_size(int size_to_remove) {

--- a/c_common/models/compressors/src/common/routing_table.h
+++ b/c_common/models/compressors/src/common/routing_table.h
@@ -74,7 +74,8 @@ void routing_table_remove_from_size(int size_to_remove);
 //! \param[in] index: Where to write it.
 static inline void routing_table_put_entry(const entry_t* entry, int index) {
     entry_t* e_ptr = routing_table_get_entry(index);
-    e_ptr->key_mask = entry->key_mask;
+    e_ptr->key_mask.key = entry->key_mask.key;
+    e_ptr->key_mask.mask = entry->key_mask.mask;
     e_ptr->route = entry->route;
     e_ptr->source = entry->source;
 }

--- a/c_common/models/compressors/src/compressor_includes/pair_minimize.h
+++ b/c_common/models/compressors/src/compressor_includes/pair_minimize.h
@@ -147,45 +147,16 @@ static inline int compare_routes(uint32_t route_a, uint32_t route_b) {
 //!                 inclusive lowest index
 //! \param[in] high: the second index into the array of the section to sort;
 //!                  exclusive highest index
-static void quicksort_table(int low, int high) {
-    if (low < high - 1) {
-        // pick low entry for the pivot
-        uint32_t pivot = routing_table_get_entry(low)->route;
-        // Location of entry currently being checked.
-        // At the end check will point to either
-        //     the right most entry with a value greater than the pivot
-        //     or high indicating there are no entries greater than the pivot
-        //Start at low + 1 as entry low is the pivot
-        int check = low + 1;
-        // Location to write any smaller values to
-        // Will always point to most left entry with pivot value
-        // If we find any less than swap with the first pivot
-        int l_write = low;
-        // Location to write any greater values to
-        // Until the algorithm ends this will point to an unsorted value
-        // if we find any higher swap with last entry in the sort section
-        int h_write = high - 1;
-
-        while (check <= h_write) {
-            uint32_t check_route =
-                    routing_table_get_entry(check)->route;
-            int compare = compare_routes(check_route, pivot);
-            if (compare < 0) {
-                // swap the check to the left, and then
-                // move the check on as known to be pivot value
-                swap_entries(l_write++, check++);
-            } else if (compare > 0) {
-                // swap the check to the right
-                // Do not move the check as it has an unknown value
-                swap_entries(h_write--, check);
-            } else {
-                // Move check as it has the pivot value
-                check++;
+static void sort_table(int table_size) {
+    for (int i = 0; i < table_size -1; i++) {
+        uint32_t route_i = routing_table_get_entry(i)->route;
+        for (int j = i + 1; j < table_size; j++) {
+            uint32_t route_j = routing_table_get_entry(j)->route;
+            if (compare_routes(route_i, route_j) < 0) {
+                swap_entries(i, j);
+                route_i = route_j;
             }
         }
-        // Now sort the ones less than or more than the pivot
-        quicksort_table(low, l_write);
-        quicksort_table(check, high);
     }
 }
 
@@ -208,57 +179,24 @@ static inline void swap_routes(int index_a, int index_b) {
 //!
 //! The routes must be non-overlapping pre-minimisation routes.
 //!
-//! \param[in] low: the first index into the array of the section to sort;
-//!                 inclusive low point of range
-//! \param[in] high: the second index into the array of the section to sort;
-//!                  exclusive high point of range
-static void quicksort_route(int low, int high) {
-    if (low < high - 1) {
-        // pick low entry for the pivot
-        uint pivot = routes_frequency[low];
-        // Location of entry currently being checked.
-        // At the end check will point to either
-        //     the right most entry with a value greater than the pivot
-        //     or high indicating there are no entries greater than the pivot
-        //Start at low + 1 as entry low is the pivot
-        int check = low + 1;
-        // Location to write any smaller values to
-        // Will always point to most left entry with pivot value
-        // If we find any less than swap with the first pivot
-        int l_write = low;
-        // Location to write any greater values to
-        // Until the algorithm ends this will point to an unsorted value
-        // if we find any higher swap with last entry in the sort section
-        int h_write = high -1;
-
-        while (check <= h_write) {
-            if (routes_frequency[check] < pivot) {
-                // swap the check to the left, and then
-                // move the check on as known to be pivot value
-                swap_routes(l_write++, check++);
-            } else if (routes_frequency[check] > pivot) {
-                // swap the check to the right
-                swap_routes(h_write--, check);
-                // Do not move the check as it has an unknown value
-            } else {
-                // Move check as it has the pivot value
-                check++;
+static void sort_routes(void) {
+    for (int i = 0; i < routes_count -1; i++) {
+        for (int j = i + 1; j < routes_count; j++) {
+            if (routes_frequency[i] > routes_frequency[j]) {
+                swap_routes(i, j);
             }
         }
-        // Now sort the ones less than or more than the pivot
-        quicksort_route(low, l_write);
-        quicksort_route(check, high);
     }
 }
 
 //! \brief Computes route histogram
 //! \param[in] index: The index of the cell to update
-static inline void update_frequency(int index) {
+static inline bool update_frequency(int index) {
     uint32_t route = routing_table_get_entry(index)->route;
     for (uint i = 0; i < routes_count; i++) {
         if (routes[i] == route) {
             routes_frequency[i]++;
-            return;
+            return true;
         }
     }
     routes[routes_count] = route;
@@ -267,11 +205,10 @@ static inline void update_frequency(int index) {
     if (routes_count >= MAX_NUM_ROUTES) {
         log_error("Best compression was %d compared to max legal of %d",
                 routes_count, MAX_NUM_ROUTES);
-        // set the failed flag and exit
-        malloc_extras_terminate(EXITED_CLEANLY);
+        return false;
     }
+    return true;
 }
-
 
 //! \brief Implementation of minimise()
 //! \param[in] target_length: ignored
@@ -287,14 +224,16 @@ bool minimise_run(int target_length, bool *failed_by_malloc,
     if (MAX_NUM_ROUTES != rtr_alloc_max()){
         log_error("MAX_NUM_ROUTES %d != rtr_alloc_max() %d",
                 MAX_NUM_ROUTES, rtr_alloc_max());
-            malloc_extras_terminate(EXIT_FAIL);
+            return false;
     }
     int table_size = routing_table_get_n_entries();
 
     routes_count = 0;
 
     for (int index = 0; index < table_size; index++) {
-        update_frequency(index);
+        if (!update_frequency(index)) {
+            return false;
+        }
     }
 
     log_debug("before sort %u", routes_count);
@@ -302,7 +241,7 @@ bool minimise_run(int target_length, bool *failed_by_malloc,
         log_debug("%u", routes[i]);
     }
 
-    quicksort_route(0, routes_count);
+    sort_routes();
     if (*stop_compressing) {
         log_info("Stopping as asked to stop");
         return false;
@@ -314,7 +253,7 @@ bool minimise_run(int target_length, bool *failed_by_malloc,
     }
 
     log_debug("do quicksort_table by route %u", table_size);
-    quicksort_table(0, table_size);
+    sort_table(table_size);
     if (*stop_compressing) {
         log_info("Stopping before compression as asked to stop");
         return false;

--- a/c_common/models/compressors/src/sorter/bit_field_sorter_and_searcher.c
+++ b/c_common/models/compressors/src/sorter/bit_field_sorter_and_searcher.c
@@ -859,7 +859,7 @@ void process_compressor_response(
 
     case FORCED_BY_COMPRESSOR_CONTROL:
         // compressor stopped at the request of the sorter.
-        log_info("ack from forced from processor %d doing mid point %d",
+        log_debug("ack from forced from processor %d doing mid point %d",
                 processor_id, mid_point);
         routing_tables_utils_free_all(comms_sdram[processor_id].routing_tables);
         break;


### PR DESCRIPTION
1. better log so the numbers are in the correct order in routing_tables.h
2. fixed the moving of key and mask to be moved seperately, as that can go wrong occasionsly. in routing_table.h
3. fixed doc to not think its being built in the sorter anymore for table generation in bit_field_table_generator.h
4. removed a log debug in bit_field_sorter_and_searcher.c
5. removed the recursive sorts into sequeial sorts, as recursive sorts broke down in pair minimize.h
6. fixed update_frequency in pair minimize.h to not shit over memory when more than 1023 unqiue routes appear.

testing via:
https://github.com/SpiNNakerManchester/sPyNNaker8/pull/441