### PR TITLE
Several minor fixes to Compressors

### DIFF
--- a/c_common/models/compressors/Makefile
+++ b/c_common/models/compressors/Makefile
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 APPS = sorter.mk \
-       bit_field_unordered_compressor.mk \
+       bit_field_ordered_covering_compressor.mk \
        bit_field_pair_compressor.mk \
        simple_pair_compressor.mk \
        simple_unordered_compressor.mk

--- a/c_common/models/compressors/bit_field_ordered_covering_compressor.mk
+++ b/c_common/models/compressors/bit_field_ordered_covering_compressor.mk
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-APP = bit_field_unordered_compressor
+APP = bit_field_ordered_covering_compressor
 
 SOURCES = bit_field_compressor.c
 

--- a/c_common/models/compressors/src/bit_field_common/compressor_sorter_structs.h
+++ b/c_common/models/compressors/src/bit_field_common/compressor_sorter_structs.h
@@ -142,6 +142,8 @@ typedef struct bitfield_proc_t {
 typedef struct region_addresses_t {
     //! Minimum percentage of bitfields to be merge in (currently ignored)
     uint32_t threshold;
+    //! Number of times that the sorters should set of the compressions again
+    uint32_t retry_count;
     //! Pointer to the area malloced to hold the comms_sdram
     comms_sdram_t* comms_sdram;
     //! Number of processors in the list

--- a/c_common/models/compressors/src/bit_field_compressor.c
+++ b/c_common/models/compressors/src/bit_field_compressor.c
@@ -381,6 +381,12 @@ static void initialise(void) {
     log_info("my processor id is %d", spin1_get_core_id());
 }
 
+//! \brief bool to say this is NOT a standalone compressor.
+bool standalone(void){
+    return false;
+}
+
+
 //! \brief the main entrance.
 void c_main(void) {
     log_info("%u bytes of free DTCM", sark_heap_max(sark.heap, 0));

--- a/c_common/models/compressors/src/bit_field_compressor.c
+++ b/c_common/models/compressors/src/bit_field_compressor.c
@@ -338,6 +338,7 @@ static void timer_callback(UNUSED uint unused0, UNUSED uint unused1) {
             log_info("Sorter cancelled run request");
         } else if (comms_sdram->compressor_state == DO_NOT_USE) {
             log_info("Compressor no longer to be used");
+            spin1_pause();
         } else {
             log_info("timer weirdness %d %d",
             comms_sdram->sorter_instruction, comms_sdram->compressor_state);
@@ -384,7 +385,7 @@ static void initialise(void) {
 }
 
 //! \brief bool to say this is NOT a standalone compressor.
-bool standalone(void){
+bool standalone(void) {
     return false;
 }
 

--- a/c_common/models/compressors/src/bit_field_compressor.c
+++ b/c_common/models/compressors/src/bit_field_compressor.c
@@ -304,6 +304,7 @@ static void wait_for_instructions(UNUSED uint unused0, UNUSED uint unused1) {
         break;
     case DO_NOT_USE:
         log_info("DO_NOT_USE detected exiting wait");
+        spin1_pause();
         return;
     }
     if (users_match) {
@@ -335,6 +336,8 @@ static void timer_callback(UNUSED uint unused0, UNUSED uint unused1) {
         stop_compressing = true;
         if (comms_sdram->compressor_state == COMPRESSING) {
             log_info("Sorter cancelled run request");
+        } else if (comms_sdram->compressor_state == DO_NOT_USE) {
+            log_info("Compressor no longer to be used");
         } else {
             log_info("timer weirdness %d %d",
             comms_sdram->sorter_instruction, comms_sdram->compressor_state);
@@ -377,7 +380,6 @@ static void initialise(void) {
     max_counter = time_for_compression_attempt / TIMER_ITERATIONS;
     spin1_set_timer_tick(TIMER_ITERATIONS);
     spin1_callback_on(TIMER_TICK, timer_callback, TIMER_TICK_PRIORITY);
-
     log_info("my processor id is %d", spin1_get_core_id());
 }
 

--- a/c_common/models/compressors/src/common/minimise.h
+++ b/c_common/models/compressors/src/common/minimise.h
@@ -33,4 +33,8 @@ bool minimise_run(
         int target_length, bool *failed_by_malloc,
         volatile bool *stop_compressing);
 
+//! \brief bool to say if this is a standalone compressor.
+//! Mainly used to change logging
+bool standalone(void);
+
 #endif  // __MINIMISE_H__

--- a/c_common/models/compressors/src/compressor_includes/pair_minimize.h
+++ b/c_common/models/compressors/src/compressor_includes/pair_minimize.h
@@ -31,6 +31,7 @@
 #include <stdbool.h>
 #include <debug.h>
 #include "../common/routing_table.h"
+#include "common/minimise.h"
 
 //! Absolute maximum number of routes that we may produce
 #define MAX_NUM_ROUTES 1023
@@ -194,8 +195,11 @@ static inline bool update_frequency(int index) {
     routes_frequency[routes_count] = 1;
     routes_count++;
     if (routes_count >= MAX_NUM_ROUTES) {
-        log_error("Too many different routes to compress found %d compared "
-                  "to max legal of %d", routes_count, MAX_NUM_ROUTES);
+        if (standalone()) {
+            log_error("Too many different routes to compress found %d "
+                      "compared to max legal of %d",
+                      routes_count, MAX_NUM_ROUTES);
+        }
         return false;
     }
     return true;
@@ -267,8 +271,11 @@ bool minimise_run(int target_length, bool *failed_by_malloc,
         log_debug("compress %u %u", left, right);
         compress_by_route(left, right);
         if (write_index > rtr_alloc_max()){
-            log_error("Compression not possible as already found %d entries "
-            "where max allowed is %d", write_index, rtr_alloc_max());
+            if (standalone()) {
+                log_error("Compression not possible as already found %d "
+                          "entries where max allowed is %d",
+                          write_index, rtr_alloc_max());
+            }
             return false;
         }
         if (*stop_compressing) {

--- a/c_common/models/compressors/src/simple/simple_compressor.c
+++ b/c_common/models/compressors/src/simple/simple_compressor.c
@@ -93,7 +93,7 @@ void compress_start(UNUSED uint unused0, UNUSED uint unused1) {
 }
 
 //! \brief bool to say this is a standalone compressor.
-bool standalone(void){
+bool standalone(void) {
     return true;
 }
 

--- a/c_common/models/compressors/src/simple/simple_compressor.c
+++ b/c_common/models/compressors/src/simple/simple_compressor.c
@@ -92,6 +92,11 @@ void compress_start(UNUSED uint unused0, UNUSED uint unused1) {
     }
 }
 
+//! \brief bool to say this is a standalone compressor.
+bool standalone(void){
+    return true;
+}
+
 //! \brief the main entrance.
 void c_main(void) {
     log_info("%u bytes of free DTCM", sark_heap_max(sark.heap, 0));

--- a/c_common/models/compressors/src/sorter/bit_field_sorter_and_searcher.c
+++ b/c_common/models/compressors/src/sorter/bit_field_sorter_and_searcher.c
@@ -329,7 +329,7 @@ static inline int locate_next_mid_point(void) {
         log_info("Stopping compression due to retry count");
         return FAILED_TO_FIND;
     }
-    retires_left-= 1;
+    retires_left -= 1;
 
     // need to find a midpoint
     log_debug("n_bf_addresses %d tested_mid_points %d",

--- a/c_common/models/compressors/src/sorter/bit_field_sorter_and_searcher.c
+++ b/c_common/models/compressors/src/sorter/bit_field_sorter_and_searcher.c
@@ -115,6 +115,10 @@ comms_sdram_t *restrict comms_sdram;
 //! Record if the last action was to reduce cores due to malloc
 bool just_reduced_cores_due_to_malloc = false;
 
+//! Number of ties after the first search compressor cores should be tasked
+//! to find a better solution
+uint32_t retires_left;
+
 //============================================================================
 
 //! \brief Load the best routing table to the router.
@@ -320,6 +324,12 @@ static inline int locate_next_mid_point(void) {
                 sorted_bit_fields->n_bit_fields);
         return sorted_bit_fields->n_bit_fields;
     }
+
+    if (retires_left == 0) {
+        log_info("Stopping compression due to retry count");
+        return FAILED_TO_FIND;
+    }
+    retires_left-= 1;
 
     // need to find a midpoint
     log_debug("n_bf_addresses %d tested_mid_points %d",
@@ -718,6 +728,8 @@ void process_failed_malloc(int mid_point, int processor_id) {
     // Remove the flag that say this midpoint has been checked
     bit_field_clear(tested_mid_points, mid_point);
 
+    // Add a retry to recover from the failure
+    retires_left += 1;
     if (just_reduced_cores_due_to_malloc) {
         log_info("Multiple malloc detected on %d keeping processor %d",
                 mid_point, processor_id);
@@ -1033,6 +1045,8 @@ static void initialise_user_register_tracker(void) {
         comms_sdram[processor_id].fake_heap_data = NULL;
     }
     usable_sdram_regions = (available_sdram_blocks *) this_vcpu_info->user3;
+
+    retires_left = region_addresses->retry_count;
 
     log_debug("finished setting up register tracker:\n\n"
             "user0 = %d\n user1 = %d\n user2 = %d\n user3 = %d\n",

--- a/c_common/models/compressors/src/sorter/bit_field_sorter_and_searcher.c
+++ b/c_common/models/compressors/src/sorter/bit_field_sorter_and_searcher.c
@@ -915,6 +915,15 @@ void start_binary_search(void) {
         mid_point -= step;
         available--;
     }
+
+    // Dont need all processors so turn the rest off
+    if (available > 0) {
+        for (int processor_id = 0; processor_id < MAX_PROCESSORS; processor_id++) {
+            if (comms_sdram[processor_id].sorter_instruction == TO_BE_PREPARED) {
+                comms_sdram[processor_id].sorter_instruction = DO_NOT_USE;
+            }
+        }
+    }
 }
 
 //! \brief Ensure that for each router table entry there is at most 1 bitfield

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1855,6 +1855,10 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
                     algorithms.append("CompressedRouterSummaryReport")
                     algorithms.append("RoutingTableFromMachineReport")
 
+                if self._config.getboolean(
+                        "Reports", "write_bit_field_compressor_report"):
+                    algorithms.append("BitFieldCompressorReport")
+
         # handle extra monitor functionality
         enable_advanced_monitor = self._config.getboolean(
             "Machine", "enable_advanced_monitor_support")

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1387,9 +1387,8 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
         # the graph
         else:
             inputs["MemoryApplicationGraph"] = self._application_graph
-            algorithms.extend(self._config.get(
-                "Mapping",
-                "application_to_machine_graph_algorithms").split(","))
+            algorithms.extend(self._config.get_str_list(
+                "Mapping", "application_to_machine_graph_algorithms"))
             outputs.append("MemoryMachineGraph")
             do_partitioning = True
 
@@ -1671,19 +1670,17 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
         # only add the partitioner if there isn't already a machine graph
         algorithms.append("MallocBasedChipIDAllocator")
         if not self._machine_graph.n_vertices:
-            full = self._config.get(
-                "Mapping", "application_to_machine_graph_algorithms")
-            algorithms.extend(full.replace(" ", "").split(","))
+            algorithms.extend(self._config.get_str_list(
+                "Mapping", "application_to_machine_graph_algorithms"))
             inputs['MemoryPreviousAllocatedResources'] = \
                 PreAllocatedResourceContainer()
 
         if self._use_virtual_board:
-            full = self._config.get(
-                "Mapping", "machine_graph_to_virtual_machine_algorithms")
+            algorithms.extend(self._config.get_str_list(
+                "Mapping", "machine_graph_to_virtual_machine_algorithms"))
         else:
-            full = self._config.get(
-                "Mapping", "machine_graph_to_machine_algorithms")
-        algorithms.extend(full.replace(" ", "").split(","))
+            algorithms.extend(self._config.get_str_list(
+                "Mapping", "machine_graph_to_machine_algorithms"))
 
         # add check for algorithm start type
         if not self._use_virtual_board:
@@ -1830,9 +1827,9 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
             # Get the executable targets
             algorithms.append("GraphBinaryGatherer")
 
-        loading_algorithm = self._read_config("Mapping", "loading_algorithms")
-        if loading_algorithm is not None and (graph_changed or data_changed):
-            algorithms.extend(loading_algorithm.split(","))
+        algorithms.extend(self._config.get_str_list(
+            "Mapping", "loading_algorithms"))
+
         algorithms.extend(self._extra_load_algorithms)
 
         write_memory_report = self._config.getboolean(
@@ -2363,12 +2360,7 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
         :rtype: list(str)
         """
         # add the extra xml files from the config file
-        xml_paths = self._config.get("Mapping", "extra_xmls_paths")
-        if xml_paths == "None":
-            xml_paths = list()
-        else:
-            xml_paths = xml_paths.split(",")
-
+        xml_paths = self._config.get_str_list("Mapping", "extra_xmls_paths")
         xml_paths.extend(get_front_end_common_pacman_xml_paths())
 
         if extra_algorithm_xml_paths is not None:

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1820,8 +1820,6 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
                 "Mapping",
                 "router_table_compression_with_bit_field_retry_count")
 
-
-
     def _do_load(self, graph_changed, data_changed):
         """
         :param bool graph_changed:

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1786,6 +1786,42 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
             data_gen_timer.take_sample())
         self._mapping_outputs["DSGTimeMs"] = self._dsg_time
 
+    def _add_router_compressor_bit_field_inputs(self, inputs):
+        """
+
+        :param dict(str, object) inputs:
+        :return:
+        """
+        # bitfield inputs
+        inputs['RouterBitfieldCompressionReport'] = \
+            self.config.getboolean(
+                "Reports", "generate_router_compression_with_bitfield_report")
+
+        inputs['RouterCompressorBitFieldUseCutOff'] = \
+            self.config.getboolean(
+                "Mapping",
+                "router_table_compression_with_bit_field_use_time_cutoff")
+
+        inputs['RouterCompressorBitFieldTimePerAttempt'] = \
+            self._read_config_int(
+                "Mapping",
+                "router_table_compression_with_bit_field_iteration_time")
+
+        inputs["RouterCompressorBitFieldPreAllocSize"] = \
+            self._read_config_int(
+                "Mapping",
+                "router_table_compression_with_bit_field_pre_alloced_sdram")
+        inputs["RouterCompressorBitFieldPercentageThreshold"] = \
+            self._read_config_int(
+                "Mapping",
+                "router_table_compression_with_bit_field_acceptance_threshold")
+        inputs["RouterCompressorBitFieldRetryCount"] = \
+            self._read_config_int(
+                "Mapping",
+                "router_table_compression_with_bit_field_retry_count")
+
+
+
     def _do_load(self, graph_changed, data_changed):
         """
         :param bool graph_changed:
@@ -1805,6 +1841,7 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
             graph_changed
         )
         inputs["NoSyncChanges"] = self._no_sync_changes
+        self._add_router_compressor_bit_field_inputs(inputs)
 
         if not graph_changed and self._has_ran:
             inputs["ExecutableTargets"] = self._last_run_outputs[
@@ -1855,9 +1892,9 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
                     algorithms.append("CompressedRouterSummaryReport")
                     algorithms.append("RoutingTableFromMachineReport")
 
-                if self._config.getboolean(
-                        "Reports", "write_bit_field_compressor_report"):
-                    algorithms.append("BitFieldCompressorReport")
+        if self._config.getboolean(
+                "Reports", "write_bit_field_compressor_report"):
+            algorithms.append("BitFieldCompressorReport")
 
         # handle extra monitor functionality
         enable_advanced_monitor = self._config.getboolean(

--- a/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
@@ -249,6 +249,10 @@
                 <param_type>RouterCompressorBitFieldPercentageThreshold</param_type>
             </parameter>
             <parameter>
+                <param_name>retry_count</param_name>
+                <param_type>RouterCompressorBitFieldRetryCount</param_type>
+            </parameter>
+            <parameter>
                 <param_name>transceiver</param_name>
                 <param_type>MemoryTransceiver</param_type>
             </parameter>
@@ -336,6 +340,7 @@
             <param_name>target_length</param_name>
             <param_name>routing_infos</param_name>
             <param_name>threshold_percentage</param_name>
+            <param_name>retry_count</param_name>
             <param_name>time_to_try_for_each_iteration</param_name>
             <param_name>use_timer_cut_off</param_name>
             <param_name>machine_time_step</param_name>
@@ -370,6 +375,10 @@
                 <param_type>RouterCompressorBitFieldPercentageThreshold</param_type>
             </parameter>
             <parameter>
+                <param_name>retry_count</param_name>
+                <param_type>RouterCompressorBitFieldRetryCount</param_type>
+            </parameter>
+            <parameter>
                 <param_name>transceiver</param_name>
                 <param_type>MemoryTransceiver</param_type>
             </parameter>
@@ -457,6 +466,7 @@
             <param_name>target_length</param_name>
             <param_name>routing_infos</param_name>
             <param_name>threshold_percentage</param_name>
+            <param_name>retry_count</param_name>
             <param_name>time_to_try_for_each_iteration</param_name>
             <param_name>use_timer_cut_off</param_name>
             <param_name>machine_time_step</param_name>

--- a/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
@@ -350,7 +350,7 @@
         <outputs>
             <token part="MulticastRoutesLoaded">DataLoaded</token>
             <param_type>CompressorExecutableTargetsUsed</param_type>
-            <param_type>RouterProvenanceItems</param_type>
+            <param_type>RouterCompressorProvenanceItems</param_type>
         </outputs>
     </algorithm>
     <algorithm name="MachineBitFieldPairRouterCompressor">
@@ -471,7 +471,7 @@
         <outputs>
             <token part="MulticastRoutesLoaded">DataLoaded</token>
             <param_type>CompressorExecutableTargetsUsed</param_type>
-            <param_type>RouterProvenanceItems</param_type>
+            <param_type>RouterCompressorProvenanceItems</param_type>
         </outputs>
     </algorithm>
     <algorithm name="SystemMulticastRoutingGenerator">

--- a/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
@@ -232,7 +232,134 @@
             <param_type>MemoryCompressedRoutingTables</param_type>
         </outputs>
     </algorithm>
+    <algorithm name="MachineBitFieldOrderedCoveringCompressor">
+        <python_module>spinn_front_end_common.interface.interface_functions.machine_bit_field_router_compressor</python_module>
+        <python_class>MachineBitFieldOrderedCoveringCompressor</python_class>
+        <input_definitions>
+            <parameter>
+                <param_name>routing_tables</param_name>
+                <param_type>MemoryRoutingTables</param_type>
+            </parameter>
+            <parameter>
+                <param_name>executable_targets</param_name>
+                <param_type>ExecutableTargets</param_type>
+            </parameter>
+            <parameter>
+                <param_name>threshold_percentage</param_name>
+                <param_type>RouterCompressorBitFieldPercentageThreshold</param_type>
+            </parameter>
+            <parameter>
+                <param_name>retry_count</param_name>
+                <param_type>RouterCompressorBitFieldRetryCount</param_type>
+            </parameter>
+            <parameter>
+                <param_name>transceiver</param_name>
+                <param_type>MemoryTransceiver</param_type>
+            </parameter>
+            <parameter>
+                <param_name>machine</param_name>
+                <param_type>MemoryMachine</param_type>
+            </parameter>
+            <parameter>
+                <param_name>app_id</param_name>
+                <param_type>APPID</param_type>
+            </parameter>
+            <parameter>
+                <param_name>provenance_file_path</param_name>
+                <param_type>SystemProvenanceFilePath</param_type>
+            </parameter>
+            <parameter>
+                <param_name>compress_as_much_as_possible</param_name>
+                <param_type>CompressionAsFarAsPos</param_type>
+            </parameter>
+            <parameter>
+                <param_name>executable_finder</param_name>
+                <param_type>ExecutableFinder</param_type>
+            </parameter>
+            <parameter>
+                <param_name>write_compressor_iobuf</param_name>
+                <param_type>WriteCompressorIobuf</param_type>
+            </parameter>
+            <parameter>
+                <param_name>machine_graph</param_name>
+                <param_type>MemoryMachineGraph</param_type>
+            </parameter>
+            <parameter>
+                <param_name>placements</param_name>
+                <param_type>MemoryPlacements</param_type>
+            </parameter>
+            <parameter>
+                <param_name>produce_report</param_name>
+                <param_type>RouterBitfieldCompressionReport</param_type>
+            </parameter>
+            <parameter>
+                <param_name>default_report_folder</param_name>
+                <param_type>ReportFolder</param_type>
+            </parameter>
+            <parameter>
+                <param_name>target_length</param_name>
+                <param_type>CompressionTargetSize</param_type>
+            </parameter>
+            <parameter>
+                <param_name>routing_infos</param_name>
+                <param_type>MemoryRoutingInfos</param_type>
+            </parameter>
+            <parameter>
+                <param_name>time_to_try_for_each_iteration</param_name>
+                <param_type>RouterCompressorBitFieldTimePerAttempt</param_type>
+            </parameter>
+            <parameter>
+                <param_name>use_timer_cut_off</param_name>
+                <param_type>RouterCompressorBitFieldUseCutOff</param_type>
+            </parameter>
+            <parameter>
+                <param_name>machine_time_step</param_name>
+                <param_type>MachineTimeStep</param_type>
+            </parameter>
+            <parameter>
+                <param_name>time_scale_factor</param_name>
+                <param_type>TimeScaleFactor</param_type>
+            </parameter>
+            <parameter>
+                <param_name>provenance_data_objects</param_name>
+                <param_type>RouterCompressorProvenanceItems</param_type>
+            </parameter>
+        </input_definitions>
+        <required_inputs>
+            <param_name>executable_finder</param_name>
+            <param_name>write_compressor_iobuf</param_name>
+            <param_name>routing_tables</param_name>
+            <param_name>transceiver</param_name>
+            <param_name>machine</param_name>
+            <param_name>app_id</param_name>
+            <param_name>provenance_file_path</param_name>
+            <param_name>machine_graph</param_name>
+            <param_name>placements</param_name>
+            <param_name>produce_report</param_name>
+            <param_name>default_report_folder</param_name>
+            <param_name>target_length</param_name>
+            <param_name>routing_infos</param_name>
+            <param_name>threshold_percentage</param_name>
+            <param_name>retry_count</param_name>
+            <param_name>time_to_try_for_each_iteration</param_name>
+            <param_name>use_timer_cut_off</param_name>
+            <param_name>machine_time_step</param_name>
+            <param_name>time_scale_factor</param_name>
+            <param_name>executable_targets</param_name>
+            <token part="BitFieldData">DataLoaded</token>
+        </required_inputs>
+        <optional_inputs>
+            <param_name>compress_as_much_as_possible</param_name>
+            <param_name>provenance_data_objects</param_name>
+        </optional_inputs>
+        <outputs>
+            <token part="MulticastRoutesLoaded">DataLoaded</token>
+            <param_type>CompressorExecutableTargetsUsed</param_type>
+            <param_type>RouterCompressorProvenanceItems</param_type>
+        </outputs>
+    </algorithm>
     <algorithm name="MachineBitFieldUnorderedRouterCompressor">
+        <!-- DEPRECATED Use OrderedCoveringOnChipRouterCompression !-->
         <python_module>spinn_front_end_common.interface.interface_functions.machine_bit_field_router_compressor</python_module>
         <python_class>MachineBitFieldUnorderedRouterCompressor</python_class>
         <input_definitions>
@@ -2536,7 +2663,61 @@
             <token part="MulticastRoutesLoaded">DataLoaded</token>
         </outputs>
     </algorithm>
+    <algorithm name="OrderedCoveringOnChipRouterCompression">
+        <python_module>spinn_front_end_common.interface.interface_functions.on_chip_router_table_compression</python_module>
+        <python_function>ordered_covering_compression</python_function>
+        <input_definitions>
+            <parameter>
+                <param_name>routing_tables</param_name>
+                <param_type>MemoryRoutingTables</param_type>
+            </parameter>
+            <parameter>
+                <param_name>transceiver</param_name>
+                <param_type>MemoryTransceiver</param_type>
+            </parameter>
+            <parameter>
+                <param_name>executable_finder</param_name>
+                <param_type>ExecutableFinder</param_type>
+            </parameter>
+            <parameter>
+                <param_name>machine</param_name>
+                <param_type>MemoryMachine</param_type>
+            </parameter>
+            <parameter>
+                <param_name>app_id</param_name>
+                <param_type>APPID</param_type>
+            </parameter>
+            <parameter>
+                <param_name>provenance_file_path</param_name>
+                <param_type>SystemProvenanceFilePath</param_type>
+            </parameter>
+            <parameter>
+                <param_name>compress_as_much_as_possible</param_name>
+                <param_type>CompressionAsFarAsPos</param_type>
+            </parameter>
+            <parameter>
+                <param_name>write_compressor_iobuf</param_name>
+                <param_type>WriteCompressorIobuf</param_type>
+            </parameter>
+        </input_definitions>
+        <required_inputs>
+            <param_name>routing_tables</param_name>
+            <param_name>transceiver</param_name>
+            <param_name>executable_finder</param_name>
+            <param_name>machine</param_name>
+            <param_name>app_id</param_name>
+            <param_name>provenance_file_path</param_name>
+        </required_inputs>
+        <optional_inputs>
+                <param_name>compress_as_much_as_possible</param_name>
+                <param_name>write_compressor_iobuf</param_name>
+        </optional_inputs>
+        <outputs>
+            <token part="MulticastRoutesLoaded">DataLoaded</token>
+        </outputs>
+    </algorithm>
     <algorithm name="UnorderedOnChipRouterCompression">
+        <!-- DEPRECATED Use OrderedCoveringOnChipRouterCompression !-->
         <python_module>spinn_front_end_common.interface.interface_functions.on_chip_router_table_compression</python_module>
         <python_function>unordered_compression</python_function>
         <input_definitions>

--- a/spinn_front_end_common/interface/interface_functions/host_bit_field_router_compressor.py
+++ b/spinn_front_end_common/interface/interface_functions/host_bit_field_router_compressor.py
@@ -31,8 +31,8 @@ from pacman.model.routing_tables import (
     CompressedMulticastRoutingTable)
 from pacman.operations.algorithm_reports.reports import format_route
 from pacman.operations.router_compressors import Entry
-from pacman.operations.router_compressors.mundys_router_compressor import (
-    minimise)
+from pacman.operations.router_compressors.ordered_covering_router_compressor\
+    import minimise
 from spinn_front_end_common.abstract_models.\
     abstract_supports_bit_field_routing_compression import (
         AbstractSupportsBitFieldRoutingCompression)

--- a/spinn_front_end_common/interface/interface_functions/machine_bit_field_router_compressor.py
+++ b/spinn_front_end_common/interface/interface_functions/machine_bit_field_router_compressor.py
@@ -871,7 +871,7 @@ class MachineBitFieldOrderedCoveringCompressor(
 
 class MachineBitFieldUnorderedRouterCompressor(
         MachineBitFieldRouterCompressor):
-    """ DEPRACATED use MachineBitFieldRouterCompressor """
+    """ DEPRACATED use MachineBitFieldOrderedCoveringCompressor """
 
     def __new__(cls, *args, **kwargs):
         logger.warning(

--- a/spinn_front_end_common/interface/interface_functions/machine_bit_field_router_compressor.py
+++ b/spinn_front_end_common/interface/interface_functions/machine_bit_field_router_compressor.py
@@ -878,7 +878,7 @@ class MachineBitFieldUnorderedRouterCompressor(
             "MachineBitFieldUnorderedRouterCompressor algorithm name is "
             "deprecated. "
             "Please use MachineBitFieldOrderedCoveringCompressor instead. "
-            "Remove loading_algorithms from your cfg to use defaults")
+            "loading_algorithms from your cfg to use defaults")
         return super(MachineBitFieldUnorderedRouterCompressor, cls).__new__(
             cls, *args, **kwargs)
 

--- a/spinn_front_end_common/interface/interface_functions/machine_bit_field_router_compressor.py
+++ b/spinn_front_end_common/interface/interface_functions/machine_bit_field_router_compressor.py
@@ -29,10 +29,8 @@ from spinnman.exceptions import (
 from spinnman.model import ExecutableTargets
 from spinnman.model.enums import CPUState
 from pacman.model.routing_tables import MulticastRoutingTables
-from pacman.operations.router_compressors.mundys_router_compressor.\
-    ordered_covering import (
-        get_generality as
-        ordered_covering_generality)
+from pacman.operations.router_compressors.ordered_covering_router_compressor.\
+    ordered_covering import (get_generality as ordered_covering_generality)
 from spinn_front_end_common.interface.interface_functions.\
     on_chip_router_table_compression import (
         make_source_hack)
@@ -857,18 +855,32 @@ class MachineBitFieldRouterCompressor(object):
         return data
 
 
-class MachineBitFieldUnorderedRouterCompressor(
+class MachineBitFieldOrderedCoveringCompressor(
         MachineBitFieldRouterCompressor):
 
     @property
     @overrides(MachineBitFieldRouterCompressor.compressor_aplx)
     def compressor_aplx(self):
-        return "bit_field_unordered_compressor.aplx"
+        return "bit_field_ordered_covering_compressor.aplx"
 
     @property
     @overrides(MachineBitFieldRouterCompressor.compressor_type)
     def compressor_type(self):
-        return "Mundy"
+        return "OrderedCovering"
+
+
+class MachineBitFieldUnorderedRouterCompressor(
+        MachineBitFieldRouterCompressor):
+    """ DEPRACATED use MachineBitFieldRouterCompressor """
+
+    def __new__(cls, *args, **kwargs):
+        logger.warning(
+            "MachineBitFieldUnorderedRouterCompressor algorithm name is "
+            "deprecated. "
+            "Please use MachineBitFieldOrderedCoveringCompressor instead. "
+            "Remove loading_algorithms from your cfg to use defaults")
+        return super(MachineBitFieldUnorderedRouterCompressor, cls).__new__(
+            cls, *args, **kwargs)
 
 
 class MachineBitFieldPairRouterCompressor(MachineBitFieldRouterCompressor):

--- a/spinn_front_end_common/interface/interface_functions/on_chip_router_table_compression/__init__.py
+++ b/spinn_front_end_common/interface/interface_functions/on_chip_router_table_compression/__init__.py
@@ -15,8 +15,9 @@
 
 from .compression import (
     Compression, make_source_hack, mundy_on_chip_router_compression,
-    pair_compression, unordered_compression)
+    ordered_covering_compression, pair_compression, unordered_compression)
 
 __all__ = (
     "Compression", "make_source_hack", "mundy_on_chip_router_compression",
-    "pair_compression", "unordered_compression")
+    "ordered_covering_compression", "pair_compression",
+    "unordered_compression")

--- a/spinn_front_end_common/interface/interface_functions/on_chip_router_table_compression/compression.py
+++ b/spinn_front_end_common/interface/interface_functions/on_chip_router_table_compression/compression.py
@@ -13,8 +13,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
 import os
 import struct
+from spinn_utilities.log import FormatAdapter
 from spinn_utilities.progress_bar import ProgressBar
 from spinn_utilities.executable_finder import ExecutableFinder
 from spinn_machine import CoreSubsets, Router
@@ -28,6 +30,8 @@ _FOUR_WORDS = struct.Struct("<IIII")
 _THREE_WORDS = struct.Struct("<III")
 # The SDRAM Tag used by the application - note this is fixed in the APLX
 _SDRAM_TAG = 1
+
+logger = FormatAdapter(logging.getLogger(__name__))
 
 
 def mundy_on_chip_router_compression(
@@ -106,7 +110,7 @@ def pair_compression(
     compression.compress()
 
 
-def unordered_compression(
+def ordered_covering_compression(
         routing_tables, transceiver, executable_finder,
         machine, app_id, provenance_file_path, write_compressor_iobuf,
         compress_as_much_as_possible=True):
@@ -143,6 +147,21 @@ def unordered_compression(
         "Running unordered routing table compression on chip",
         write_compressor_iobuf, result_register=1)
     compression.compress()
+
+
+def unordered_compression(
+        routing_tables, transceiver, executable_finder,
+        machine, app_id, provenance_file_path, write_compressor_iobuf,
+        compress_as_much_as_possible=True):
+    """ DEPRECATED use ordered_covering_compression """
+    logger.warning(
+        "UnorderedOnChipRouterCompression algorithm name is deprecated. "
+        "Please use OrderedCoveringOnChipRouterCompression instead. "
+        "Remove loading_algorithms from your cfg to use defaults")
+    ordered_covering_compression(
+        routing_tables, transceiver, executable_finder,
+        machine, app_id, provenance_file_path, write_compressor_iobuf,
+        compress_as_much_as_possible)
 
 
 def make_source_hack(entry):

--- a/spinn_front_end_common/interface/interface_functions/on_chip_router_table_compression/compression.py
+++ b/spinn_front_end_common/interface/interface_functions/on_chip_router_table_compression/compression.py
@@ -157,7 +157,7 @@ def unordered_compression(
     logger.warning(
         "UnorderedOnChipRouterCompression algorithm name is deprecated. "
         "Please use OrderedCoveringOnChipRouterCompression instead. "
-        "Remove loading_algorithms from your cfg to use defaults")
+        "loading_algorithms from your cfg to use defaults")
     ordered_covering_compression(
         routing_tables, transceiver, executable_finder,
         machine, app_id, provenance_file_path, write_compressor_iobuf,

--- a/spinn_front_end_common/interface/spinnaker.cfg
+++ b/spinn_front_end_common/interface/spinnaker.cfg
@@ -208,7 +208,7 @@ router_table_compression_with_bit_field_use_time_cutoff = True
 router_table_compression_with_bit_field_iteration_time = 1000
 router_table_compression_with_bit_field_pre_alloced_sdram = 10000
 router_table_compression_with_bit_field_acceptance_threshold = 0
-
+router_table_compression_with_bit_field_retry_count = 2
 
 # format is <path1>,<path2>
 extra_xmls_paths = None

--- a/spinn_front_end_common/interface/spinnaker.cfg
+++ b/spinn_front_end_common/interface/spinnaker.cfg
@@ -73,6 +73,7 @@ write_json_placements = False
 write_json_routing_tables = False
 write_json_partition_n_keys_map = False
 write_compressor_iobuf = False
+write_bit_field_compressor_report = True
 
 # NOTE ***that for bespoke file paths, folders will not be automatically deleted***
 # options are DEFAULT or a file path

--- a/spinn_front_end_common/interface/spinnaker.cfg
+++ b/spinn_front_end_common/interface/spinnaker.cfg
@@ -208,7 +208,7 @@ router_table_compression_with_bit_field_use_time_cutoff = True
 router_table_compression_with_bit_field_iteration_time = 1000
 router_table_compression_with_bit_field_pre_alloced_sdram = 10000
 router_table_compression_with_bit_field_acceptance_threshold = 0
-router_table_compression_with_bit_field_retry_count = 2
+router_table_compression_with_bit_field_retry_count = None
 
 # format is <path1>,<path2>
 extra_xmls_paths = None

--- a/spinn_front_end_common/utilities/report_functions/bit_field_compressor_report.py
+++ b/spinn_front_end_common/utilities/report_functions/bit_field_compressor_report.py
@@ -37,17 +37,20 @@ class BitFieldCompressorReport(object):
         bitfields into the routing table.
     """
     def __call__(
-            self, report_default_directory, provenance_items, machine_graph,
-            placements):
+            self, report_default_directory, machine_graph, placements,
+            provenance_items=None):
         """
         :param str report_default_directory: report folder
-        :param list(ProvenanceDataItem) provenance_items: prov items
         :param ~pacman.model.graphs.machine.MachineGraph machine_graph:
             the machine graph
         :param ~pacman.model.placements.Placements placements: the placements
+        :param provenance_items: prov items
+        :type provenance_items: list(ProvenanceDataItem) or None
         :return: a summary, or `None` if the report file can't be written
         :rtype: BitFieldSummary
         """
+        if provenance_items is None:
+            provenance_items = []
         file_name = os.path.join(report_default_directory, _FILE_NAME)
         try:
             with open(file_name, "w") as f:

--- a/spinn_front_end_common/utilities/report_functions/bit_field_compressor_report.py
+++ b/spinn_front_end_common/utilities/report_functions/bit_field_compressor_report.py
@@ -181,7 +181,7 @@ class BitFieldCompressorReport(object):
             margin = "1%"
         writer.write(
             "\n\nWarning the number of retires was capped at {}. "
-            "\nWithout this cap the bitfileds merges is likely to be higher. "
+            "\nWithout this cap the bitfields merges is likely to be higher. "
             "\nA very crude estimate suggests up to {} better."
             "\nRemoving router_table_compression_with_bit_field_retry_count "
             "from your cfg file may improve bitfields merged.".format(

--- a/spinn_front_end_common/utilities/report_functions/bit_field_compressor_report.py
+++ b/spinn_front_end_common/utilities/report_functions/bit_field_compressor_report.py
@@ -99,8 +99,8 @@ class BitFieldCompressorReport(object):
                     found = True
                     to_merge_chips.remove((x, y))
                     writer.write(
-                        "Chip {}:{} has {} bitfields out of {} merged into it\n"
-                        "".format(x, y, prov_item.value, to_merge))
+                        "Chip {}:{} has {} bitfields out of {} merged into it"
+                        "\n".format(x, y, prov_item.value, to_merge))
                     total_bit_fields_merged += int(prov_item.value)
                     if int(prov_item.value) > top_bit_field:
                         top_bit_field = int(prov_item.value)

--- a/spinn_front_end_common/utilities/report_functions/front_end_common_reports.xml
+++ b/spinn_front_end_common/utilities/report_functions/front_end_common_reports.xml
@@ -38,6 +38,10 @@
                 <param_name>machine_graph</param_name>
                 <param_type>MemoryMachineGraph</param_type>
             </parameter>
+            <parameter>
+                <param_name>retry_count</param_name>
+                <param_type>RouterCompressorBitFieldRetryCount</param_type>
+            </parameter>
         </input_definitions>
         <required_inputs>
             <param_name>report_default_directory</param_name>
@@ -47,6 +51,7 @@
         </required_inputs>
         <optional_inputs>
             <param_name>provenance_items</param_name>
+            <param_name>retry_count</param_name>
         </optional_inputs>
         <outputs>
             <param_type>BitFieldSummary</param_type>

--- a/spinn_front_end_common/utilities/report_functions/front_end_common_reports.xml
+++ b/spinn_front_end_common/utilities/report_functions/front_end_common_reports.xml
@@ -41,11 +41,13 @@
         </input_definitions>
         <required_inputs>
             <param_name>report_default_directory</param_name>
-            <param_name>provenance_items</param_name>
             <param_name>machine_graph</param_name>
             <param_name>placements</param_name>
             <token part="MulticastRoutesLoaded">DataLoaded</token>
         </required_inputs>
+        <optional_inputs>
+            <param_name>provenance_items</param_name>
+        </optional_inputs>
         <outputs>
             <param_type>BitFieldSummary</param_type>
         </outputs>


### PR DESCRIPTION
Part of https://github.com/SpiNNakerManchester/PACMAN/pull/347

Builds on SpiNNakerManchester/SpiNNFrontEndCommon#735

BitFieldCompressorReport:
     Reports the bitfield count even if a none bitfield compressor used.
     Does not report chips with no bitfields
     can be turned on with write_bit_field_compressor_report cfg flag

Ability to reduce the time Bitfields compressors take BUT at the cost of probably less that optimal bit fields merged in! 
    cfg param router_table_compression_with_bit_field_retry_count
          default (none) as much as possible
          0: single pass but can loose up to 10% of merged bitfields
          at about 10 the compressor will take twice as long as 0 but less than half the error

Which compressor and retry count added to progress bar so clearly visible to user

Remove confusing log error messages if using MachineBitFieldPairRouterCompressor
 
Moves router_table_compression... param handling to this level.