### PR TITLE
InsertEdgesToExtraMonitorFunctionality cleanup

### DIFF
--- a/spinn_front_end_common/interface/interface_functions/insert_edges_to_extra_monitor_functionality.py
+++ b/spinn_front_end_common/interface/interface_functions/insert_edges_to_extra_monitor_functionality.py
@@ -84,12 +84,6 @@ class InsertEdgesToExtraMonitorFunctionality(object):
                 if isinstance(vertex, ExtraMonitorSupportMachineVertex):
                     self._process_app_graph_vertex(
                         vertex, machine_graph, application_graph)
-            for app_vertex in progress.over(application_graph.vertices):
-                if not isinstance(app_vertex, ExtraMonitorSupport):
-                    continue
-                for vertex in app_vertex.machine_vertices:
-                    self._process_app_graph_vertex(
-                        vertex, machine_graph, application_graph)
 
     def _process_app_graph_vertex(
             self, vertex, machine_graph, application_graph):

--- a/spinn_front_end_common/interface/interface_functions/insert_edges_to_extra_monitor_functionality.py
+++ b/spinn_front_end_common/interface/interface_functions/insert_edges_to_extra_monitor_functionality.py
@@ -20,7 +20,7 @@ from spinn_front_end_common.utilities.constants import (
     PARTITION_ID_FOR_MULTICAST_DATA_SPEED_UP)
 from spinn_front_end_common.utility_models import (
     DataSpeedUpPacketGatherMachineVertex as DataSpeedUp,
-    ExtraMonitorSupport, ExtraMonitorSupportMachineVertex)
+    ExtraMonitorSupportMachineVertex)
 
 
 class InsertEdgesToExtraMonitorFunctionality(object):


### PR DESCRIPTION
As the only machine vertex an ExtraMonitorSupport can have is a ExtraMonitorSupportMachineVertex there is no need to call 
self._process_app_graph_vertex twice with the same vertex