### PR TITLE
Add app ID to database

### DIFF
--- a/spinn_front_end_common/interface/interface_functions/database_interface.py
+++ b/spinn_front_end_common/interface/interface_functions/database_interface.py
@@ -40,7 +40,8 @@ class DatabaseInterface(object):
 
     def __call__(
             self, machine_graph, tags, runtime, machine, data_n_timesteps,
-            placements, routing_infos, router_tables, application_graph=None):
+            placements, routing_infos, router_tables, app_id,
+            application_graph=None):
         """
         :param ~pacman.model.graphs.machine.MachineGraph machine_graph:
         :param ~pacman.model.tags.Tags tags:
@@ -52,6 +53,7 @@ class DatabaseInterface(object):
         :param router_tables:
         :type router_tables:
             ~pacman.model.routing_tables.MulticastRoutingTables
+        :param int app_id:
         :param application_graph:
         :type application_graph:
             ~pacman.model.graphs.application.ApplicationGraph
@@ -76,7 +78,7 @@ class DatabaseInterface(object):
             self._write_to_db(
                 machine, runtime, application_graph, machine_graph,
                 data_n_timesteps, placements, routing_infos, router_tables,
-                tags)
+                tags, app_id)
 
         return self, self.database_file_path
 
@@ -92,7 +94,7 @@ class DatabaseInterface(object):
     def _write_to_db(
             self, machine, runtime, app_graph, machine_graph,
             data_n_timesteps, placements, routing_infos, router_tables,
-            tags):
+            tags, app_id):
         """
         :param ~.Machine machine:
         :param int runtime:
@@ -104,12 +106,13 @@ class DatabaseInterface(object):
         :param ~.RoutingInfo routing_infos:
         :param ~.MulticastRoutingTables router_tables:
         :param ~.Tags tags:
+        :param int app_id:
         """
         # pylint: disable=too-many-arguments
 
         with self._writer as w, ProgressBar(
                 9, "Creating graph description database") as p:
-            w.add_system_params(runtime)
+            w.add_system_params(runtime, app_id)
             p.update()
             w.add_machine_objects(machine)
             p.update()

--- a/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
+++ b/spinn_front_end_common/interface/interface_functions/front_end_common_interface_functions.xml
@@ -1459,6 +1459,10 @@
                 <param_name>application_graph</param_name>
                 <param_type>ApplicationGraph</param_type>
             </parameter>
+            <parameter>
+                <param_name>app_id</param_name>
+                <param_type>APPID</param_type>
+            </parameter>
         </input_definitions>
         <required_inputs>
             <param_name>machine_graph</param_name>
@@ -1469,6 +1473,7 @@
             <param_name>placements</param_name>
             <param_name>routing_infos</param_name>
             <param_name>router_tables</param_name>
+            <param_name>app_id</param_name>
         </required_inputs>
         <optional_inputs>
             <param_name>application_graph</param_name>

--- a/spinn_front_end_common/utilities/database/database_writer.py
+++ b/spinn_front_end_common/utilities/database/database_writer.py
@@ -191,7 +191,7 @@ class DatabaseWriter(SQLiteDB):
                     for edge in application_graph.get_edges_starting_at_vertex(
                         vertex)))
 
-    def add_system_params(self, runtime):
+    def add_system_params(self, runtime, app_id):
         """ Write system params into the database
 
         :param int runtime: the amount of time the application is to run for
@@ -206,7 +206,8 @@ class DatabaseWriter(SQLiteDB):
                     ("machine_time_step", machine_time_step()),
                     ("time_scale_factor", time_scale_factor()),
                     ("infinite_run", str(runtime is None)),
-                    ("runtime", -1 if runtime is None else runtime)])
+                    ("runtime", -1 if runtime is None else runtime),
+                    ("app_id", app_id)])
 
     def add_vertices(self, machine_graph, data_n_timesteps, application_graph):
         """ Add the machine graph into the database.


### PR DESCRIPTION
Minor change to add the App ID to the external device database.  This allows external tools to send the sync signals required to progress a stepped simulation.  This will help to support the MUSIC integration with SpiNNaker.

Testing being done here:
SpiNNakerManchester/IntegrationTests#71