### PR TITLE
Always have an Application graph

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -77,6 +77,8 @@ from spinn_front_end_common.interface.simulator_status import (
 from spinn_front_end_common.interface.interface_functions import (
     ChipProvenanceUpdater,  PlacementsProvenanceGatherer,
     RouterProvenanceGatherer, interface_xml)
+from spinn_front_end_common.utility_models import (
+    WrapperApplicationEdge, WrapperApplicationVertex)
 
 from spinn_front_end_common import __version__ as fec_version
 try:
@@ -2409,12 +2411,8 @@ class AbstractSpinnakerBase(ConfigHandler):
             If there is an attempt to add the same vertex more than once
         """
         # check that there's no application vertices added so far
-        if self._original_application_graph.n_vertices:
-            raise ConfigurationException(
-                "Cannot add vertices to both the machine and application"
-                " graphs")
-        self._original_machine_graph.add_vertex(vertex)
-        self._vertices_or_edges_added = True
+        wrapped = WrapperApplicationVertex(vertex)
+        self.add_application_vertex(wrapped)
 
     def add_application_edge(self, edge_to_add, partition_identifier):
         """
@@ -2434,8 +2432,8 @@ class AbstractSpinnakerBase(ConfigHandler):
         :param str partition_id:
             the partition identifier for the outgoing edge partition
         """
-        self._original_machine_graph.add_edge(edge, partition_id)
-        self._vertices_or_edges_added = True
+        wrapper = WrapperApplicationEdge(edge)
+        self.add_application_edge(wrapper, partition_id)
 
     def _shutdown(
             self, turn_off_machine=None, clear_routing_tables=None,

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1308,7 +1308,7 @@ class AbstractSpinnakerBase(ConfigHandler):
             return False
 
         # only add machine graph is it has vertices.
-        if self._machine_graph.n_vertices:
+        if self._machine_graph and self._machine_graph.n_vertices:
             inputs["MachineGraph"] = self._machine_graph
             algorithms.append("GraphMeasurer")
             do_partitioning = False

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -42,7 +42,8 @@ from pacman.executor.injection_decorator import (
     clear_injectables, provide_injectables)
 from pacman.model.graphs.application import (
     ApplicationGraph, ApplicationGraphView, ApplicationEdge, ApplicationVertex)
-from pacman.model.graphs.machine import (MachineGraphView, MachineVertex)
+from pacman.model.graphs.machine import (
+    MachineGraphView, MachineVertex)
 from pacman.model.resources import (
     ConstantSDRAM, PreAllocatedResourceContainer)
 from pacman import __version__ as pacman_version
@@ -1527,8 +1528,9 @@ class AbstractSpinnakerBase(ConfigHandler):
         algorithms.append("MallocBasedChipIDAllocator")
         if _PREALLOC_NAME not in inputs:
             inputs[_PREALLOC_NAME] = PreAllocatedResourceContainer()
-        algorithms.extend(get_config_str_list(
-            "Mapping", "application_to_machine_graph_algorithms"))
+        if not self._machine_graph:
+            algorithms.extend(get_config_str_list(
+                "Mapping", "application_to_machine_graph_algorithms"))
 
         if self._use_virtual_board:
             algorithms.extend(get_config_str_list(

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -147,9 +147,6 @@ class AbstractSpinnakerBase(ConfigHandler):
         # the pacman machine graph, used to hold vertices which represent cores
         "_machine_graph",
 
-        # boolean for empty graphs
-        "_empty_graphs",
-
         # The holder for where machine graph vertices are placed.
         "_placements",
 
@@ -400,8 +397,6 @@ class AbstractSpinnakerBase(ConfigHandler):
         # pacman objects
         self._original_application_graph = ApplicationGraph(
             label=self._graph_label)
-        self._empty_graphs = False
-
         self._placements = None
         self._router_tables = None
         self._routing_infos = None
@@ -1890,7 +1885,7 @@ class AbstractSpinnakerBase(ConfigHandler):
 
         # Clear iobuf from machine
         if (n_machine_time_steps is not None and
-                not self._use_virtual_board and not self._empty_graphs and
+                not self._use_virtual_board and
                 get_config_bool("Reports", "clear_iobuf_during_run")):
             algorithms.append("ChipIOBufClearer")
 

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -42,8 +42,7 @@ from pacman.executor.injection_decorator import (
     clear_injectables, provide_injectables)
 from pacman.model.graphs.application import (
     ApplicationGraph, ApplicationGraphView, ApplicationEdge, ApplicationVertex)
-from pacman.model.graphs.machine import (
-    MachineGraph, MachineGraphView, MachineVertex)
+from pacman.model.graphs.machine import (MachineGraphView, MachineVertex)
 from pacman.model.resources import (
     ConstantSDRAM, PreAllocatedResourceContainer)
 from pacman import __version__ as pacman_version
@@ -739,10 +738,6 @@ class AbstractSpinnakerBase(ConfigHandler):
         """
         self._run(run_time, sync_time)
 
-    def _build_graphs_for_usage(self):
-        self._application_graph = self._original_application_graph.clone()
-        self._machine_graph = None
-
     def __timesteps(self, time_in_ms):
         """ Get a number of timesteps for a given time in milliseconds.
 
@@ -862,7 +857,8 @@ class AbstractSpinnakerBase(ConfigHandler):
                 # create new sub-folder for reporting data
                 self._set_up_output_folders(self._n_calls_to_run)
 
-            self._build_graphs_for_usage()
+            self._application_graph = self._original_application_graph.clone()
+            self._machine_graph = None
             self._add_dependent_verts_and_edges_for_application_graph()
             self._add_commands_to_command_sender()
 

--- a/spinn_front_end_common/utility_models/__init__.py
+++ b/spinn_front_end_common/utility_models/__init__.py
@@ -29,6 +29,8 @@ from .multi_cast_command import MultiCastCommand
 from .reverse_ip_tag_multi_cast_source import ReverseIpTagMultiCastSource
 from .reverse_ip_tag_multicast_source_machine_vertex import (
     ReverseIPTagMulticastSourceMachineVertex)
+from .wrapper_application_edge import WrapperApplicationEdge
+from .wrapper_application_vertex import WrapperApplicationVertex
 
 __all__ = ["CommandSender", "CommandSenderMachineVertex",
            "ChipPowerMonitor", "ChipPowerMonitorMachineVertex",
@@ -36,4 +38,5 @@ __all__ = ["CommandSender", "CommandSenderMachineVertex",
            "ExtraMonitorSupport", "ExtraMonitorSupportMachineVertex",
            "LivePacketGather", "LivePacketGatherMachineVertex",
            "MultiCastCommand", "ReverseIpTagMultiCastSource",
-           "ReverseIPTagMulticastSourceMachineVertex"]
+           "ReverseIPTagMulticastSourceMachineVertex",
+           "WrapperApplicationEdge", "WrapperApplicationVertex"]

--- a/spinn_front_end_common/utility_models/wrapper_application_edge.py
+++ b/spinn_front_end_common/utility_models/wrapper_application_edge.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2022-202 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pacman.model.graphs.application import ApplicationEdge
+
+
+class WrapperApplicationEdge(ApplicationEdge):
+
+    def __init__(self, machine_edge):
+        pre_vertex = machine_edge.pre_vertex.app_vertex
+        post_vertex = machine_edge.post_vertex.app_vertex
+        super().__init__(pre_vertex, post_vertex, machine_edge.label)
+        machine_edge._app_edge = self

--- a/spinn_front_end_common/utility_models/wrapper_application_vertex.py
+++ b/spinn_front_end_common/utility_models/wrapper_application_vertex.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from pacman.model.graphs import AbstractSupportsSDRAMEdges, AbstractVirtual
 from pacman.model.graphs.application.abstract import (
     AbstractOneAppOneMachineVertex)
 
@@ -30,7 +31,13 @@ class WrapperApplicationVertex(AbstractOneAppOneMachineVertex):
         :raise PacmanInvalidParameterException:
             If one of the constraints is not valid
         """
-
+        if isinstance(machine_vertex, AbstractSupportsSDRAMEdges):
+            raise NotImplementedError(
+                "Wrapping a vertex which implements "
+                "AbstractSupportsSDRAMEdges is not supported yet")
+        if isinstance(machine_vertex, AbstractVirtual):
+            raise NotImplementedError(
+                "Wrapping a virtual vertex is not supported yet")
         super().__init__(
             machine_vertex, machine_vertex.label, constraints,
             machine_vertex.vertex_slice.n_atoms)

--- a/spinn_front_end_common/utility_models/wrapper_application_vertex.py
+++ b/spinn_front_end_common/utility_models/wrapper_application_vertex.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2022-202 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pacman.model.graphs.application.abstract import (
+    AbstractOneAppOneMachineVertex)
+
+
+class WrapperApplicationVertex(AbstractOneAppOneMachineVertex):
+
+    def __init__(self, machine_vertex, constraints=None):
+        """
+        Creates an ApplicationVertex which has exactly one predefined \
+        MachineVertex
+
+        :param machine_vertex: MachineVertex
+        :param iterable(AbstractConstraint) constraints:
+            The optional initial constraints of the vertex.
+        :raise PacmanInvalidParameterException:
+            If one of the constraints is not valid
+        """
+
+        super().__init__(
+            machine_vertex, machine_vertex.label, constraints,
+            machine_vertex.vertex_slice.n_atoms)
+        machine_vertex._app_vertex = self


### PR DESCRIPTION
This PR makes sure there is always an application Graph.

GFE calls to add machine Vertices and Edges are wrapped in Application ones.

Yes this then has the weirdness that these have to be partitioned,
but allows algorithms to always use the Application Graph.

This PR is only ground work as it guarantees the presence of an Application Graph but does not yet make use that fact.

Tested by https://github.com/SpiNNakerManchester/IntegrationTests/pull/82