### PR TITLE
extract_iobuff False by default

### DIFF
--- a/spinn_front_end_common/interface/spinnaker.cfg
+++ b/spinn_front_end_common/interface/spinnaker.cfg
@@ -84,7 +84,7 @@ max_application_binaries_kept = 10
 provenance_format = sql
 
 display_algorithm_timings = True
-extract_iobuf = True
+extract_iobuf = False
 extract_iobuf_during_run = True
 extract_iobuf_from_cores = ALL
 extract_iobuf_from_binary_types = None

--- a/spinn_front_end_common/interface/spinnaker.cfg.template
+++ b/spinn_front_end_common/interface/spinnaker.cfg.template
@@ -29,17 +29,17 @@ time_scale_factor = None
 default_report_file_path = DEFAULT
 
 # If enabled this option will extract the log information from the boards
-# iobuff extraction can take a condsiderable time and uses disk space
+# iobuf extraction can take a condsiderable time and uses disk space
 extract_iobuf = False
 
-# List the cores to extract iobuff from
+# List the cores to extract iobuf from
 # format is x,y,p[:x,y,p]*
 # ie comma between x y and p And semicolumn between cores
 # ALL extracts from all cores
 # None extracts from only those of the requested binary_types
 extract_iobuf_from_cores = ALL
 
-# Comma seperated list of the apply files to extract iobuff for
+# Comma seperated list of the apply files to extract iobuf for
 # include the .aplx but no directory needed
 extract_iobuf_from_binary_types = None
 

--- a/spinn_front_end_common/interface/spinnaker.cfg.template
+++ b/spinn_front_end_common/interface/spinnaker.cfg.template
@@ -28,6 +28,21 @@ time_scale_factor = None
 # In all cases oldest folders are automatically deleted to max_reports_kept=
 default_report_file_path = DEFAULT
 
+# If enabled this option will extract the log information from the boards
+# iobuff extraction can take a condsiderable time and uses disk space
+extract_iobuf = False
+
+# List the cores to extract iobuff from
+# format is x,y,p[:x,y,p]*
+# ie comma between x y and p And semicolumn between cores
+# ALL extracts from all cores
+# None extracts from only those of the requested binary_types
+extract_iobuf_from_cores = ALL
+
+# Comma seperated list of the apply files to extract iobuff for
+# include the .aplx but no directory needed
+extract_iobuf_from_binary_types = None
+
 [Mode]
 # mode = Production or Debug
 # In Debug mode all report boolean config values are automatically overwritten to True


### PR DESCRIPTION
extract_iobuf Off by default.

Added the three main ones to the template.

Did not add
extract_iobuf_during_run = True 
or 
clear_iobuf_during_run = True

as use of these as rather advanced.