### PR TITLE
UNUSED declarations!

### DIFF
--- a/c_common/Doxyfile
+++ b/c_common/Doxyfile
@@ -187,7 +187,7 @@ USE_MDFILE_AS_MAINPAGE =
 # Configuration options related to source browsing
 #---------------------------------------------------------------------------
 
-SOURCE_BROWSER         = NO
+SOURCE_BROWSER         = YES
 INLINE_SOURCES         = NO
 STRIP_CODE_COMMENTS    = YES
 REFERENCED_BY_RELATION = NO
@@ -310,7 +310,7 @@ EXPAND_ONLY_PREDEF     = YES
 SEARCH_INCLUDES        = YES
 INCLUDE_PATH           =
 INCLUDE_FILE_PATTERNS  =
-PREDEFINED             = __attribute__(x)= PROFILER_ENABLED=YES INT_HANDLER=void
+PREDEFINED             = __attribute__(x)= PROFILER_ENABLED=YES INT_HANDLER=void UNDEFINED= 
 EXPAND_AS_DEFINED      =
 SKIP_FUNCTION_MACROS   = YES
 
@@ -318,7 +318,7 @@ SKIP_FUNCTION_MACROS   = YES
 # Configuration options related to external references
 #---------------------------------------------------------------------------
 
-TAGFILES               = sllt.tag=http://spinnakermanchester.github.io/spinnaker_tools/ common.tag=http://spinnakermanchester.github.io/spinn_common/ 
+TAGFILES               = sllt.tag=http://spinnakermanchester.github.io/spinnaker_tools/ common.tag=http://spinnakermanchester.github.io/spinn_common/
 GENERATE_TAGFILE       = doc/html/fec.tag
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES

--- a/c_common/front_end_common_lib/src/recording.c
+++ b/c_common/front_end_common_lib/src/recording.c
@@ -486,8 +486,7 @@ static inline void recording_send_buffering_out_trigger_message(
 //!
 //! \param[in,out] mailbox: Pointer to the message to receive
 //! \param[in] port: The SDP port of the message. Constant.
-static void buffering_in_handler(uint mailbox, uint port) {
-    use(port);
+static void buffering_in_handler(uint mailbox, UNUSED uint port) {
     sdp_msg_t *msg = (sdp_msg_t *) mailbox;
     uint16_t length = msg->length;
     eieio_msg_t eieio_msg_ptr = (eieio_msg_t) &msg->cmd_rc;

--- a/c_common/front_end_common_lib/src/simulation.c
+++ b/c_common/front_end_common_lib/src/simulation.c
@@ -160,8 +160,7 @@ static void synchronise_start(uint unused0, uint unused1) {
 //!     needs to be stopped.
 //! \param[in] mailbox: The mailbox containing the SDP packet received
 //! \param[in] port: The port on which the packet was received
-static void simulation_control_scp_callback(uint mailbox, uint port) {
-    use(port);
+static void simulation_control_scp_callback(uint mailbox, UNUSED uint port) {
     sdp_msg_t *msg = (sdp_msg_t *) mailbox;
     uint16_t length = msg->length;
 

--- a/c_common/models/chip_power_monitor/src/chip_power_monitor.c
+++ b/c_common/models/chip_power_monitor/src/chip_power_monitor.c
@@ -147,9 +147,7 @@ static void count_core_states(void) {
 //! \brief Called to actually record a sample.
 //! \param unused0 unused
 //! \param unused1 unused
-static void sample_in_slot(uint unused0, uint unused1) {
-    use(unused0);
-    use(unused1);
+static void sample_in_slot(UNUSED uint unused0, UNUSED uint unused1) {
     time++;
 
     // handle the situation when the first time update is sent

--- a/c_common/models/command_sender_multicast_source/src/command_sender_multicast_source.c
+++ b/c_common/models/command_sender_multicast_source/src/command_sender_multicast_source.c
@@ -274,9 +274,7 @@ static bool read_pause_stop_commands(command_list *sdram_commands) {
 //!
 //! \param unused0 unused
 //! \param unused1 unused
-static void timer_callback(uint unused0, uint unused1) {
-    use(unused0);
-    use(unused1);
+static void timer_callback(UNUSED uint unused0, UNUSED uint unused1) {
     time++;
 
     if (resume) {

--- a/c_common/models/compressors/src/bit_field_compressor.c
+++ b/c_common/models/compressors/src/bit_field_compressor.c
@@ -268,11 +268,7 @@ static inline bool process_force(compressor_states compressor_state) {
 //!     (including to deliver instructions to us to work) will breeze past.
 //! \param[in] unused0: unused
 //! \param[in] unused1: unused
-static void wait_for_instructions(uint unused0, uint unused1) {
-    //api requirements
-    use(unused0);
-    use(unused1);
-
+static void wait_for_instructions(UNUSED uint unused0, UNUSED uint unused1) {
     // set if combination of user2 and user3 is expected
     bool users_match = true;
 
@@ -325,9 +321,7 @@ static void wait_for_instructions(uint unused0, uint unused1) {
 //!     Could be because sorter has cancelled run request.
 //! \param[in] unused0: not used
 //! \param[in] unused1: not used
-static void timer_callback(uint unused0, uint unused1) {
-    use(unused0);
-    use(unused1);
+static void timer_callback(UNUSED uint unused0, UNUSED uint unused1) {
     counter++;
 
     if (counter >= max_counter) {

--- a/c_common/models/compressors/src/ordered_covering_includes/bit_set.h
+++ b/c_common/models/compressors/src/ordered_covering_includes/bit_set.h
@@ -166,8 +166,6 @@ static inline void print_bit_field_entry_v2(uint32_t e, int offset) {
 //! \param[in] b The sequence of words representing a bit_field.
 //! \param[in] s The size of the bit_field.
 void print_bit_field_bits_v2(bit_field_t b, size_t s) {
-    use(b);
-    use(s);
     for (int i = s; i > 0; i--) {
 	    print_bit_field_entry_v2(b[i], ((i - 1) * 32));
     }
@@ -178,8 +176,6 @@ void print_bit_field_bits_v2(bit_field_t b, size_t s) {
 //! \param[in] b The sequence of words representing a bit_field.
 //! \param[in] s The size of the bit_field.
 void print_bit_set_bits(bit_field_t b, int s) {
-    use(b);
-    use(s);
     for (int i = s; i > 0; i--) {
 	    print_bit_field_entry_v2(b[i], ((i - 1) * BITS_IN_A_WORD));
     }

--- a/c_common/models/compressors/src/simple/simple_compressor.c
+++ b/c_common/models/compressors/src/simple/simple_compressor.c
@@ -37,10 +37,7 @@
 //! \brief The callback for setting off the router compressor
 //! \param[in] unused0: unused
 //! \param[in] unused1: unused
-void compress_start(uint unused0, uint unused1) {
-    use(unused0);
-    use(unused1);
-
+void compress_start(UNUSED uint unused0, UNUSED uint unused1) {
     log_info("Starting on chip router compressor");
 
     // Prepare to minimise the routing tables

--- a/c_common/models/compressors/src/sorter/bit_field_sorter_and_searcher.c
+++ b/c_common/models/compressors/src/sorter/bit_field_sorter_and_searcher.c
@@ -702,9 +702,7 @@ void carry_on_binary_search(void) {
 //! \brief Timer interrupt for controlling time taken to try to compress table
 //! \param[in] unused0: unused
 //! \param[in] unused1: unused
-void timer_callback(uint unused0, uint unused1) {
-    use(unused0);
-    use(unused1);
+void timer_callback(UNUSED uint unused0, UNUSED uint unused1) {
     time_steps++;
     // Debug stuff please keep
 #if 0
@@ -877,10 +875,7 @@ void process_compressor_response(
 //! \brief Check compressors' state till they're finished.
 //! \param[in] unused0: unused
 //! \param[in] unused1: unused
-void check_compressors(uint unused0, uint unused1) {
-    use(unused0);
-    use(unused1);
-
+void check_compressors(UNUSED uint unused0, UNUSED uint unused1) {
     log_info("Entering the check_compressors loop");
     // iterate over the compressors buffer until we have the finished state
     while (!terminated) {
@@ -952,11 +947,7 @@ void start_binary_search(void) {
 //! \brief Start the work for the compression search
 //! \param[in] unused0: unused
 //! \param[in] unused1: unused
-void start_compression_process(uint unused0, uint unused1) {
-    //api requirements
-    use(unused0);
-    use(unused1);
-
+void start_compression_process(UNUSED uint unused0, UNUSED uint unused1) {
     // malloc the struct and populate n bit-fields. DOES NOT populate the rest.
     sorted_bit_fields = bit_field_reader_initialise(region_addresses);
     // check state to fail if not read in

--- a/c_common/models/live_packet_gather/src/live_packet_gather.c
+++ b/c_common/models/live_packet_gather/src/live_packet_gather.c
@@ -249,10 +249,7 @@ static void record_provenance_data(address_t provenance_region_address) {
 //!
 //! \param unused0: unused
 //! \param unused1: unused
-static void timer_callback(uint unused0, uint unused1) {
-    use(unused0);
-    use(unused1);
-
+static void timer_callback(UNUSED uint unused0, UNUSED uint unused1) {
     // flush the spike message and sent it over the Ethernet
     flush_events();
 
@@ -362,10 +359,8 @@ static void process_incoming_event_payload(uint key, uint payload) {
 //!
 //! \param unused0: Ignored
 //! \param unused1: Ignored
-static void incoming_event_process_callback(uint unused0, uint unused1) {
-    use(unused0);
-    use(unused1);
-
+static void incoming_event_process_callback(
+        UNUSED uint unused0, UNUSED uint unused1) {
     do {
         uint32_t key, payload;
 
@@ -391,8 +386,7 @@ static void incoming_event_process_callback(uint unused0, uint unused1) {
 //!
 //! \param[in] key: The key of the incoming packet.
 //! \param unused: unused
-static void incoming_event_callback(uint key, uint unused) {
-    use(unused);
+static void incoming_event_callback(uint key, UNUSED uint unused) {
     log_debug("Received key %x", key);
 
     if (circular_buffer_add(without_payload_buffer, key)) {

--- a/c_common/models/reverse_iptag_multicast_source/src/reverse_iptag_multicast_source.c
+++ b/c_common/models/reverse_iptag_multicast_source/src/reverse_iptag_multicast_source.c
@@ -38,6 +38,10 @@
 #error APPLICATION_NAME_HASH must be defined
 #endif
 
+#ifndef __use
+#define __use(x)    do { (void) (x); } while (0)
+#endif
+
 //! \brief human readable versions of the different priorities and usages.
 enum interrupt_priorities {
     DMA = 0,
@@ -352,8 +356,8 @@ static inline uint16_t calculate_eieio_packet_size(eieio_msg_t eieio_msg_ptr) {
 //! \param[in] length: Length of the message
 static inline void print_packet_bytes(
         eieio_msg_t eieio_msg_ptr, uint16_t length) {
-    use(eieio_msg_ptr);
-    use(length);
+    __use(eieio_msg_ptr);
+    __use(length);
 #if LOG_LEVEL >= LOG_DEBUG
     uint8_t *ptr = (uint8_t *) eieio_msg_ptr;
 
@@ -375,7 +379,7 @@ static inline void print_packet_bytes(
 //!
 //! \param[in] eieio_msg_ptr Pointer to the message to print
 static inline void print_packet(const eieio_msg_t eieio_msg_ptr) {
-    use(eieio_msg_ptr);
+    __use(eieio_msg_ptr);
 #if LOG_LEVEL >= LOG_DEBUG
     uint32_t len = calculate_eieio_packet_size(eieio_msg_ptr);
     print_packet_bytes(eieio_msg_ptr, len);
@@ -390,8 +394,8 @@ static inline void print_packet(const eieio_msg_t eieio_msg_ptr) {
 //! \param[in] length: The length of the message
 static inline void signal_software_error(
         const eieio_msg_t eieio_msg_ptr, uint16_t length) {
-    use(eieio_msg_ptr);
-    use(length);
+    __use(eieio_msg_ptr);
+    __use(length);
 #if LOG_LEVEL >= LOG_DEBUG
     print_packet_bytes(eieio_msg_ptr, length);
     rt_error(RTE_SWERR);
@@ -848,9 +852,7 @@ static inline bool eieio_data_parse_packet(
 //! \param[in] eieio_msg_ptr: The command message
 //! \param[in] length: The length of the message
 static inline void eieio_command_parse_stop_requests(
-        const eieio_msg_t eieio_msg_ptr, uint16_t length) {
-    use(eieio_msg_ptr);
-    use(length);
+        UNUSED const eieio_msg_t eieio_msg_ptr, UNUSED uint16_t length) {
     log_debug("Stopping packet requests - parse_stop_packet_reqs");
     send_packet_reqs = false;
     last_stop_notification_request = time;
@@ -860,9 +862,7 @@ static inline void eieio_command_parse_stop_requests(
 //! \param[in] eieio_msg_ptr: The command message
 //! \param[in] length: The length of the message
 static inline void eieio_command_parse_start_requests(
-        const eieio_msg_t eieio_msg_ptr, uint16_t length) {
-    use(eieio_msg_ptr);
-    use(length);
+        UNUSED const eieio_msg_t eieio_msg_ptr, UNUSED uint16_t length) {
     log_debug("Starting packet requests - parse_start_packet_reqs");
     send_packet_reqs = true;
 }
@@ -1249,9 +1249,7 @@ static void resume_callback(void) {
 //! \brief The fundamental operation loop for the application.
 //! \param unused0 unused
 //! \param unused1 unused
-static void timer_callback(uint unused0, uint unused1) {
-    use(unused0);
-    use(unused1);
+static void timer_callback(UNUSED uint unused0, UNUSED uint unused1) {
     time++;
 
     log_debug("timer_callback, final time: %d, current time: %d,"
@@ -1310,8 +1308,7 @@ static void timer_callback(uint unused0, uint unused1) {
 //!
 //! \param[in] mailbox: The address of the message.
 //! \param port: The SDP port of the message. Ignored.
-static void sdp_packet_callback(uint mailbox, uint port) {
-    use(port);
+static void sdp_packet_callback(uint mailbox, UNUSED uint port) {
     sdp_msg_t *msg = (sdp_msg_t *) mailbox;
     uint16_t length = msg->length;
     eieio_msg_t eieio_msg_ptr = (eieio_msg_t) &msg->cmd_rc;


### PR DESCRIPTION
This uses [the new capabilities of spinn_common](https://github.com/SpiNNakerManchester/spinn_common/pull/43) to mark things as unused in ways that the compiler can actually check for us. This is good.

This should not affect the running executable at all. Testing is by reading the output of the compilation run on Travis only.