### PR TITLE
Use the python-tools action in order to fix pip version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,8 @@ jobs:
       - name: Set dynamic environment variables
         run: |
           echo "SPINN_DIRS=$PWD/spinnaker_tools" >> $GITHUB_ENV
+      - name: Install pip, etc
+        uses: ./support/actions/python-tools
       - name: Checkout SpiNNaker Dependencies
         uses: ./support/actions/checkout-spinn-deps
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,8 @@ jobs:
           echo "SPINN_DIRS=$PWD/spinnaker_tools" >> $GITHUB_ENV
       - name: Install pip, etc
         uses: ./support/actions/python-tools
+        with:
+          coverage: false
       - name: Checkout SpiNNaker Dependencies
         uses: ./support/actions/checkout-spinn-deps
         with:


### PR DESCRIPTION
The pip version currently needs to be fixed to an earlier version to avoid resolver issues (see https://github.com/SpiNNakerManchester/sPyNNaker/issues/1105).