### PR TITLE
remove extract_iobuf_during_run flag

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -2016,8 +2016,6 @@ class AbstractSpinnakerBase(ConfigHandler):
 
         # add extractor of iobuf if needed
         if (get_config_bool("Reports", "extract_iobuf") and
-                get_config_bool(
-                    "Reports", "extract_iobuf_during_run") and
                 not self._use_virtual_board and
                 n_machine_time_steps is not None):
             algorithms.append("ChipIOBufExtractor")
@@ -2706,8 +2704,7 @@ class AbstractSpinnakerBase(ConfigHandler):
         read_prov = get_config_bool("Reports", "read_provenance_data")
 
         # add extractor of iobuf if needed
-        if get_config_bool("Reports", "extract_iobuf") and \
-                get_config_bool("Reports", "extract_iobuf_during_run"):
+        if get_config_bool("Reports", "extract_iobuf"):
             algorithms.append("ChipIOBufExtractor")
 
         # add extractor of provenance if needed
@@ -2752,8 +2749,6 @@ class AbstractSpinnakerBase(ConfigHandler):
             self._buffer_manager, power_used)
 
     def _extract_iobufs(self):
-        if get_config_bool("Reports", "extract_iobuf_during_run"):
-            return
         if get_config_bool("Reports", "clear_iobuf_during_run"):
             return
         extractor = IOBufExtractor(

--- a/spinn_front_end_common/interface/config_handler.py
+++ b/spinn_front_end_common/interface/config_handler.py
@@ -40,9 +40,9 @@ WARNING_LOGS_FILENAME = "warning_logs.txt"
 # options names are all lower without _ inside config
 _DEBUG_ENABLE_OPTS = frozenset([
     "reportsenabled",
-    "clear_iobuf_during_run", "extract_iobuf", "extract_iobuf_during_run"])
+    "clear_iobuf_during_run", "extract_iobuf"])
 _REPORT_DISABLE_OPTS = frozenset([
-    "clear_iobuf_during_run", "extract_iobuf", "extract_iobuf_during_run"])
+    "clear_iobuf_during_run", "extract_iobuf"])
 
 
 class ConfigHandler(object):

--- a/spinn_front_end_common/interface/spinnaker.cfg
+++ b/spinn_front_end_common/interface/spinnaker.cfg
@@ -87,7 +87,6 @@ provenance_report_cutoff = 20
 
 display_algorithm_timings = True
 extract_iobuf = False
-extract_iobuf_during_run = True
 extract_iobuf_from_cores = ALL
 extract_iobuf_from_binary_types = None
 clear_iobuf_during_run = True


### PR DESCRIPTION
removes the  extract_iobuf_during_run cfg setting.

Now always done every run if extract_iobuf = True
including auto pause loop

Agreed as part of https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/834 which was closed due to reworking in no executor work

needed for the no executor but can be merged before.
must be done at same time as linked spy PR.