### PR TITLE
Split out the shared DB setup code

### DIFF
--- a/doc/unfiltered-files.txt
+++ b/doc/unfiltered-files.txt
@@ -25,5 +25,6 @@ spinn_front_end_common/utilities/constants.py
 spinn_front_end_common/utilities/exceptions.py
 spinn_front_end_common/utilities/globals_variables.py
 spinn_front_end_common/utilities/helpful_functions.py
+spinn_front_end_common/utilities/sqlite_db.py
 spinn_front_end_common/utilities/system_control_logic.py
 spinn_front_end_common/utilities/report_functions/energy_report.py

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/sqllite_database.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/sqllite_database.py
@@ -18,6 +18,7 @@ import sqlite3
 import time
 from spinn_utilities.abstract_context_manager import AbstractContextManager
 from spinn_utilities.overrides import overrides
+from spinn_front_end_common.utilities.sqlite_db import SQLiteDB
 from .abstract_database import AbstractDatabase
 
 _DDL_FILE = os.path.join(os.path.dirname(__file__), "db.sql")
@@ -28,7 +29,7 @@ def _timestamp():
     return int(time.time() * _SECONDS_TO_MICRO_SECONDS_CONVERSION)
 
 
-class SqlLiteDatabase(AbstractDatabase, AbstractContextManager):
+class SqlLiteDatabase(SQLiteDB, AbstractContextManager):
     """ Specific implementation of the Database for SQLite 3.
 
     .. note::
@@ -36,10 +37,7 @@ class SqlLiteDatabase(AbstractDatabase, AbstractContextManager):
         Threads can access different DBs just fine.
     """
 
-    __slots__ = [
-        # the database holding the data to store
-        "_db",
-    ]
+    __slots__ = []
 
     def __init__(self, database_file=None):
         """
@@ -48,24 +46,11 @@ class SqlLiteDatabase(AbstractDatabase, AbstractContextManager):
             database holding the data. If omitted, an unshared in-memory
             database will be used.
         """
-        if database_file is None:
-            database_file = ":memory:"  # Magic name!
-        self._db = sqlite3.connect(database_file)
-        self.__init_db()
-
-    def __del__(self):
-        self.close()
-
-    @overrides(AbstractDatabase.close)
-    def close(self):
-        if self._db is not None:
-            self._db.close()
-            self._db = None
+        super().__init__(database_file, ddl_file=_DDL_FILE)
 
     @overrides(AbstractDatabase.clear)
     def clear(self):
-        with self._db:
-            cursor = self._db.cursor()
+        with self.transaction() as cursor:
             cursor.execute(
                 """
                 UPDATE region SET
@@ -76,8 +61,7 @@ class SqlLiteDatabase(AbstractDatabase, AbstractContextManager):
 
     @overrides(AbstractDatabase.clear_region)
     def clear_region(self, x, y, p, region):
-        with self._db:
-            cursor = self._db.cursor()
+        with self.transaction() as cursor:
             for row in cursor.execute(
                     """
                     SELECT region_id FROM region_view
@@ -100,14 +84,6 @@ class SqlLiteDatabase(AbstractDatabase, AbstractContextManager):
                 DELETE FROM region_extra WHERE region_id = ?
                 """, locus)
             return True
-
-    def __init_db(self):
-        """ Set up the database if required. """
-        self._db.row_factory = sqlite3.Row
-        self._db.text_factory = memoryview
-        with open(_DDL_FILE) as f:
-            sql = f.read()
-        self._db.executescript(sql)
 
     def __read_contents(self, cursor, x, y, p, region):
         """
@@ -207,8 +183,7 @@ class SqlLiteDatabase(AbstractDatabase, AbstractContextManager):
         # pylint: disable=too-many-arguments
         # TODO: Use missing
         datablob = sqlite3.Binary(data)
-        with self._db:
-            cursor = self._db.cursor()
+        with self.transaction() as cursor:
             region_id = self.__get_region_id(cursor, x, y, p, region)
             if self.__use_main_table(cursor, region_id):
                 cursor.execute(
@@ -255,9 +230,8 @@ class SqlLiteDatabase(AbstractDatabase, AbstractContextManager):
     @overrides(AbstractDatabase.get_region_data)
     def get_region_data(self, x, y, p, region):
         try:
-            with self._db:
-                c = self._db.cursor()
-                data = self.__read_contents(c, x, y, p, region)
+            with self.transaction() as cursor:
+                data = self.__read_contents(cursor, x, y, p, region)
                 # TODO missing data
                 return data, False
         except LookupError:

--- a/spinn_front_end_common/interface/ds/ds_sqllite_database.py
+++ b/spinn_front_end_common/interface/ds/ds_sqllite_database.py
@@ -16,19 +16,17 @@
 import logging
 import os
 import sqlite3
-from spinn_utilities.abstract_context_manager import AbstractContextManager
 from spinn_utilities.log import FormatAdapter
+from spinn_front_end_common.utilities.sqlite_db import SQLiteDB
 from spinn_front_end_common.utilities.utility_objs import DataWritten
 
 DB_NAME = "ds.sqlite3"
-DDL_FILE = os.path.join(os.path.dirname(__file__), "dse.sql")
+_DDL_FILE = os.path.join(os.path.dirname(__file__), "dse.sql")
 logger = FormatAdapter(logging.getLogger(__name__))
 
 
-class DsSqlliteDatabase(AbstractContextManager):
+class DsSqlliteDatabase(SQLiteDB):
     __slots__ = [
-        # the database holding the data to store, if used
-        "_db",
         # The machine cached for getting the "ethernet"s
         "_machine",
         # The root ethernet id if required
@@ -48,21 +46,15 @@ class DsSqlliteDatabase(AbstractContextManager):
         if init is None:
             init = not os.path.exists(database_file)
 
-        self._db = sqlite3.connect(database_file)
-        self._db.text_factory = memoryview
-        self._db.row_factory = sqlite3.Row
+        super().__init__(database_file, ddl_file=_DDL_FILE if init else None)
         if init:
-            self.__init_db()
+            self.__init_db_contents()
         self._root_ethernet_id = self.__find_root_id()
 
-    def __init_db(self):
-        """ Set up the database if required. """
-        with open(DDL_FILE) as f:
-            sql = f.read()
-        self._db.executescript(sql)
-
-        with self._db:
-            self._db.executemany(
+    def __init_db_contents(self):
+        """ Set up the database contents from the machine. """
+        with self.transaction() as cursor:
+            cursor.executemany(
                 """
                 INSERT INTO ethernet(
                     ethernet_x, ethernet_y, ip_address)
@@ -73,8 +65,8 @@ class DsSqlliteDatabase(AbstractContextManager):
 
     def __find_root_id(self):
         first_x = first_y = root_id = None
-        with self._db:
-            for row in self._db.execute(
+        with self.transaction() as cursor:
+            for row in cursor.execute(
                     """
                     SELECT ethernet_id, ethernet_x, ethernet_y FROM ethernet
                     ORDER BY ethernet_x, ethernet_y
@@ -92,25 +84,11 @@ class DsSqlliteDatabase(AbstractContextManager):
                 "for all boards with no IP address.", first_x, first_y)
         return root_id
 
-    def __del__(self):
-        self.close()
-
-    def close(self):
-        """ Signals that the database can be closed and will not be reused.
-
-        .. note::
-            Once this is called any other method in this API is allowed to
-            raise any kind of exception.
-        """
-        if self._db is not None:
-            self._db.close()
-            self._db = None
-
     def clear_ds(self):
         """ Clear all saved data specification data
         """
-        with self._db:
-            self._db.execute(
+        with self.transaction() as cursor:
+            cursor.execute(
                 """
                 DELETE FROM core
                 """)
@@ -123,8 +101,8 @@ class DsSqlliteDatabase(AbstractContextManager):
         :param bytearray ds: the data spec as byte code
         """
         chip = self._machine.get_chip_at(core_x, core_y)
-        with self._db:
-            self._db.execute(
+        with self.transaction() as cursor:
+            cursor.execute(
                 """
                 INSERT INTO core(
                     x, y, processor, content, ethernet_id)
@@ -147,8 +125,8 @@ class DsSqlliteDatabase(AbstractContextManager):
         :return: data spec as byte code
         :rtype: bytearray
         """
-        with self._db:
-            for row in self._db.execute(
+        with self.transaction() as cursor:
+            for row in cursor.execute(
                     """
                     SELECT content FROM core
                     WHERE x = ? AND y = ? AND processor = ?
@@ -166,8 +144,8 @@ class DsSqlliteDatabase(AbstractContextManager):
         :return: Yields the (x, y, p) and saved ds pairs
         :rtype: iterable(tuple(tuple(int, int, int), bytearray))
         """
-        with self._db:
-            for row in self._db.execute(
+        with self.transaction() as cursor:
+            for row in cursor.execute(
                     """
                     SELECT x, y, processor, content FROM core
                     WHERE content IS NOT NULL
@@ -179,8 +157,8 @@ class DsSqlliteDatabase(AbstractContextManager):
 
         :rtype: int
         """
-        with self._db:
-            for row in self._db.execute(
+        with self.transaction() as cursor:
+            for row in cursor.execute(
                     """
                     SELECT COUNT(*) as count FROM core
                     WHERE content IS NOT NULL
@@ -194,8 +172,8 @@ class DsSqlliteDatabase(AbstractContextManager):
 
         :param int app_id: value to set
         """
-        with self._db:
-            self._db.execute(
+        with self.transaction() as cursor:
+            cursor.execute(
                 """
                 UPDATE core SET
                     app_id = ?
@@ -210,8 +188,8 @@ class DsSqlliteDatabase(AbstractContextManager):
         :param int p: core
         :rtype: int
         """
-        with self._db:
-            for row in self._db.execute(
+        with self.transaction() as cursor:
+            for row in cursor.execute(
                     """
                     SELECT app_id FROM core
                     WHERE x = ? AND y = ? AND processor = ?
@@ -226,8 +204,8 @@ class DsSqlliteDatabase(AbstractContextManager):
         :param iterable(tuple(int,int,int)) core_list:
             list of (core x, core y, core p)
         """
-        with self._db:
-            self._db.executemany(
+        with self.transaction() as cursor:
+            cursor.executemany(
                 """
                 UPDATE core SET
                     is_system = 1
@@ -251,8 +229,8 @@ class DsSqlliteDatabase(AbstractContextManager):
         :param int p: core p
         :rtype: DataWritten
         """
-        with self._db:
-            for row in self._db.execute(
+        with self.transaction() as cursor:
+            for row in cursor.execute(
                     """
                     SELECT start_address, memory_used, memory_written
                     FROM core
@@ -260,7 +238,7 @@ class DsSqlliteDatabase(AbstractContextManager):
                     LIMIT 1
                     """, (x, y, p)):
                 return self._row_to_info(row)
-        raise ValueError("No info for {}:{}:{}".format(x, y, p))
+        raise ValueError(f"No info for {x}:{y}:{p}")
 
     def set_write_info(self, x, y, p, info):
         """ Sets the provenance returned by the Data Spec executor.
@@ -278,8 +256,7 @@ class DsSqlliteDatabase(AbstractContextManager):
             start = info["start_address"]
             used = info["memory_used"]
             written = info["memory_written"]
-        with self._db:
-            cursor = self._db.cursor()
+        with self.transaction() as cursor:
             cursor.execute(
                 """
                 UPDATE core SET
@@ -305,8 +282,7 @@ class DsSqlliteDatabase(AbstractContextManager):
                         chip.nearest_ethernet_y, self._root_ethernet_id))
 
     def set_size_info(self, x, y, p, memory_used):
-        with self._db:
-            cursor = self._db.cursor()
+        with self.transaction() as cursor:
             cursor.execute(
                 """
                 UPDATE core SET
@@ -332,8 +308,8 @@ class DsSqlliteDatabase(AbstractContextManager):
     def clear_write_info(self):
         """ Clears the provenance for all rows.
         """
-        with self._db:
-            self._db.execute(
+        with self.transaction() as cursor:
+            cursor.execute(
                 """
                 UPDATE core SET
                     start_address = NULL,
@@ -346,8 +322,8 @@ class DsSqlliteDatabase(AbstractContextManager):
 
         :rtype: int
         """
-        with self._db:
-            for row in self._db.execute(
+        with self.transaction() as cursor:
+            for row in cursor.execute(
                     """
                     SELECT count(*) as count FROM core
                     WHERE start_address IS NOT NULL
@@ -366,8 +342,8 @@ class DsSqlliteDatabase(AbstractContextManager):
         :return: Yields the (x, y, p) and DataWritten
         :rtype: iterable(tuple(tuple(int, int, int), DataWritten))
         """
-        with self._db:
-            for row in self._db.execute(
+        with self.transaction() as cursor:
+            for row in cursor.execute(
                     """
                     SELECT
                         x, y, processor,

--- a/spinn_front_end_common/interface/provenance/router_prov_mapper.py
+++ b/spinn_front_end_common/interface/provenance/router_prov_mapper.py
@@ -17,6 +17,7 @@ import argparse
 import os
 import sqlite3
 import numpy
+from spinn_front_end_common.utilities.sqlite_db import SQLiteDB
 # import matplotlib.pyplot as plot
 # import seaborn
 
@@ -53,19 +54,9 @@ class Plotter(object):
     __seaborn = None
 
     def __init__(self, db_filename, verbose=False):
-        # Check the existence of the database here
-        # if the DB isn't there, the errors are otherwise *weird* if we don't
-        # check...
-        if not os.path.exists(db_filename):
-            raise Exception("no such DB: " + db_filename)
         # TODO: use magic to open a read-only connection once we're Py3 only
         # See: https://stackoverflow.com/a/21794758/301832
-        self._db = sqlite3.connect(db_filename)
-        self._db.row_factory = sqlite3.Row
-        # Force case-insensitive matching of provenance names
-        self._db.execute("""
-            PRAGMA case_sensitive_like=OFF;
-            """)
+        self._db = SQLiteDB(db_filename, read_only=True, text_factory=str)
         self.__have_insertion_order = True
         self.__verbose = verbose
         self.cmap = "plasma"
@@ -78,39 +69,39 @@ class Plotter(object):
 
     def __do_chip_query(self, description):
         # Does the query in one of two ways, depending on schema version
-        if self.__have_insertion_order:
-            try:
-                return self._db.execute("""
-                    SELECT source_name AS "source", x, y,
-                        description_name AS "description",
-                        the_value AS "value"
-                    FROM provenance_view
-                    WHERE description LIKE ?
-                    GROUP BY x, y, p
-                    HAVING insertion_order = MAX(insertion_order)
-                    """, (description, ))
-            except sqlite3.OperationalError as e:
-                if "no such column: insertion_order" != str(e):
-                    raise
-                self.__have_insertion_order = 0
-        return self._db.execute("""
-            SELECT source_name AS "source", x, y,
-                description_name AS "description",
-                MAX(the_value) AS "value"
-            FROM provenance_view
-            WHERE description LIKE ?
-            GROUP BY x, y, p
-            """, (description, ))
+        with self._db.transaction() as cur:
+            if self.__have_insertion_order:
+                try:
+                    return cur.execute("""
+                        SELECT source_name AS "source", x, y,
+                            description_name AS "description",
+                            the_value AS "value"
+                        FROM provenance_view
+                        WHERE description LIKE ?
+                        GROUP BY x, y, p
+                        HAVING insertion_order = MAX(insertion_order)
+                        """, (description, ))
+                except sqlite3.OperationalError as e:
+                    if "no such column: insertion_order" != str(e):
+                        raise
+                    self.__have_insertion_order = False
+            return cur.execute("""
+                SELECT source_name AS "source", x, y,
+                    description_name AS "description",
+                    MAX(the_value) AS "value"
+                FROM provenance_view
+                WHERE description LIKE ?
+                GROUP BY x, y, p
+                """, (description, ))
 
     def get_per_chip_prov_types(self):
-        names = list()
-        for row in self._db.execute("""
-                SELECT DISTINCT description_name AS "description"
-                FROM provenance_view
-                WHERE x IS NOT NULL AND p IS NULL AND "description" IS NOT NULL
-                """):
-            names.append(row["description"])
-        return frozenset(names)
+        query = """
+            SELECT DISTINCT description_name AS "description"
+            FROM provenance_view
+            WHERE x IS NOT NULL AND p IS NULL AND "description" IS NOT NULL
+            """
+        with self._db.transaction() as cur:
+            return frozenset(row["description"] for row in cur.execute(query))
 
     def get_per_chip_prov_details(self, info):
         data = []
@@ -134,48 +125,48 @@ class Plotter(object):
 
     def __do_sum_query(self, description):
         # Does the query in one of two ways, depending on schema version
-        if self.__have_insertion_order:
-            try:
-                return self._db.execute("""
-                    SELECT "source", x, y, "description",
-                        SUM("value") AS "value"
-                    FROM (
-                        SELECT source_name AS "source", x, y, p,
-                            description_name AS "description",
-                            the_value AS "value"
-                        FROM provenance_view
-                        WHERE description LIKE ? AND p IS NOT NULL
-                        GROUP BY x, y, p
-                        HAVING insertion_order = MAX(insertion_order))
-                    GROUP BY x, y
-                    """, (description, ))
-            except sqlite3.OperationalError as e:
-                if "no such column: insertion_order" != str(e):
-                    raise
-                self.__have_insertion_order = 0
-        return self._db.execute("""
-            SELECT "source", x, y, "description",
-                SUM("value") AS "value"
-            FROM (
-                SELECT source_name AS "source", x, y,
-                    description_name AS "description",
-                    MAX(the_value) AS "value"
-                FROM provenance_view
-                WHERE description LIKE ? AND p IS NOT NULL
-                GROUP BY x, y, p)
-            GROUP BY x, y
-            """, (description, ))
+        with self._db.transaction() as cur:
+            if self.__have_insertion_order:
+                try:
+                    return cur.execute("""
+                        SELECT "source", x, y, "description",
+                            SUM("value") AS "value"
+                        FROM (
+                            SELECT source_name AS "source", x, y, p,
+                                description_name AS "description",
+                                the_value AS "value"
+                            FROM provenance_view
+                            WHERE description LIKE ? AND p IS NOT NULL
+                            GROUP BY x, y, p
+                            HAVING insertion_order = MAX(insertion_order))
+                        GROUP BY x, y
+                        """, (description, ))
+                except sqlite3.OperationalError as e:
+                    if "no such column: insertion_order" != str(e):
+                        raise
+                    self.__have_insertion_order = False
+            return cur.execute("""
+                SELECT "source", x, y, "description",
+                    SUM("value") AS "value"
+                FROM (
+                    SELECT source_name AS "source", x, y,
+                        description_name AS "description",
+                        MAX(the_value) AS "value"
+                    FROM provenance_view
+                    WHERE description LIKE ? AND p IS NOT NULL
+                    GROUP BY x, y, p)
+                GROUP BY x, y
+                """, (description, ))
 
     def get_per_core_prov_types(self):
-        names = list()
-        for row in self._db.execute("""
-                SELECT DISTINCT description_name AS "description"
-                FROM provenance_view
-                WHERE x IS NOT NULL AND p IS NOT NULL
-                    AND "description" IS NOT NULL
-                """):
-            names.append(row["description"])
-        return frozenset(names)
+        query = """
+            SELECT DISTINCT description_name AS "description"
+            FROM provenance_view
+            WHERE x IS NOT NULL AND p IS NOT NULL
+                AND "description" IS NOT NULL
+            """
+        with self._db.transaction() as cur:
+            return frozenset(row["description"] for row in cur.execute(query))
 
     def get_sum_chip_prov_details(self, info):
         data = []

--- a/spinn_front_end_common/interface/provenance/router_prov_mapper.py
+++ b/spinn_front_end_common/interface/provenance/router_prov_mapper.py
@@ -54,8 +54,6 @@ class Plotter(object):
     __seaborn = None
 
     def __init__(self, db_filename, verbose=False):
-        # TODO: use magic to open a read-only connection once we're Py3 only
-        # See: https://stackoverflow.com/a/21794758/301832
         self._db = SQLiteDB(db_filename, read_only=True, text_factory=str)
         self.__have_insertion_order = True
         self.__verbose = verbose

--- a/spinn_front_end_common/interface/provenance/sqllite_database.py
+++ b/spinn_front_end_common/interface/provenance/sqllite_database.py
@@ -16,15 +16,14 @@
 import datetime
 import os
 import re
-import sqlite3
 from spinn_utilities.ordered_set import OrderedSet
-from spinn_utilities.abstract_context_manager import AbstractContextManager
+from spinn_front_end_common.utilities.sqlite_db import SQLiteDB
 
 _DDL_FILE = os.path.join(os.path.dirname(__file__), "db.sql")
 _RE = re.compile(r"(\d+)([_,:])(\d+)(?:\2(\d+))?")
 
 
-class SqlLiteDatabase(AbstractContextManager):
+class SqlLiteDatabase(SQLiteDB):
     """ Specific implementation of the Database for SQLite 3.
 
     .. note::
@@ -36,10 +35,7 @@ class SqlLiteDatabase(AbstractContextManager):
         You can't port to a different database engine without a lot of work.
     """
 
-    __slots__ = [
-        # the database holding the data to store
-        "_db",
-    ]
+    __slots__ = []
 
     def __init__(self, database_file=None):
         """
@@ -49,48 +45,26 @@ class SqlLiteDatabase(AbstractContextManager):
             database will be used (suitable only for testing).
         :type database_file: str
         """
-        if database_file is None:
-            database_file = ":memory:"  # Magic name!
-        self._db = sqlite3.connect(database_file)
-        self.__init_db()
-
-    def __del__(self):
-        self.close()
-
-    def close(self):
-        """ Finalises and closes the database.
-        """
-        if self._db is not None:
-            self._db.close()
-            self._db = None
-
-    def __init_db(self):
-        """ Set up the database if required.
-        """
-        self._db.row_factory = sqlite3.Row
-        self._db.text_factory = memoryview
-        with open(_DDL_FILE) as f:
-            sql = f.read()
-        self._db.executescript(sql)
+        super().__init__(database_file, ddl_file=_DDL_FILE)
 
     def insert_items(self, items):
         """ Does a bulk insert of the items into the database.
 
         :param list(ProvenanceDataItem) items: The items to insert
         """
-        with self._db:
-            self._db.executemany(
+        with self.transaction() as cur:
+            cur.executemany(
                 """
                 INSERT OR IGNORE INTO source(
                     source_name, source_short_name, x, y, p)
                 VALUES(?, ?, ?, ?, ?)
                 """, self.__unique_sources(items, slice(None, -1), "/"))
-            self._db.executemany(
+            cur.executemany(
                 """
                 INSERT OR IGNORE INTO description(description_name)
                 VALUES(?)
                 """, self.__unique_names(items, -1))
-            self._db.executemany(
+            cur.executemany(
                 """
                 INSERT INTO provenance(
                     source_id, description_id, the_value)

--- a/spinn_front_end_common/utilities/connections/live_event_connection.py
+++ b/spinn_front_end_common/utilities/connections/live_event_connection.py
@@ -228,6 +228,9 @@ class LiveEventConnection(DatabaseConnection):
         self.__pause_stop_callbacks[label].append(pause_stop_callback)
 
     def __read_database_callback(self, db_reader):
+        """
+        :param DatabaseReader db_reader:
+        """
         self.__handle_possible_rerun_state()
 
         vertex_sizes = OrderedDict()
@@ -248,6 +251,10 @@ class LiveEventConnection(DatabaseConnection):
                     label, vertex_size, run_time_ms, machine_timestep_ms)
 
     def __init_sender(self, db, vertex_sizes):
+        """
+        :param DatabaseReader db:
+        :param dict(str,int) vertex_sizes:
+        """
         if self.__sender_connection is None:
             self.__sender_connection = UDPConnection()
         for label in self.__send_labels:
@@ -263,6 +270,10 @@ class LiveEventConnection(DatabaseConnection):
                 vertex_sizes[label] = len(self._atom_id_to_key[label])
 
     def __init_receivers(self, db, vertex_sizes):
+        """
+        :param DatabaseReader db:
+        :param dict(str,int) vertex_sizes:
+        """
         # Set up a single connection for receive
         if self.__receiver_connection is None:
             self.__receiver_connection = EIEIOConnection()
@@ -305,6 +316,11 @@ class LiveEventConnection(DatabaseConnection):
             self.__receiver_listener.start()
 
     def __get_live_input_details(self, db_reader, send_label):
+        """
+        :param DatabaseReader db_reader:
+        :param str send_label:
+        :rtype: tuple(int,int,int,str or None)
+        """
         if self.__machine_vertices:
             x, y, p = db_reader.get_placement(send_label)
         else:

--- a/spinn_front_end_common/utilities/database/database_connection.py
+++ b/spinn_front_end_common/utilities/database/database_connection.py
@@ -33,6 +33,10 @@ class DatabaseConnection(UDPConnection):
         database has been written, and can then respond when the database \
         has been read, and further wait for notification that the simulation \
         has started.
+
+    .. note::
+        The machine description database reader can only be used while the
+        registered database callbacks are running.
     """
 
     __slots__ = [
@@ -75,9 +79,8 @@ class DatabaseConnection(UDPConnection):
             A function to be called when the database message has been
             received.  This function should take a single parameter, which
             will be a DatabaseReader object. Once the function returns, it
-            will be assumed that the database has been read, and the return
-            response will be sent.
-        :raises SpinnmanIOException: If anything goes wrong
+            will be assumed that the database has been read and will not be
+            needed further, and the return response will be sent.
         """
         self.__database_callbacks.append(database_callback_function)
 

--- a/spinn_front_end_common/utilities/database/database_reader.py
+++ b/spinn_front_end_common/utilities/database/database_reader.py
@@ -12,53 +12,24 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-import os
-import sqlite3
-from spinn_utilities.abstract_context_manager import AbstractContextManager
-from spinn_utilities.overrides import overrides
+from spinn_front_end_common.utilities.sqlite_db import SQLiteDB
 
 
-class DatabaseReader(AbstractContextManager):
+class DatabaseReader(SQLiteDB):
     """ A reader for the database.
     """
-
-    __slots__ = [
-        # the database connection (is basically a lock on the database)
-        "_connection",
-
-        # the handle for working on the DB
-        "_cursor"
-    ]
+    __slots__ = []
 
     def __init__(self, database_path):
         """
         :param str database_path: The path to the database
         """
-        # Ugly: must ensure database exists ourselves because Python doesn't
-        # have option to open read-only (in the real SQLite API!) exposed
-        if not os.path.exists(database_path):
-            raise FileNotFoundError(
-                "[Errno 2] No such file or directory: '{}'".format(
-                    database_path))
-        self._connection = sqlite3.connect(database_path)
-        self._connection.row_factory = sqlite3.Row
-        self._cursor = self._connection.cursor()
-
-    @property
-    def cursor(self):
-        """ The database cursor. Allows custom SQL queries to be performed.
-
-        :rtype: ~sqlite3.Cursor
-        """
-        return self._cursor
+        super().__init__(database_path, read_only=True)
 
     def __exec_one(self, query, *args):
-        self._cursor.execute(query + " LIMIT 1", args)
-        return self._cursor.fetchone()
-
-    def __exec_all(self, query, *args):
-        self._cursor.execute(query, args)
-        return self._cursor.fetchall()
+        with self.transaction() as cur:
+            cur.execute(query + " LIMIT 1", args)
+            return cur.fetchone()
 
     @staticmethod
     def __r2t(row, *args):
@@ -71,12 +42,14 @@ class DatabaseReader(AbstractContextManager):
         :return: dictionary of atom IDs indexed by event key
         :rtype: dict(int, int)
         """
-        return {row["event"]: row["atom"]
-                for row in self.__exec_all(
+        with self.transaction() as cur:
+            return {
+                row["event"]: row["atom"]
+                for row in cur.execute(
                     """
                     SELECT * FROM label_event_atom_view
                     WHERE label = ?
-                    """, label)}
+                    """, (label, ))}
 
     def get_atom_id_to_key_mapping(self, label):
         """ Get a mapping of atom ID to event key for a given vertex
@@ -85,12 +58,14 @@ class DatabaseReader(AbstractContextManager):
         :return: dictionary of event keys indexed by atom ID
         :rtype: dict(int, int)
         """
-        return {row["atom"]: row["event"]
-                for row in self.__exec_all(
+        with self.transaction() as cur:
+            return {
+                row["atom"]: row["event"]
+                for row in cur.execute(
                     """
                     SELECT * FROM label_event_atom_view
                     WHERE label = ?
-                    """, label)}
+                    """, (label, ))}
 
     def get_live_output_details(self, label, receiver_label):
         """ Get the IP address, port and whether the SDP headers are to be\
@@ -240,12 +215,13 @@ class DatabaseReader(AbstractContextManager):
         :return: A list of x, y, p coordinates of the vertices
         :rtype: list(tuple(int, int, int))
         """
-
-        return [self.__xyp(row) for row in self.__exec_all(
-            """
-            SELECT x, y, p FROM application_vertex_placements
-            WHERE vertex_label = ?
-            """, label)]
+        with self.transaction() as cur:
+            return [
+                self.__xyp(row) for row in cur.execute(
+                    """
+                    SELECT x, y, p FROM application_vertex_placements
+                    WHERE vertex_label = ?
+                    """, (label, ))]
 
     def get_ip_address(self, x, y):
         """ Get an IP address to contact a chip
@@ -263,7 +239,3 @@ class DatabaseReader(AbstractContextManager):
             """, x, y)
         # Should only fail if no machine is present!
         return None if row is None else row["eth_ip_address"]
-
-    @overrides(AbstractContextManager.close)
-    def close(self):
-        self._connection.close()

--- a/spinn_front_end_common/utilities/database/database_writer.py
+++ b/spinn_front_end_common/utilities/database/database_writer.py
@@ -15,11 +15,9 @@
 
 import logging
 import os
-import sqlite3
-from spinn_utilities.abstract_context_manager import AbstractContextManager
 from spinn_utilities.log import FormatAdapter
-from spinn_utilities.overrides import overrides
 from pacman.model.graphs.common import EdgeTrafficType
+from spinn_front_end_common.utilities.sqlite_db import SQLiteDB
 from spinn_front_end_common.abstract_models import (
     AbstractProvidesKeyToAtomMapping,
     AbstractSupportsDatabaseInjection)
@@ -33,24 +31,18 @@ def _extract_int(x):
     return None if x is None else int(x)
 
 
-class DatabaseWriter(AbstractContextManager):
+class DatabaseWriter(SQLiteDB):
     """ The interface for the database system for main front ends.\
         Any special tables needed from a front end should be done\
         by sub classes of this interface.
     """
 
     __slots__ = [
-        # boolean flag for when the database writer has finished
-        "_done",
-
         # the path of the database
         "_database_path",
 
         # the identifier for the SpiNNaker machine
         "_machine_id",
-
-        # the database connection itself
-        "_connection",
 
         # Mappings used to accelerate inserts
         "__machine_to_id", "__vertex_to_id", "__edge_to_id"
@@ -60,29 +52,20 @@ class DatabaseWriter(AbstractContextManager):
         """
         :param str database_directory: Where the database will be written
         """
-        self._done = False
         self._database_path = os.path.join(database_directory, DB_NAME)
-        self._connection = None
-        self.__machine_to_id = dict()
-        self.__vertex_to_id = dict()
-        self.__edge_to_id = dict()
+        init_sql_path = os.path.join(os.path.dirname(__file__), INIT_SQL)
 
         # delete any old database
         if os.path.isfile(self._database_path):
             os.remove(self._database_path)
 
+        super().__init__(self._database_path, ddl_file=init_sql_path)
+        self.__machine_to_id = dict()
+        self.__vertex_to_id = dict()
+        self.__edge_to_id = dict()
+
         # set up checks
         self._machine_id = 0
-
-    @overrides(AbstractContextManager._context_entered)
-    def _context_entered(self):
-        self._connection = sqlite3.connect(self._database_path)
-        self.__create_schema()
-
-    @overrides(AbstractContextManager.close)
-    def close(self):
-        self._connection.close()
-        self._connection = None
 
     @staticmethod
     def auto_detect_database(machine_graph):
@@ -104,39 +87,34 @@ class DatabaseWriter(AbstractContextManager):
         """
         return self._database_path
 
-    def __insert(self, sql, *args):
+    def __insert(self, cur, sql, *args):
         """
+        :param ~sqlite3.Cursor cur:
         :param str sql:
         :rtype: int
         """
-        c = self._connection.cursor()
         try:
-            c.execute(sql, args)
-            return c.lastrowid
+            cur.execute(sql, args)
+            return cur.lastrowid
         except Exception:
             logger.exception("problem with insertion; argument types are {}",
                              str(map(type, args)))
             raise
-
-    def __create_schema(self):
-        init_sql_path = os.path.join(os.path.dirname(__file__), INIT_SQL)
-        with self._connection, open(init_sql_path) as f:
-            sql = f.read()
-            self._connection.executescript(sql)
 
     def add_machine_objects(self, machine):
         """ Store the machine object into the database
 
         :param ~spinn_machine.Machine machine: the machine object.
         """
-        with self._connection:
+        with self.transaction() as cur:
             self.__machine_to_id[machine] = self._machine_id = self.__insert(
+                cur,
                 """
                 INSERT INTO Machine_layout(
                     x_dimension, y_dimension)
                 VALUES(?, ?)
                 """, machine.width, machine.height)
-            self._connection.executemany(
+            cur.executemany(
                 """
                 INSERT INTO Machine_chip(
                     no_processors, chip_x, chip_y, machine_id)
@@ -144,7 +122,7 @@ class DatabaseWriter(AbstractContextManager):
                 """, (
                     (chip.n_processors, chip.x, chip.y, self._machine_id)
                     for chip in machine.chips if chip.virtual))
-            self._connection.executemany(
+            cur.executemany(
                 """
                 INSERT INTO Machine_chip(
                     no_processors, chip_x, chip_y, machine_id,
@@ -155,7 +133,7 @@ class DatabaseWriter(AbstractContextManager):
                      chip.ip_address,
                      chip.nearest_ethernet_x, chip.nearest_ethernet_y)
                     for chip in machine.chips if not chip.virtual))
-            self._connection.executemany(
+            cur.executemany(
                 """
                 INSERT INTO Processor(
                     chip_x, chip_y, machine_id, available_DTCM,
@@ -174,10 +152,11 @@ class DatabaseWriter(AbstractContextManager):
         :type application_graph:
             ~pacman.model.graphs.application.ApplicationGraph
         """
-        with self._connection:
+        with self.transaction() as cur:
             # add vertices
             for vertex in application_graph.vertices:
                 self.__vertex_to_id[vertex] = self.__insert(
+                    cur,
                     """
                     INSERT INTO Application_vertices(
                         vertex_label, vertex_class, no_atoms,
@@ -190,6 +169,7 @@ class DatabaseWriter(AbstractContextManager):
             # add edges
             for edge in application_graph.edges:
                 self.__edge_to_id[edge] = self.__insert(
+                    cur,
                     """
                     INSERT INTO Application_edges (
                         pre_vertex, post_vertex, edge_label, edge_class)
@@ -200,7 +180,7 @@ class DatabaseWriter(AbstractContextManager):
                     edge.label, edge.__class__.__name__)
 
             # update graph
-            self._connection.executemany(
+            cur.executemany(
                 """
                 INSERT INTO Application_graph (
                     vertex_id, edge_id)
@@ -218,8 +198,8 @@ class DatabaseWriter(AbstractContextManager):
         :param int machine_time_step: the machine time step used in timing
         :param int runtime: the amount of time the application is to run for
         """
-        with self._connection:
-            self._connection.executemany(
+        with self.transaction() as cur:
+            cur.executemany(
                 """
                 INSERT INTO configuration_parameters (
                     parameter_id, value)
@@ -241,10 +221,11 @@ class DatabaseWriter(AbstractContextManager):
         :type application_graph:
             ~pacman.model.graphs.application.ApplicationGraph
         """
-        with self._connection:
+        with self.transaction() as cur:
             for vertex in machine_graph.vertices:
                 req = vertex.resources_required
                 self.__vertex_to_id[vertex] = self.__insert(
+                    cur,
                     """
                     INSERT INTO Machine_vertices (
                         label, class, cpu_used, sdram_used, dtcm_used)
@@ -258,6 +239,7 @@ class DatabaseWriter(AbstractContextManager):
             # add machine edges
             for edge in machine_graph.edges:
                 self.__edge_to_id[edge] = self.__insert(
+                    cur,
                     """
                     INSERT INTO Machine_edges (
                         pre_vertex, post_vertex, label, class)
@@ -268,7 +250,7 @@ class DatabaseWriter(AbstractContextManager):
                     edge.label, edge.__class__.__name__)
 
             # add to machine graph
-            self._connection.executemany(
+            cur.executemany(
                 """
                 INSERT INTO Machine_graph (
                     vertex_id, edge_id)
@@ -280,7 +262,7 @@ class DatabaseWriter(AbstractContextManager):
                         vertex)))
 
             if application_graph is not None:
-                self._connection.executemany(
+                cur.executemany(
                     """
                     INSERT INTO graph_mapper_vertex (
                         application_vertex_id, machine_vertex_id, lo_atom,
@@ -294,7 +276,7 @@ class DatabaseWriter(AbstractContextManager):
                         for vertex in machine_graph.vertices))
 
                 # add graph_mapper edges
-                self._connection.executemany(
+                cur.executemany(
                     """
                     INSERT INTO graph_mapper_edges (
                         application_edge_id, machine_edge_id)
@@ -310,9 +292,9 @@ class DatabaseWriter(AbstractContextManager):
         :param ~pacman.model.placements.Placements placements:
             the placements object
         """
-        with self._connection:
+        with self.transaction() as cur:
             # add records
-            self._connection.executemany(
+            cur.executemany(
                 """
                 INSERT INTO Placements(
                     vertex_id, chip_x, chip_y, chip_p, machine_id)
@@ -336,8 +318,8 @@ class DatabaseWriter(AbstractContextManager):
                 partition))
             for partition in machine_graph.outgoing_edge_partitions
             if partition.traffic_type == EdgeTrafficType.MULTICAST)
-        with self._connection:
-            self._connection.executemany(
+        with self.transaction() as cur:
+            cur.executemany(
                 """
                 INSERT INTO Routing_info(
                     edge_id, "key", mask)
@@ -355,8 +337,8 @@ class DatabaseWriter(AbstractContextManager):
         :type routing_tables:
             ~pacman.model.routing_tables.MulticastRoutingTables
         """
-        with self._connection:
-            self._connection.executemany(
+        with self.transaction() as cur:
+            cur.executemany(
                 """
                 INSERT INTO Routing_table(
                     chip_x, chip_y, position, key_combo, mask, route)
@@ -376,10 +358,10 @@ class DatabaseWriter(AbstractContextManager):
             the machine graph object
         :param ~pacman.model.tags.Tags tags: the tags object
         """
-        with self._connection:
+        with self.transaction() as cur:
             for vertex in machine_graph.vertices:
                 v_id = self.__vertex_to_id[vertex]
-                self._connection.executemany(
+                cur.executemany(
                     """
                     INSERT INTO IP_tags(
                         vertex_id, tag, board_address, ip_address, port,
@@ -389,7 +371,7 @@ class DatabaseWriter(AbstractContextManager):
                         (v_id, ipt.tag, ipt.board_address, ipt.ip_address,
                          ipt.port or 0, 1 if ipt.strip_sdp else 0)
                         for ipt in tags.get_ip_tags_for_vertex(vertex) or []))
-                self._connection.executemany(
+                cur.executemany(
                     """
                     INSERT INTO Reverse_IP_tags(
                         vertex_id, tag, board_address, port)
@@ -423,8 +405,8 @@ class DatabaseWriter(AbstractContextManager):
                 for partition in machine_graph.
                 get_outgoing_edge_partitions_starting_at_vertex(vertex))
 
-        with self._connection:
-            self._connection.executemany(
+        with self.transaction() as cur:
+            cur.executemany(
                 """
                 INSERT INTO event_to_atom_mapping(
                     vertex_id, event_id, atom_id)

--- a/spinn_front_end_common/utilities/sqlite_db.py
+++ b/spinn_front_end_common/utilities/sqlite_db.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2017-2021 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from contextlib import AbstractContextManager as ACMBase
+import os
+import pathlib
+import sqlite3
+from spinn_utilities.abstract_context_manager import AbstractContextManager
+
+
+class SQLiteDB(AbstractContextManager):
+    """ General support class for SQLite databases.
+    """
+
+    __slots__ = [
+        # the database holding the data to store
+        "__db",
+    ]
+
+    def __init__(self, database_file=None, *, read_only=False, ddl_file=None,
+                 row_factory=sqlite3.Row, text_factory=memoryview,
+                 case_insensitive_like=True):
+        """
+        :param str database_file:
+            The name of a file that contains (or will contain) an SQLite
+            database holding the data. If omitted, an unshared in-memory
+            database will be used (suitable only for testing).
+        :param bool read_only:
+        :param str ddl_file:
+        :param ~collections.abc.Callable row_factory:
+        :param ~collections.abc.Callable text_factory:
+        :param bool case_insensitive_like:
+        """
+        if database_file is None:
+            self.__db = sqlite3.connect(":memory:")  # Magic name!
+            # in-memory DB is never read-only
+        elif read_only:
+            if not os.path.exists(database_file):
+                raise FileNotFoundError(f"no such DB: {database_file}")
+            db_uri = pathlib.Path(os.path.abspath(database_file)).as_uri()
+            self.__db = sqlite3.connect(f"{db_uri}?mode=ro", uri=True)
+        else:
+            self.__db = sqlite3.connect(database_file)
+        if row_factory:
+            self.__db.row_factory = row_factory
+        if text_factory:
+            self.__db.text_factory = text_factory
+        if ddl_file:
+            with open(ddl_file) as f:
+                sql = f.read()
+            self.__db.executescript(sql)
+        if case_insensitive_like:
+            self.__db.executescript("""
+                PRAGMA case_sensitive_like=OFF;
+                """)
+
+    def __del__(self):
+        self.close()
+
+    def close(self):
+        """ Finalises and closes the database.
+        """
+        if self.__db is not None:
+            self.__db.close()
+            self.__db = None
+
+    @property
+    def db(self):
+        """ The underlying SQLite database connection.
+
+        :rtype: ~sqlite3.Connection
+        :raises AttributeError: if the database connection has been closed
+        """
+        if not self.__db:
+            raise AttributeError("database has been closed")
+        return self.__db
+
+    def transaction(self, isolation_level=None):
+        """ Get a context manager that manages a transaction on the database.\
+        The value of the context manager is a :py:class:`~sqlite3.Cursor`.\
+        This means you can do this::
+
+            with db.transaction() as cursor:
+                cursor.execute(...)
+
+        :param str isolation_level:
+            The transaction isolation level (see the sqlite3 documentation for
+            permitted values); note that this sets it for the connection!
+        """
+        db = self.db
+        if isolation_level:
+            db.isolation_level = isolation_level
+        return _DbWrapper(db)
+
+
+class _DbWrapper(ACMBase):
+    def __init__(self, db):
+        self.__d = db
+
+    def __enter__(self):
+        self.__d.__enter__()
+        return self.__d.cursor()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return self.__d.__exit__(exc_type, exc_value, traceback)

--- a/spinn_front_end_common/utilities/sqlite_db.py
+++ b/spinn_front_end_common/utilities/sqlite_db.py
@@ -16,11 +16,14 @@
 from contextlib import AbstractContextManager as ACMBase
 import enum
 import hashlib
+import logging
 import os
 import pathlib
 import sqlite3
 import struct
 from spinn_utilities.abstract_context_manager import AbstractContextManager
+from spinn_utilities.logger_utils import warn_once
+logger = logging.getLogger(__name__)
 
 
 class Isolation(enum.Enum):
@@ -174,6 +177,11 @@ class SQLiteDB(AbstractContextManager):
         :rtype: ~sqlite3.Connection
         :raises AttributeError: if the database connection has been closed
         """
+        warn_once(
+            logger,
+            "Low-level connection used instead of transaction() context. "
+            "Please contact SpiNNaker Software Team with your use-case for "
+            "assistance.")
         if not self.__db:
             raise AttributeError("database has been closed")
         return self.__db

--- a/spinn_front_end_common/utilities/sqlite_db.py
+++ b/spinn_front_end_common/utilities/sqlite_db.py
@@ -118,7 +118,7 @@ class SQLiteDB(AbstractContextManager):
             #
             # The application_id pragma would be used within the DDL schema.
             ddl_hash, = struct.unpack_from(
-                ">I", hashlib.md5(sql.encode()).digest)
+                ">I", hashlib.md5(sql.encode()).digest())
             self.pragma("user_version", ddl_hash)
         if case_insensitive_like:
             self.pragma("case_sensitive_like", False)


### PR DESCRIPTION
This concentrates some very similar code for opening a database and setting up the connection into a single shared file.

I've also enhanced the documentation for the `ProvenanceReader` (intended to be a user-extensible class) to better explain how to use the class and made one of the example queries use `sqlite3.Row`s to demonstrate their use.