### PR TITLE
Compressors sdram

### DIFF
--- a/c_common/front_end_common_lib/src/malloc_extras.c
+++ b/c_common/front_end_common_lib/src/malloc_extras.c
@@ -85,12 +85,10 @@ void malloc_extras_terminate(uint result_code) {
     uint core = spin1_get_core_id();
     sark_virtual_processor_info[core].user1 = result_code;
 
-    // hopefully one of these functions will kill the binary
-    spin1_pause();
-    spin1_exit(0);
     if (result_code != EXITED_CLEANLY && result_code != EXIT_FAIL) {
         rt_error(RTE_SWERR);
     }
+    spin1_exit(0);
 }
 
 bool malloc_extras_check(void *ptr) {

--- a/c_common/models/compressors/src/simple/simple_compressor.c
+++ b/c_common/models/compressors/src/simple/simple_compressor.c
@@ -101,6 +101,7 @@ bool standalone(void) {
 void c_main(void) {
     log_info("%u bytes of free DTCM", sark_heap_max(sark.heap, 0));
     malloc_extras_turn_off_safety();
+    malloc_extras_initialise_no_fake_heap_data();
 
     // kick-start the process
     spin1_schedule_callback(compress_start, 0, 0, 3);


### PR DESCRIPTION
Allows the simple compressor to use SDRAM.  This can be useful if the table is very big, but also includes lots of default entries, so it doesn't fit in DTCM, but will actually load directly into the routing tables without compression.

Also fixes the exiting mechanism to simply use spin1_exit but only if not doing an RTE.

Testing with: http://apollo.cs.man.ac.uk:8080/blue/organizations/jenkins/Integration%20Tests/activity?branch=compressors_sdram