### PR TITLE
Token loop fix

### DIFF
--- a/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
@@ -766,10 +766,6 @@
                 <param_type>JavaCaller</param_type>
             </parameter>
             <parameter>
-                <param_name>processor_to_app_data_base_address</param_name>
-                <param_type>ProcessorToAppDataBaseAddress</param_type>
-            </parameter>
-            <parameter>
                 <param_name>executable_targets</param_name>
                 <param_type>ExecutableTargets</param_type>
             </parameter>
@@ -799,7 +795,6 @@
         </required_inputs>
         <optional_inputs>
             <param_name>java_caller</param_name>
-            <param_name>processor_to_app_data_base_address</param_name>
             <param_name>executable_targets</param_name>
             <param_name>placements</param_name>
             <param_name>extra_monitor_cores</param_name>
@@ -808,7 +803,7 @@
             <token part="SystemBinariesLoaded">DataLoaded</token>
         </optional_inputs>
         <outputs>
-            <param_type>ProcessorToAppDataBaseAddress</param_type>
+            <param_type>AppCoreToDsWrite</param_type>
             <token part="DSGDataLoaded">DataLoaded</token>
             <token part="DSGAppDataLoaded">DataLoaded</token>
         </outputs>
@@ -843,10 +838,6 @@
                 <param_type>JavaCaller</param_type>
             </parameter>
             <parameter>
-                <param_name>processor_to_app_data_base_address</param_name>
-                <param_type>ProcessorToAppDataBaseAddress</param_type>
-            </parameter>
-            <parameter>
                 <param_name>region_sizes</param_name>
                 <param_type>RegionSizes</param_type>
             </parameter>
@@ -861,10 +852,9 @@
         </required_inputs>
         <optional_inputs>
             <param_name>java_caller</param_name>
-            <param_name>processor_to_app_data_base_address</param_name>
         </optional_inputs>
         <outputs>
-            <param_type>ProcessorToAppDataBaseAddress</param_type>
+            <param_type>SystemCoreToDsWrite</param_type>
             <token part="DSGSystemDataLoaded">DataLoaded</token>
         </outputs>
     </algorithm>

--- a/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
@@ -1597,11 +1597,7 @@
         <required_inputs>
             <param_name>transceiver</param_name>
             <param_name>executable_types</param_name>
-            <token>ApplicationRun</token>
         </required_inputs>
-        <optional_inputs>
-            <token>ReadIOBuf</token>
-        </optional_inputs>
         <outputs>
             <token>ClearedIOBuf</token>
         </outputs>

--- a/spinn_front_end_common/interface/interface_functions/host_execute_data_specification.py
+++ b/spinn_front_end_common/interface/interface_functions/host_execute_data_specification.py
@@ -389,7 +389,7 @@ class HostExecuteDataSpecification(object):
             executable_targets, region_sizes,
             placements=None, extra_monitor_cores=None,
             extra_monitor_cores_to_ethernet_connection_map=None,
-            java_caller=None, processor_to_app_data_base_address=None):
+            java_caller=None):
         """ Execute the data specs for all non-system targets.
 
         :param ~spinn_machine.Machine machine:
@@ -413,17 +413,11 @@ class HostExecuteDataSpecification(object):
             how to talk to extra monitor cores
         :type extra_monitor_cores_to_ethernet_connection_map:
             dict(tuple(int,int), DataSpeedUpPacketGatherMachineVertex)
-        :param processor_to_app_data_base_address:
-            map of placement and DSG data
-        :type processor_to_app_data_base_address:
-            dict(tuple(int,int,int), DsWriteInfo)
         :return: map of placement and DSG data
         :rtype: dict(tuple(int,int,int),DataWritten) or DsWriteInfo
         """
         # pylint: disable=too-many-arguments
-        if processor_to_app_data_base_address is None:
-            processor_to_app_data_base_address = dict()
-        self._write_info_map = processor_to_app_data_base_address
+        self._write_info_map = dict()
         self._java = java_caller
         self._machine = machine
         self._txrx = transceiver
@@ -548,8 +542,7 @@ class HostExecuteDataSpecification(object):
 
     def execute_system_data_specs(
             self, transceiver, machine, app_id, dsg_targets, region_sizes,
-            executable_targets,
-            java_caller=None, processor_to_app_data_base_address=None):
+            executable_targets, java_caller=None):
         """ Execute the data specs for all system targets.
 
         :param ~spinnman.transceiver.Transceiver transceiver:
@@ -564,17 +557,12 @@ class HostExecuteDataSpecification(object):
         :param ~spinnman.model.ExecutableTargets executable_targets:
             the map between binaries and locations and executable types
         :param JavaCaller java_caller:
-        :param processor_to_app_data_base_address:
-        :type processor_to_app_data_base_address:
-            dict(tuple(int,int,int),DataWritten)
         :return: map of placement and DSG data, and loaded data flag.
         :rtype: dict(tuple(int,int,int),DataWritten) or DsWriteInfo
         """
         # pylint: disable=too-many-arguments
 
-        if processor_to_app_data_base_address is None:
-            processor_to_app_data_base_address = dict()
-        self._write_info_map = processor_to_app_data_base_address
+        self._write_info_map = dict()
         self._machine = machine
         self._txrx = transceiver
         self._app_id = app_id

--- a/spinn_front_end_common/utilities/report_functions/front_end_common_reports.xml
+++ b/spinn_front_end_common/utilities/report_functions/front_end_common_reports.xml
@@ -103,13 +103,17 @@
         <python_class>MemoryMapOnHostReport</python_class>
         <input_definitions>
             <parameter>
-                <param_name>processor_to_app_data_base_address</param_name>
-                <param_type>ProcessorToAppDataBaseAddress</param_type>
+                <param_name>app_core_to_dswrite</param_name>
+                <param_type>AppCoreToDsWrite</param_type>
+            </parameter>
+            <parameter>
+                <param_name>system_core_to_dswrite</param_name>
+                <param_type>SystemCoreToDsWrite</param_type>
             </parameter>
         </input_definitions>
         <required_inputs>
-             <param_name>processor_to_app_data_base_address</param_name>
-            <token>DataLoaded</token>
+             <param_name>app_core_to_dswrite</param_name>
+             <param_name>system_core_to_dswrite</param_name>
         </required_inputs>
     </algorithm>
     <algorithm name="MemoryMapOnHostChipReport">

--- a/spinn_front_end_common/utilities/report_functions/memory_map_on_host_report.py
+++ b/spinn_front_end_common/utilities/report_functions/memory_map_on_host_report.py
@@ -26,26 +26,32 @@ _FOLDER_NAME = "memory_map_from_processor_to_address_space"
 class MemoryMapOnHostReport(object):
     """ Report on memory usage.
     """
-
     def __call__(
-            self, processor_to_app_data_base_address):
+            self, app_core_to_dswrite, system_core_to_dswrite):
         """
-        :param processor_to_app_data_base_address:
-        :type processor_to_app_data_base_address:
+        :param app_core_to_dswrite: dswrite per core for application vertexes
+        :type app_core_to_dswrite:
+            dict(tuple(int,int,int),DataWritten)
+        :param system_core_to_dswrite: dswrite per core for system vertexes
+        :type system_core_to_dswrite:
             dict(tuple(int,int,int),DataWritten)
         """
 
         file_name = os.path.join(report_default_directory(), _FOLDER_NAME)
         try:
             with open(file_name, "w") as f:
-                self._describe_mem_map(f, processor_to_app_data_base_address)
+                self._describe_mem_map(
+                    f, app_core_to_dswrite, system_core_to_dswrite)
         except IOError:
             logger.exception("Generate_placement_reports: Can't open file"
                              " {} for writing.", file_name)
 
-    def _describe_mem_map(self, f, memory_map):
+    def _describe_mem_map(
+            self, f, app_core_to_dswrite, system_core_to_dswrite):
         f.write("On host data specification executor\n")
-        for key, data in memory_map.items():
+        for key, data in app_core_to_dswrite.items():
+            self._describe_map_entry(f, key, data)
+        for key, data in system_core_to_dswrite.items():
             self._describe_map_entry(f, key, data)
 
     @staticmethod


### PR DESCRIPTION
This PR removes an edge case and fixes a loop

ProcessorToAppDataBaseAddress was both an input and an output in two algorithms.
Now neither inputs it and the two outputs are given different names.
The consumer now uses both

Removed the token loop:
ChipIOBufClearer had an input ReadIOBuf, ChipIOBufExtractor had an input ApplicationRun and an has an input ClearedIOBuf

I choose the order  ClearedIOBuf, ApplicationRu, ChipIOBufExtractor, for two reasons.
1. It leaves the iobuff on core for any advanced debugging
2. Another pr will make ClearedIOBuf, happen on additional runs only


This PR is required for https://github.com/SpiNNakerManchester/PACMAN/pull/405 but can be committed first
