### PR TITLE
avoid update_buffer being called until do run

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1674,7 +1674,6 @@ class AbstractSpinnakerBase(ConfigHandler):
         # The initial inputs are the mapping outputs
         inputs = dict(self._mapping_outputs)
         tokens = list(self._mapping_tokens)
-        inputs["RunUntilTimeSteps"] = n_machine_time_steps
         inputs["FirstMachineTimeStep"] = self._current_run_timesteps
 
         # This is done twice to make things nicer for things which don't have

--- a/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
@@ -772,9 +772,8 @@ class ReverseIPTagMulticastSourceMachineVertex(
         :param int run_until_timesteps:
             The last machine time step in the simulation
         """
-        if self._virtual_key is not None:
-            self._fill_send_buffer(
-                first_machine_time_step, run_until_timesteps)
+        self._fill_send_buffer(
+            first_machine_time_step, run_until_timesteps)
 
     @overrides(AbstractReceiveBuffersToHost.get_recorded_region_ids)
     def get_recorded_region_ids(self):

--- a/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
@@ -681,30 +681,23 @@ class ReverseIPTagMulticastSourceMachineVertex(
     @inject_items({
         "machine_graph": "MachineGraph",
         "routing_info": "RoutingInfos",
-        "first_machine_time_step": "FirstMachineTimeStep",
-        "data_n_time_steps": "DataNTimeSteps",
-        "run_until_timesteps": "RunUntilTimeSteps"
+        "data_n_time_steps": "DataNTimeSteps"
     })
     @overrides(
         AbstractGeneratesDataSpecification.generate_data_specification,
         additional_arguments={
-            "machine_graph", "routing_info", "first_machine_time_step",
-            "data_n_time_steps", "run_until_timesteps"
+            "machine_graph", "routing_info", "data_n_time_steps"
         })
     def generate_data_specification(
             self, spec, placement,  # @UnusedVariable
-            machine_graph, routing_info, first_machine_time_step,
-            data_n_time_steps, run_until_timesteps):
+            machine_graph, routing_info, data_n_time_steps):
         """
         :param ~pacman.model.graphs.machine.MachineGraph machine_graph:
         :param ~pacman.model.routing_info.RoutingInfo routing_info:
-        :param int first_machine_time_step:
         :param int data_n_time_steps:
-        :param int run_until_timesteps:
         """
         # pylint: disable=too-many-arguments, arguments-differ
         self._update_virtual_key(routing_info, machine_graph)
-        self._fill_send_buffer(first_machine_time_step, run_until_timesteps)
 
         # Reserve regions
         self._reserve_regions(spec, data_n_time_steps)
@@ -765,12 +758,12 @@ class ReverseIPTagMulticastSourceMachineVertex(
     def is_in_injection_mode(self):
         return self._in_injection_mode
 
-    @inject("FirstMachineTimeStep")
+    @inject("RunUntilTimeSteps")
     @inject_items({
-        "run_until_timesteps": "RunUntilTimeSteps"
+        "first_machine_time_step": "FirstMachineTimeStep"
     })
     def update_buffer(
-            self, first_machine_time_step, run_until_timesteps):
+            self, run_until_timesteps, first_machine_time_step):
         """ Updates the buffers on specification of the first machine timestep.
             Note: This is called by injection.
 


### PR DESCRIPTION
ReverseIPTagMulticastSourceMachineVertex._fill_send_buffer is not needed until do_run

So to avoid calling it early this PR.
1. Changes ReverseIPTagMulticastSourceMachineVertex.update_buffer to be triggered by the injection of RunUntilTimeSteps
2. Removed _fill_send_buffer from ReverseIPTagMulticastSourceMachineVertex.generate_data_specification
3. No longer sets RunUntilTimeSteps in the do_data_generation stage.

This has the added advantage that
RunUntilTimeSteps is now always the end of the do_loop timestep

In the past update_buffer did not fill the send buffer if there was no virtual_key
However if there is no virtual key
1. The user has probably done something weird as why have a ReverseIPTagMulticastSourceMachineVertex with no output
2. The user may be recording the spikes and then the buffers still need filling


