### PR TITLE
Trickery to make Sphinx4 work

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -18,6 +18,6 @@ flake8
 # pytest will be brought in by pytest-cov
 coverage >= 4.4, < 5.0
 pytest-cov
-sphinx >= 2, < 4
+sphinx >= 4
 testfixtures
 httpretty != 1.0.0


### PR DESCRIPTION
This fixes #805 in a way that doesn't leave us stuck on an old version. It does this by sorting out the mess that was canonical class naming.

If only there was better support for doing this from the Sphinx side, but there isn't. At least the “skip” handler is called at the right time.