### PR TITLE
wait for interrupt in a common header

### DIFF
--- a/c_common/front_end_common_lib/Makefile
+++ b/c_common/front_end_common_lib/Makefile
@@ -36,7 +36,7 @@ BUILD_OBJS = $(OBJS:%.o=$(SPINN_COMMON_BUILD)/%.o)
 # Headers
 HEADERS = common-typedefs.h data_specification.h simulation.h recording.h \
           profiler.h buffered_eieio_defs.h debug.h eieio.h sdp_no_scp.h \
-          filter_info.h key_atom_map.h malloc_extras.h
+          filter_info.h key_atom_map.h malloc_extras.h spin1-wfi.h
 INSTALL_HEADERS = $(HEADERS:%.h=$(SPINN_INC_DIR)/%.h)
 
 # Makefile

--- a/c_common/front_end_common_lib/include/spin1-wfi.h
+++ b/c_common/front_end_common_lib/include/spin1-wfi.h
@@ -27,7 +27,7 @@
 //!     see [the relevant ARM documentation][wfi] (it's hardware magic,
 //!     specific to the ARM968).
 //!
-//! [wfi]: [https://developer.arm.com/documentation/ddi0311/d/system-control-coprocessor/cp15-register-descriptions/cp15-c7-core-control-operations]
+//! [wfi]: https://developer.arm.com/documentation/ddi0311/d/system-control-coprocessor/cp15-register-descriptions/cp15-c7-core-control-operations
 static inline void spin1_wfi(void) {
     register uint32_t value = 0;
     asm volatile("mcr p15, 0, %[value], c7, c0, 4" : : [value] "r" (value));

--- a/c_common/front_end_common_lib/include/spin1-wfi.h
+++ b/c_common/front_end_common_lib/include/spin1-wfi.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include <stdint.h>
+
+//! \file
+//! \brief Declaration that is common but not in spin1_api.h
+
+//! \brief Wait for interrupt.
+//! \details Inline version of code that appears in spin1_api so that we can
+//!     get more compact code. For a description of what this actually does,
+//!     see [the relevant ARM documentation][wfi] (it's hardware magic,
+//!     specific to the ARM968).
+//!
+//! [wfi]: [https://developer.arm.com/documentation/ddi0311/d/system-control-coprocessor/cp15-register-descriptions/cp15-c7-core-control-operations]
+static inline void spin1_wfi(void) {
+    register uint32_t value = 0;
+    asm volatile("mcr p15, 0, %[value], c7, c0, 4" : : [value] "r" (value));
+}

--- a/c_common/front_end_common_lib/include/spin1-wfi.h
+++ b/c_common/front_end_common_lib/include/spin1-wfi.h
@@ -21,13 +21,14 @@
 //! \file
 //! \brief Declaration that is common but not in spin1_api.h
 
-//! \brief Wait for interrupt.
-//! \details Inline version of code that appears in spin1_api so that we can
-//!     get more compact code. For a description of what this actually does,
-//!     see [the relevant ARM documentation][wfi] (it's hardware magic,
-//!     specific to the ARM968).
-//!
-//! [wfi]: https://developer.arm.com/documentation/ddi0311/d/system-control-coprocessor/cp15-register-descriptions/cp15-c7-core-control-operations
+/*! \brief Wait for interrupt.
+ *  \details Inline version of code that appears in spin1_api so that we can
+ *      get more compact code. For a description of what this actually does,
+ *      see <a href="https://developer.arm.com/
+documentation/ddi0311/d/system-control-coprocessor/cp15-register-descriptions/
+cp15-c7-core-control-operations">the relevant ARM documentation</a>
+ *      (it's hardware magic, specific to the ARM968).
+ */
 static inline void spin1_wfi(void) {
     register uint32_t value = 0;
     asm volatile("mcr p15, 0, %[value], c7, c0, 4" : : [value] "r" (value));

--- a/c_common/front_end_common_lib/src/recording.c
+++ b/c_common/front_end_common_lib/src/recording.c
@@ -28,10 +28,7 @@
 #include <circular_buffer.h>
 #include <spin1_api_params.h>
 #include <debug.h>
-
-// Declare wfi function
-//! Wait For Interrupt
-extern void spin1_wfi(void);
+#include <spin1-wfi.h>
 
 //---------------------------------------
 // Structures

--- a/c_common/front_end_common_lib/src/simulation.c
+++ b/c_common/front_end_common_lib/src/simulation.c
@@ -26,13 +26,9 @@
 #include <debug.h>
 #include <spin1_api_params.h>
 #include <spin1_api.h>
+#include <spin1-wfi.h>
 
 // Import things from spin1_api that are not explicitly exposed //
-
-//! \brief Wait for interrupt.
-//! \details Will return to just after this point after an
-//!     interrupt has been raised.
-extern void spin1_wfi(void);
 
 //! \brief Indicate whether the SYNC signal has been received.
 //! \return 0 (false) if not received and 1 (true) if received.

--- a/c_common/models/reverse_iptag_multicast_source/src/reverse_iptag_multicast_source.c
+++ b/c_common/models/reverse_iptag_multicast_source/src/reverse_iptag_multicast_source.c
@@ -30,10 +30,7 @@
 #include <eieio.h>
 #include <buffered_eieio_defs.h>
 #include "recording.h"
-
-// Declare wfi function
-//! Wait for interrupt (semi-public part of Spin1API)
-extern void spin1_wfi(void);
+#include <spin1-wfi.h>
 
 // ------------------------------------------------------------------------
 

--- a/c_common/models/system_models/src/extra_monitor_support.c
+++ b/c_common/models/system_models/src/extra_monitor_support.c
@@ -29,6 +29,7 @@
 #include <stdbool.h>
 #include <common-typedefs.h>
 #include "common.h"
+#include <spin1-wfi.h>
 
 // Debugging control
 //#define DEBUG_DATA_IN
@@ -585,9 +586,6 @@ static bool data_out_stop = false;
 // ------------------------------------------------------------------------
 // support functions and variables
 // ------------------------------------------------------------------------
-
-//! Wait for interrupt. (Undisclosed import from Spin1API.)
-extern void spin1_wfi(void);
 
 //! The standard SARK CPU interrupt handler.
 extern INT_HANDLER sark_int_han(void);


### PR DESCRIPTION
This shouldn't lengthen the code, since it generates the same code as always, yet it allows us to get rid of one of the few calls that remains in our inner loops. (We also retain `spin1_send_mc_packet()` and so on, but those are doing a lot more work.)