### PR TITLE
Sphinx 4 currently fails; add a version restriction

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -18,6 +18,6 @@ flake8
 # pytest will be brought in by pytest-cov
 coverage >= 4.4, < 5.0
 pytest-cov
-sphinx >= 2
+sphinx >= 2, < 4
 testfixtures
 httpretty != 1.0.0


### PR DESCRIPTION
The issue is that it's picking up files that it shouldn't. No idea why. So add a version restriction as a workaround.