### PR TITLE
Too broad an exception is not a good idea

### DIFF
--- a/spinn_front_end_common/interface/interface_functions/router_provenance_gatherer.py
+++ b/spinn_front_end_common/interface/interface_functions/router_provenance_gatherer.py
@@ -16,6 +16,7 @@
 import logging
 from spinn_utilities.progress_bar import ProgressBar
 from spinn_utilities.log import FormatAdapter
+from spinnman.exceptions import SpinnmanException
 from spinn_front_end_common.utilities.utility_objs import ProvenanceDataItem
 
 logger = FormatAdapter(logging.getLogger(__name__))
@@ -162,7 +163,7 @@ class RouterProvenanceGatherer(object):
         if not self._machine.get_chip_at(x, y).virtual:
             try:
                 diagnostics = self._txrx.get_router_diagnostics(x, y)
-            except:  # noqa: E722
+            except SpinnmanException:
                 logger.warning(
                     "Could not read routing diagnostics from {}, {}",
                     x, y, exc_info=True)
@@ -184,7 +185,7 @@ class RouterProvenanceGatherer(object):
         # pylint: disable=bare-except
         try:
             diagnostics = self._txrx.get_router_diagnostics(chip.x, chip.y)
-        except:  # noqa: E722
+        except SpinnmanException:
             # There could be issues with unused chips - don't worry!
             return
         if (diagnostics.n_dropped_multicast_packets or


### PR DESCRIPTION
https://github.com/SpiNNakerManchester/SpiNNMan/pull/249
Got away with removing a used Transceiver method due to an except:

All other places we use the pattern
except:  # noqa: E722
some work is done and then the exception re raised

emergency_recover_states_from_failure
raise