### PR TITLE
Reset fix can of worms

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -656,13 +656,6 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
                 "Only one type of graph can be used during live output. "
                 "Please fix and try again")
 
-    # options names are all lower without _ inside config
-    _DEBUG_ENABLE_OPTS = frozenset([
-        "reportsenabled",
-        "clear_iobuf_during_run", "extract_iobuf", "extract_iobuf_during_run"])
-    _REPORT_DISABLE_OPTS = frozenset([
-        "clear_iobuf_during_run", "extract_iobuf", "extract_iobuf_during_run"])
-
     def set_up_machine_specifics(self, hostname):
         """ Adds machine specifics for the different modes of execution.
 
@@ -868,8 +861,7 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
 
         self._status = Simulator_Status.IN_RUN
 
-        self._adjust_config(
-            run_time, self._DEBUG_ENABLE_OPTS, self._REPORT_DISABLE_OPTS)
+        self._adjust_config(run_time)
 
         # Install the Control-C handler
         if isinstance(threading.current_thread(), threading._MainThread):

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1566,7 +1566,10 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
             "Mapping", "router_table_compress_as_far_as_possible")
         inputs["WriteCompressorIobuf"] = get_config_bool(
             "Reports", "write_compressor_iobuf")
-
+        inputs["RouterCompressorBitFieldPreAllocSize"] = \
+            get_config_int(
+                "Mapping",
+                "router_table_compression_with_bit_field_pre_alloced_sdram")
         algorithms = list()
 
         # process for TDMA required cores

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -907,6 +907,10 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
 
         # build the graphs to modify with system requirements
         if not self._has_ran or graph_changed:
+            if self._has_ran:
+                # create new sub-folder for reporting data
+                self._set_up_output_folders(self._n_calls_to_run)
+
             self._build_graphs_for_usage()
             self._add_dependent_verts_and_edges_for_application_graph()
             self._add_commands_to_command_sender()
@@ -2366,9 +2370,6 @@ class AbstractSpinnakerBase(ConfigHandler, SimulatorInterface):
         """
 
         logger.info("Resetting")
-
-        # create new sub-folder for reporting data
-        self._set_up_output_folders(self._n_calls_to_run)
 
         # rewind the buffers from the buffer manager, to start at the beginning
         # of the simulation again and clear buffered out

--- a/spinn_front_end_common/interface/interface_functions/pre_allocate_for_bit_field_router_compressor.py
+++ b/spinn_front_end_common/interface/interface_functions/pre_allocate_for_bit_field_router_compressor.py
@@ -15,7 +15,7 @@
 
 from spinn_utilities.progress_bar import ProgressBar
 from pacman.model.resources import (
-    SpecificChipSDRAMResource, PreAllocatedResourceContainer)
+    ConstantSDRAM, SpecificChipSDRAMResource, PreAllocatedResourceContainer)
 from spinn_front_end_common.interface.interface_functions. \
     machine_bit_field_router_compressor import (
         SIZE_OF_SDRAM_ADDRESS_IN_BYTES)
@@ -50,10 +50,10 @@ class PreAllocateForBitFieldRouterCompressor(object):
         sdrams = list()
 
         for chip in progress_bar.over(machine.chips):
-            sdrams.append(SpecificChipSDRAMResource(
-                chip,
+            sdram = ConstantSDRAM(
                 (SIZE_OF_SDRAM_ADDRESS_IN_BYTES * chip.n_user_processors) +
-                sdram_to_pre_alloc_for_bit_fields))
+                sdram_to_pre_alloc_for_bit_fields)
+            sdrams.append(SpecificChipSDRAMResource(chip, sdram))
 
         # note what has been preallocated
         allocated = PreAllocatedResourceContainer(


### PR DESCRIPTION
Must be done atthe same time as
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1083

tested by
https://github.com/SpiNNakerManchester/IntegrationTests/pull/55


While changing how directories are passed into algorithms (separate PR) I noticed that after a soft reset
run() reset() run() 

A new run_ directory is created but almost never used.

This was fixed by delaying the creation if the new directories until we know if the graph has changed.

----
Looking at what did use the second run_ directory it was 
 pacman_executor_provenance.rpt

Which interestingly enough was only sometimes produced.

This was because in mode debug the changing of the write  cfg opetions to True was done too late.

This was fixed by doing the debug changes earlier.

---
This in turn found other issues as 
 AbstractSpiNNakerCommon was checking configs before the debug changes.

PreAllocateForBitFieldRouterCompressor needs RouterCompressorBitFieldPreAllocSize

but it was added as a Mapping Algorithm while RouterCompressorBitFieldPreAllocSize was added in do_load

temp fix add RouterCompressorBitFieldPreAllocSize to do_mapping
When config PR goes in PreAllocateForBitFieldRouterCompressor will read config directly

--
see also 
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1083




