### PR TITLE
dont fail in error support

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1180,11 +1180,18 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
             self._machine_allocation_controller = executor.get_item(
                 "MachineAllocationController")
             report_folder = executor.get_item("ReportFolder")
-            TagsFromMachineReport()(report_folder, self._txrx)
+            try:
+                if report_folder:
+                    TagsFromMachineReport()(report_folder, self._txrx)
+            except Exception as e2:
+                logger.warning(
+                    "problem with TagsFromMachineReport {}".format(e2),
+                    exc_info=True)
             try:
                 self._shutdown()
-            except Exception:
-                logger.warning("problem when shutting down", exc_info=True)
+            except Exception as e3:
+                logger.warning("problem when shutting down {}".format(e3),
+                               exc_info=True)
             raise e
 
     def _get_machine(self, total_run_time=0.0, n_machine_time_steps=None):


### PR DESCRIPTION
Issues discovered while playing with config files that had an invalid machine.

This caused the algorithms to raise an exception before a ReportFolder was created.

Which in turn cause TagsFromMachineReport to fail hiding the real issue.

Fixes.
1. Do not run TagsFromMachineReport if you dont have a report folder.
2. If you run TagsFromMachineReport dont lets its exception be the main one