### PR TITLE
clone partitions when building new machine graphs

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -761,7 +761,8 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
         self._application_graph = self._original_application_graph.clone()
 
         # sort out machine graph
-        self._machine_graph = self._original_machine_graph.clone()
+        self._machine_graph = self._original_machine_graph.clone(
+            self._application_graph)
 
     def __timesteps(self, time_in_ms):
         """ Get a number of timesteps for a given time in milliseconds.

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -2432,9 +2432,10 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
     @property
     def machine_graph(self):
         """
+        Returns a frozen clone of the machine_graph
         :rtype: ~pacman.model.graphs.machine.MachineGraph
         """
-        return self._machine_graph
+        return self._machine_graph.clone(frozen=True)
 
     @property
     def original_machine_graph(self):
@@ -2452,12 +2453,12 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
 
     @property
     def application_graph(self):
-        """ The application graph used to derive the runtime machine
-            configuration.
+        """ The frozen clone of the application graph used to derive the
+            runtime machine configuration.
 
         :rtype: ~pacman.model.graphs.application.ApplicationGraph
         """
-        return self._application_graph
+        return self._application_graph.clone(frozen=True)
 
     @property
     def routing_infos(self):

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -783,11 +783,9 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
                 raise ConfigurationException(
                     "Illegal state where both original_application and "
                     "original machine graph have vertices in them")
-            self._application_graph = self._original_application_graph.clone()
-            self._machine_graph = MachineGraph()
-        else:
-            self._application_graph = ApplicationGraph()
-            self._machine_graph = self._original_machine_graph.clone()
+
+        self._application_graph = self._original_application_graph.clone()
+        self._machine_graph = self._original_machine_graph.clone()
 
     def __timesteps(self, time_in_ms):
         """ Get a number of timesteps for a given time in milliseconds.

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -776,7 +776,9 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
             self._machine_graph.add_vertex(vertex)
         for outgoing_partition in \
                 self._original_machine_graph.outgoing_edge_partitions:
-            self._machine_graph.add_outgoing_edge_partition(outgoing_partition)
+            new_outgoing_partition = outgoing_partition.clone_without_edges()
+            self._machine_graph.add_outgoing_edge_partition(
+                new_outgoing_partition)
             for edge in outgoing_partition.edges:
                 self._machine_graph.add_edge(
                     edge, outgoing_partition.identifier)

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1455,8 +1455,9 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
                 self._config.getboolean("Machine", "enable_reinjection")):
             algorithms.append("PreAllocateResourcesForExtraMonitorSupport")
 
-        # add the application or machine graphs as needed
-        if self._application_graph.n_vertices:
+        # add the application and machine graphs as needed
+        # Both could be None if call from other than self._run
+        if self._application_graph and self._application_graph.n_vertices:
             inputs["MemoryApplicationGraph"] = self._application_graph
         else:
             inputs["MemoryMachineGraph"] = self._machine_graph

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -758,30 +758,10 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
 
     def _build_graphs_for_usage(self):
         # sort out app graph
-        self._application_graph = ApplicationGraph(
-            label=self._original_application_graph.label)
-        for vertex in self._original_application_graph.vertices:
-            self._application_graph.add_vertex(vertex)
-        for outgoing_partition in \
-                self._original_application_graph.outgoing_edge_partitions:
-            for edge in outgoing_partition.edges:
-                self._application_graph.add_edge(
-                    edge, outgoing_partition.identifier)
+        self._application_graph = self._original_application_graph.clone()
 
         # sort out machine graph
-        self._machine_graph = MachineGraph(
-            label=self._original_machine_graph.label,
-            application_graph=self._application_graph)
-        for vertex in self._original_machine_graph.vertices:
-            self._machine_graph.add_vertex(vertex)
-        for outgoing_partition in \
-                self._original_machine_graph.outgoing_edge_partitions:
-            new_outgoing_partition = outgoing_partition.clone_without_edges()
-            self._machine_graph.add_outgoing_edge_partition(
-                new_outgoing_partition)
-            for edge in outgoing_partition.edges:
-                self._machine_graph.add_edge(
-                    edge, outgoing_partition.identifier)
+        self._machine_graph = self._original_machine_graph.clone()
 
     def __timesteps(self, time_in_ms):
         """ Get a number of timesteps for a given time in milliseconds.

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1652,7 +1652,7 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
 
         # only add the partitioner if there isn't already a machine graph
         algorithms.append("MallocBasedChipIDAllocator")
-        if self._application_graph.n_vertices:
+        if not self._machine_graph.n_vertices:
             full = self._config.get(
                 "Mapping", "application_to_machine_graph_algorithms")
             algorithms.extend(full.replace(" ", "").split(","))

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1459,7 +1459,7 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
         # Both could be None if call from other than self._run
         if self._application_graph and self._application_graph.n_vertices:
             inputs["MemoryApplicationGraph"] = self._application_graph
-        else:
+        elif self._machine_graph and self._machine_graph.n_vertices:
             inputs["MemoryMachineGraph"] = self._machine_graph
 
         return inputs, algorithms


### PR DESCRIPTION
As partition's can now only be added to one graph we have to clone then when copying graphs.

Also now ASB _run will return immediately if both graphs are empty.

Depends on https://github.com/SpiNNakerManchester/PACMAN/pull/331
Tested by 
https://github.com/SpiNNakerManchester/SpiNNakerGraphFrontEnd/pull/158
https://github.com/SpiNNakerManchester/sPyNNaker8/pull/506

AbstractSpinnakerBase._build_graphs_for_usage just calls clone methods on graph 
