### PR TITLE
Spalloc avoid boards

### DIFF
--- a/spinn_front_end_common/interface/interface_functions/spalloc_allocator.py
+++ b/spinn_front_end_common/interface/interface_functions/spalloc_allocator.py
@@ -145,7 +145,7 @@ class SpallocAllocator(object):
         if spalloc_machine is not None:
             spalloc_kw_args['machine'] = spalloc_machine
 
-        job, hostname = self._launch_job(n_boards, spalloc_kw_args)
+        job, hostname = self._launch_checked_job(n_boards, spalloc_kw_args)
         machine_allocation_controller = _SpallocJobController(job)
 
         return (

--- a/spinn_front_end_common/interface/interface_functions/spalloc_allocator.py
+++ b/spinn_front_end_common/interface/interface_functions/spalloc_allocator.py
@@ -158,7 +158,7 @@ class SpallocAllocator(object):
         avoid_jobs = []
         job, hostname = self._launch_job(n_boards, spalloc_kw_args)
         while hostname in avoid_boards:
-            avoid_jobs.append[job]
+            avoid_jobs.append(job)
             logger.warning(
                 f"Asking for new job as {hostname} "
                 f"as in the spalloc_avoid_boards list")

--- a/spinn_front_end_common/interface/spinnaker.cfg
+++ b/spinn_front_end_common/interface/spinnaker.cfg
@@ -117,6 +117,8 @@ spalloc_server = None
 spalloc_port = 22244
 spalloc_user = None
 spalloc_machine = None
+# A comma seperated list of boards to avoid as chip 0,0
+spalloc_avoid_boards = 10.11.195.1
 
 # If using virtual_board both width and height must be set
 virtual_board = False


### PR DESCRIPTION
Adds the ability for a user to specif which boards to avoid as the host/ chip 0,0 in spalloc.

Does not include HBP at this point.

Known risk is that if the combination of job size and avoid list is too big it could block the whole machine!

