### PR TITLE
Auto pause safety reduction

### DIFF
--- a/c_common/front_end_common_lib/src/recording.c
+++ b/c_common/front_end_common_lib/src/recording.c
@@ -681,8 +681,11 @@ bool recording_initialize(
                     sv->sdram_heap, size + sizeof(recording_channel_t), 0,
                     ALLOC_LOCK + ALLOC_ID + (sark_vec->app_id << 8));
             if (region_addresses[counter] == NULL) {
-                log_error("Could not allocate recording region %u of %u bytes",
-                        counter, size);
+                log_error(
+                    "Could not allocate recording region %u of %u bytes, "
+                    "available was %u bytes",
+                    counter, size + sizeof(recording_channel_t),
+                    sark_heap_max(sv->sdram_heap, 0));
                 return false;
             }
             sdram_region_ptrs[counter] = region_addresses[counter];

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1115,7 +1115,10 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
                 max_this_chip = int((size - sdram.fixed) // sdram.per_timestep)
                 max_time_steps = min(max_time_steps, max_this_chip)
 
-        return max_time_steps
+        # Reduce the number of timesteps as a safetly factor
+        time_safety_factor = self._read_config_int(
+            "Simulation", "auto_pause_safety_reduction")
+        return max_time_steps - time_safety_factor
 
     @staticmethod
     def _generate_steps(n_steps, n_steps_per_segment):

--- a/spinn_front_end_common/interface/spinnaker.cfg
+++ b/spinn_front_end_common/interface/spinnaker.cfg
@@ -232,6 +232,10 @@ fraction_of_time_spike_sending = 0.8
 # TDMA
 fraction_of_time_before_sending = 0.01
 
+# Reduces the max timesteps that can be done in each auto pause resume loop
+# This to ensure an SDRAM estimate error does not kill the job
+auto_pause_safety_reduction = 1
+
 [Buffers]
 use_auto_pause_and_resume = True
 chip_power_monitor_buffer = 1048576


### PR DESCRIPTION
As there as sdram cost estimate errors:
https://github.com/SpiNNakerManchester/sPyNNaker/issues/991

This adds a cfg configurable reduction in the auto pause resume max timesteps.
Which reduces the recording space allocated.

Also needs:
https://github.com/SpiNNakerManchester/sPyNNaker/pull/995

Tested by ...

https://github.com/SpiNNakerManchester/IntegrationTests/pull/16