### PR TITLE
Enable -Wold-style-definition and fix fault it finds

### DIFF
--- a/c_common/front_end_common_lib/local.mk
+++ b/c_common/front_end_common_lib/local.mk
@@ -90,7 +90,7 @@ ifndef FEC_OPT
     FEC_OPT = $(OTIME)
 endif
 
-CFLAGS += -Wall -Wextra -D$(FEC_DEBUG) -D$(PROFILER) $(FEC_OPT)
+CFLAGS += -Wall -Wextra -Wold-style-definition -D$(FEC_DEBUG) -D$(PROFILER) $(FEC_OPT)
 
 # Get the application name hash by running md5sum on application name and 
 # extracting the first 8 bytes

--- a/c_common/models/compressors/src/sorter/bit_field_sorter_and_searcher.c
+++ b/c_common/models/compressors/src/sorter/bit_field_sorter_and_searcher.c
@@ -907,8 +907,7 @@ void start_binary_search(void) {
 
 //! \brief Ensure that for each router table entry there is at most 1 bitfield
 //!        per processor
-//! \param[in] sorted_bit_fields The bit fields ordered by key
-static inline void check_bitfield_to_routes() {
+static inline void check_bitfield_to_routes(void) {
     filter_info_t **bit_fields = sorted_bit_fields->bit_fields;
     int *processor_ids = sorted_bit_fields->processor_ids;
     entry_t *entries = uncompressed_router_table->uncompressed_table.entries;


### PR DESCRIPTION
Old-style function definitions (with `foo_bar()` instead of `foo_bar(void)`) allow _any_ number of arguments rather than _none,_ and are always wrong in our code. This PR makes them much easier to pick up.