### PR TITLE
A minor improvement to our .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ lastfailed
 *.dict
 .dbeaver/
 ._dbeaver/
+test_output


### PR DESCRIPTION
Some tests produce files in the directory `unittests/interface/interface_functions/test_output`; we should ignore them.