### PR TITLE
Prealloc cleanup

### DIFF
--- a/fec_integration_tests/interface/interface_functions/test_front_end_common_create_pre_allocated_res_for_lpg.py
+++ b/fec_integration_tests/interface/interface_functions/test_front_end_common_create_pre_allocated_res_for_lpg.py
@@ -60,7 +60,8 @@ class TestLPGPreAllocateRes(unittest.TestCase):
         pre_alloc = PreAllocateResourcesForLivePacketGatherers()
         pre_res = pre_alloc(
             live_packet_gatherer_parameters=live_packet_gatherers,
-            machine=machine)
+            machine=machine,
+            pre_allocated_resources=PreAllocatedResourceContainer())
 
         locs = list()
         locs.append((0, 0))
@@ -125,7 +126,8 @@ class TestLPGPreAllocateRes(unittest.TestCase):
         pre_alloc = PreAllocateResourcesForLivePacketGatherers()
         pre_res = pre_alloc(
             live_packet_gatherer_parameters=live_packet_gatherers,
-            machine=machine)
+            machine=machine,
+            pre_allocated_resources=PreAllocatedResourceContainer())
 
         # verify sdram
         locs = [(0, 0), (4, 8), (8, 4)]
@@ -245,19 +247,25 @@ class TestLPGPreAllocateRes(unittest.TestCase):
         pre_alloc = PreAllocateResourcesForLivePacketGatherers()
         pre_res = pre_alloc(
             live_packet_gatherer_parameters=live_packet_gatherers,
-            machine=machine)
+            machine=machine,
+            pre_allocated_resources=PreAllocatedResourceContainer())
         self.assertEqual(len(pre_res.specific_core_resources), 0)
         self.assertEqual(len(pre_res.core_resources), 0)
         self.assertEqual(len(pre_res.specific_sdram_usage), 0)
 
     def test_fail(self):
         machine = virtual_machine(width=12, height=12)
-        live_packet_gatherers = dict()
+        live_packet_gatherers = {'foo': 'bar'}
         pre_alloc = PreAllocateResourcesForLivePacketGatherers()
-        self.assertRaises(
-            Exception, pre_alloc(
+        with self.assertRaises(Exception) as exn:
+            pre_alloc(
                 live_packet_gatherer_parameters=live_packet_gatherers,
-                machine=machine))
+                machine=machine,
+                pre_allocated_resources=PreAllocatedResourceContainer())
+        # Make sure we know what the exception was; NOT an important test!
+        self.assertEqual(
+            "'str' object has no attribute 'board_address'",
+            str(exn.exception))
 
 
 if __name__ == "__main__":

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1669,11 +1669,10 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
 
         # only add the partitioner if there isn't already a machine graph
         algorithms.append("MallocBasedChipIDAllocator")
+        inputs['MemoryPreAllocatedResources'] = PreAllocatedResourceContainer()
         if not self._machine_graph.n_vertices:
             algorithms.extend(self._config.get_str_list(
                 "Mapping", "application_to_machine_graph_algorithms"))
-            inputs['MemoryPreviousAllocatedResources'] = \
-                PreAllocatedResourceContainer()
 
         if self._use_virtual_board:
             algorithms.extend(self._config.get_str_list(

--- a/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
@@ -144,10 +144,8 @@
         <required_inputs>
             <param_name>machine</param_name>
             <param_name>sdram_to_pre_alloc_for_bit_fields</param_name>
-        </required_inputs>
-        <optional_inputs>
             <param_name>pre_allocated_resources</param_name>
-        </optional_inputs>
+        </required_inputs>
         <outputs>
             <param_type>MemoryPreAllocatedResources</param_type>
             <token part="BitFieldRouterCompressor">GeneratedPreAllocatedResources</token>
@@ -764,9 +762,9 @@
         </input_definitions>
         <required_inputs>
             <param_name>machine</param_name>
+            <param_name>pre_allocated_resources</param_name>
         </required_inputs>
         <optional_inputs>
-            <param_name>pre_allocated_resources</param_name>
             <param_name>n_cores_to_allocate</param_name>
         </optional_inputs>
         <outputs>
@@ -812,10 +810,8 @@
             <param_name>sampling_frequency</param_name>
             <param_name>time_scale_factor</param_name>
             <param_name>machine_time_step</param_name>
-        </required_inputs>
-        <optional_inputs>
             <param_name>pre_allocated_resources</param_name>
-        </optional_inputs>
+        </required_inputs>
         <outputs>
             <param_type>MemoryPreAllocatedResources</param_type>
             <token part="EnergyMonitor">GeneratedPreAllocatedResources</token>
@@ -879,10 +875,8 @@
         <required_inputs>
             <param_name>live_packet_gatherer_parameters</param_name>
             <param_name>machine</param_name>
-        </required_inputs>
-        <optional_inputs>
             <param_name>pre_allocated_resources</param_name>
-        </optional_inputs>
+        </required_inputs>
         <outputs>
             <param_type>MemoryPreAllocatedResources</param_type>
             <token part="LivePacketGatherer">GeneratedPreAllocatedResources</token>

--- a/spinn_front_end_common/interface/interface_functions/pre_allocate_for_bit_field_router_compressor.py
+++ b/spinn_front_end_common/interface/interface_functions/pre_allocate_for_bit_field_router_compressor.py
@@ -26,7 +26,7 @@ class PreAllocateForBitFieldRouterCompressor(object):
     """
 
     def __call__(self, machine, sdram_to_pre_alloc_for_bit_fields,
-                 pre_allocated_resources=None):
+                 pre_allocated_resources):
         """
         :param ~spinn_machine.Machine machine:
             the SpiNNaker machine as discovered
@@ -36,7 +36,7 @@ class PreAllocateForBitFieldRouterCompressor(object):
             is no SDRAM available to steal/use.
         :param pre_allocated_resources: other preallocated resources
         :type pre_allocated_resources:
-            ~pacman.model.resources.PreAllocatedResourceContainer or None
+            ~pacman.model.resources.PreAllocatedResourceContainer
         :return: preallocated resources
         :rtype: ~pacman.model.resources.PreAllocatedResourceContainer
         """
@@ -55,13 +55,8 @@ class PreAllocateForBitFieldRouterCompressor(object):
                 (SIZE_OF_SDRAM_ADDRESS_IN_BYTES * chip.n_user_processors) +
                 sdram_to_pre_alloc_for_bit_fields))
 
-        # create preallocated resource container
-        resource_container = PreAllocatedResourceContainer(
+        # note what has been preallocated
+        allocated = PreAllocatedResourceContainer(
             specific_sdram_usage=sdrams)
-
-        # add other preallocated resources
-        if pre_allocated_resources is not None:
-            resource_container.extend(pre_allocated_resources)
-
-        # return preallocated resources
-        return resource_container
+        allocated.extend(pre_allocated_resources)
+        return allocated

--- a/spinn_front_end_common/interface/interface_functions/pre_allocate_resources_for_chip_power_monitor.py
+++ b/spinn_front_end_common/interface/interface_functions/pre_allocate_resources_for_chip_power_monitor.py
@@ -27,7 +27,7 @@ class PreAllocateResourcesForChipPowerMonitor(object):
     def __call__(
             self, machine, n_samples_per_recording,
             sampling_frequency, time_scale_factor, machine_time_step,
-            pre_allocated_resources=None):
+            pre_allocated_resources):
         """
         :param ~spinn_machine.Machine machine:
             the SpiNNaker machine as discovered
@@ -38,7 +38,7 @@ class PreAllocateResourcesForChipPowerMonitor(object):
         :param int machine_time_step: the machine time step
         :param pre_allocated_resources: other preallocated resources
         :type pre_allocated_resources:
-            ~pacman.model.resources.PreAllocatedResourceContainer or None
+            ~pacman.model.resources.PreAllocatedResourceContainer
         :return: preallocated resources
         :rtype: ~pacman.model.resources.PreAllocatedResourceContainer
         """
@@ -63,14 +63,8 @@ class PreAllocateResourcesForChipPowerMonitor(object):
                 SpecificChipSDRAMResource(chip, resources.sdram))
             cores.append(CoreResource(chip, 1))
 
-        # create preallocated resource container
-        cpm_pre_allocated_resource_container = PreAllocatedResourceContainer(
+        # note what has been preallocated
+        allocated = PreAllocatedResourceContainer(
             specific_sdram_usage=sdrams, core_resources=cores)
-
-        # add other preallocated resources
-        if pre_allocated_resources is not None:
-            cpm_pre_allocated_resource_container.extend(
-                pre_allocated_resources)
-
-        # return preallocated resources
-        return cpm_pre_allocated_resource_container
+        allocated.extend(pre_allocated_resources)
+        return allocated

--- a/spinn_front_end_common/interface/interface_functions/pre_allocate_resources_for_live_packet_gatherers.py
+++ b/spinn_front_end_common/interface/interface_functions/pre_allocate_resources_for_live_packet_gatherers.py
@@ -27,7 +27,7 @@ class PreAllocateResourcesForLivePacketGatherers(object):
 
     def __call__(
             self, live_packet_gatherer_parameters, machine,
-            pre_allocated_resources=None):
+            pre_allocated_resources):
         """
         :param live_packet_gatherer_parameters:
             the LPG parameters requested by the script
@@ -38,7 +38,7 @@ class PreAllocateResourcesForLivePacketGatherers(object):
             the SpiNNaker machine as discovered
         :param pre_allocated_resources: other preallocated resources
         :type pre_allocated_resources:
-            ~pacman.model.resources.PreAllocatedResourceContainer or None
+            ~pacman.model.resources.PreAllocatedResourceContainer
         :return: preallocated resources
         :rtype: ~pacman.model.resources.PreAllocatedResourceContainer
         """
@@ -60,17 +60,12 @@ class PreAllocateResourcesForLivePacketGatherers(object):
                 live_packet_gatherer_parameters, chip, sdram_requirement,
                 sdrams, cores, iptags)
 
-        # create preallocated resource container
-        lpg_prealloc_resource_container = PreAllocatedResourceContainer(
+        # note what has been preallocated
+        allocated = PreAllocatedResourceContainer(
             specific_sdram_usage=sdrams, core_resources=cores,
             specific_iptag_resources=iptags)
-
-        # add other preallocated resources
-        if pre_allocated_resources is not None:
-            lpg_prealloc_resource_container.extend(pre_allocated_resources)
-
-        # return preallocated resources
-        return lpg_prealloc_resource_container
+        allocated.extend(pre_allocated_resources)
+        return allocated
 
     @staticmethod
     def _add_chip_lpg_reqs(

--- a/spinn_front_end_common/interface/interface_functions/preallocate_resources_for_extra_monitor_support.py
+++ b/spinn_front_end_common/interface/interface_functions/preallocate_resources_for_extra_monitor_support.py
@@ -27,13 +27,13 @@ class PreAllocateResourcesForExtraMonitorSupport(object):
     """ Allocates resources for the extra monitors.
     """
     def __call__(
-            self, machine, pre_allocated_resources=None,
+            self, machine, pre_allocated_resources,
             n_cores_to_allocate=1):
         """
         :param ~spinn_machine.Machine machine: SpiNNaker machine object
         :param pre_allocated_resources: resources already preallocated
         :type pre_allocated_resources:
-            ~pacman.model.resources.PreAllocatedResourceContainer or None
+            ~pacman.model.resources.PreAllocatedResourceContainer
         :param int n_cores_to_allocate: how many gatherers to use per chip
         :rtype: ~pacman.model.resources.PreAllocatedResourceContainer
         """
@@ -55,17 +55,12 @@ class PreAllocateResourcesForExtraMonitorSupport(object):
         # extractor
         self._handle_second_monitor_support(cores, sdrams, machine, progress)
 
-        # create pre allocated resource container
-        extra_monitor_pre_allocations = PreAllocatedResourceContainer(
+        # note what has been preallocated
+        allocated = PreAllocatedResourceContainer(
             specific_sdram_usage=sdrams, core_resources=cores,
             specific_iptag_resources=tags)
-
-        # add other pre allocated resources
-        if pre_allocated_resources is not None:
-            extra_monitor_pre_allocations.extend(pre_allocated_resources)
-
-        # return pre allocated resources
-        return extra_monitor_pre_allocations
+        allocated.extend(pre_allocated_resources)
+        return allocated
 
     @staticmethod
     def _handle_second_monitor_support(cores, sdrams, machine, progress):


### PR DESCRIPTION
We were not allocating a preallocated resource container ahead of time because we were allocating it… with the _wrong type name._ This fixes that and updates the code to work with the (now valid!) assumption that the thing is there.