### PR TITLE
Get rid of signed/unsigned warnings

### DIFF
--- a/c_common/models/compressors/src/bit_field_common/bit_field_table_generator.h
+++ b/c_common/models/compressors/src/bit_field_common/bit_field_table_generator.h
@@ -199,33 +199,25 @@ void print_table(table_t *table) {
    }
 }
 
-//! \brief sorts a given table so that the entries in the table are by key
+static inline bool compare_entries(const entry_t *ent_1, const entry_t *ent_2) {
+    return ent_1->key_mask.key > ent_2->key_mask.key;
+}
+
+//! \brief Sort a given table so that the entries in the table are by key
 //!     value.
+//! \details Uses insertion sort.
 //! \param[in] table: the table to sort.
 void sort_table_by_key(table_t *table) {
     uint32_t size = table->size;
     entry_t *entries = table->entries;
 
-    for (uint32_t i = 0; i < size - 1; i++) {
-        for (uint32_t j = i + 1; j < size; j++) {
-            if (entries[i].key_mask.key > entries[j].key_mask.key) {
-                uint32_t temp = entries[i].key_mask.key;
-                entries[i].key_mask.key = entries[j].key_mask.key;
-                entries[j].key_mask.key = temp;
-
-                temp = entries[i].key_mask.mask;
-                entries[i].key_mask.mask = entries[j].key_mask.mask;
-                entries[j].key_mask.mask = temp;
-
-                temp = entries[i].route;
-                entries[i].route = entries[j].route;
-                entries[j].route = temp;
-
-                temp = entries[i].source;
-                entries[i].source = entries[j].source;
-                entries[j].source = temp;
-            }
+    uint32_t i, j;
+    for (i = 1; i < size; i++) {
+        const entry_t temp = entries[i];
+        for (j = i; j > 0 && compare_entries(&entries[j - 1], &temp); j--) {
+            entries[j] = entries[j - 1];
         }
+        entries[j] = temp;
     }
 }
 

--- a/c_common/models/compressors/src/sorter/bit_field_reader.h
+++ b/c_common/models/compressors/src/sorter/bit_field_reader.h
@@ -104,43 +104,6 @@ static inline void order_bitfields(
     }
 }
 
-//! \brief Sort the data bases on the sort_order array
-//! \param[in] sorted_bit_fields: Data to be ordered
-//! \internal
-//!     DEAD code but left as it shows how it could be sorted by order fast
-static inline void sort_by_order(
-        sorted_bit_fields_t *restrict sorted_bit_fields) {
-    // Every time there is a swap at least one of the rows is moved to the
-    // final place.
-    //
-    // There is one check per row in the for loop plus if the first fails
-    // up to one more for each row about to be moved to the correct place.
-
-    int *restrict processor_ids = sorted_bit_fields->processor_ids;
-    int *restrict sort_order = sorted_bit_fields->sort_order;
-    filter_info_t **restrict bit_fields = sorted_bit_fields->bit_fields;
-
-    // Check each row in the lists
-    for (int i = 0; i < sorted_bit_fields->n_bit_fields; i++) {
-        // check that the data is in the correct place
-        while (sort_order[i] != i) {
-            int j = sort_order[i];
-            // If not swap the data there into the correct place
-            int temp_processor_id = processor_ids[i];
-            processor_ids[i] = processor_ids[j];
-            processor_ids[j] = temp_processor_id;
-
-            uint32_t temp_sort_order = sort_order[i];
-            sort_order[i] = sort_order[j];
-            sort_order[j] = temp_sort_order;
-
-            filter_info_t* bit_field_temp = bit_fields[i];
-            bit_fields[i] = bit_fields[j];
-            bit_fields[j] = bit_field_temp;
-        }
-    }
-}
-
 //! \brief Sort the data based on the bitfield key
 //! \param[in] sorted_bit_fields: Data to be ordered
 static inline void sort_by_key(
@@ -149,29 +112,23 @@ static inline void sort_by_key(
     int *restrict processor_ids = sorted_bit_fields->processor_ids;
     int *restrict sort_order = sorted_bit_fields->sort_order;
     filter_info_t **restrict bit_fields = sorted_bit_fields->bit_fields;
+    int i, j;
 
-    // Everytime there is a swap at least one of the rows is moved to the
-    //      final place.
-    //  There is one check per row in the for loop plus if the first fails
-    //      up to one more for each row about to be moved to the correct place.
-    for (int i = 0; i < sorted_bit_fields->n_bit_fields - 1; i++) {
-        for (int j = i + 1; j < sorted_bit_fields->n_bit_fields; j++) {
-           // check location
-           if (bit_fields[i]->key > bit_fields[j]->key) {
-                // If not swap the data there into the correct place
-                int temp_processor_id = processor_ids[i];
-                processor_ids[i] = processor_ids[j];
-                processor_ids[j] = temp_processor_id;
+    for (i = 1; i < sorted_bit_fields->n_bit_fields; i++) {
+        const int temp_processor_id = processor_ids[i];
+        const uint32_t temp_sort_order = sort_order[i];
+        filter_info_t *const bit_field_temp = bit_fields[i];
+        register uint32_t key = bit_field_temp->key;
 
-                uint32_t temp_sort_order = sort_order[i];
-                sort_order[i] = sort_order[j];
-                sort_order[j] = temp_sort_order;
-
-                filter_info_t* bit_field_temp = bit_fields[i];
-                bit_fields[i] = bit_fields[j];
-                bit_fields[j] = bit_field_temp;
-            }
+        for (j = i; j > 0 && bit_fields[j - 1]->key > key; j--) {
+            processor_ids[j] = processor_ids[j - 1];
+            sort_order[j] = sort_order[j - 1];
+            bit_fields[j] = bit_fields[j - 1];
         }
+
+        processor_ids[j] = temp_processor_id;
+        sort_order[j] = temp_sort_order;
+        bit_fields[j] = bit_field_temp;
     }
 }
 


### PR DESCRIPTION
This is done by avoiding bubblesort and using [insertion sort](https://en.wikipedia.org/wiki/Insertion_sort) instead. This should be a bit faster too, and the code is shorter.