### PR TITLE
Global Data model

### DIFF
--- a/spinn_front_end_common/data/__init__.py
+++ b/spinn_front_end_common/data/__init__.py
@@ -17,4 +17,4 @@ from .fec_data_view import FecDataView
 from .fec_data_writer import FecDataWriter
 
 
-__all__ = ["FecDataView"]
+__all__ = ["FecDataView", "FecDataWriter"]

--- a/spinn_front_end_common/data/__init__.py
+++ b/spinn_front_end_common/data/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2017-2019 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from .fec_data_view import FecDataView
+from .fec_data_writer import FecDataWriter
+
+
+__all__ = ["FecDataView"]

--- a/spinn_front_end_common/data/data_status.py
+++ b/spinn_front_end_common/data/data_status.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2017-2019 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from enum import Enum
+from spinn_front_end_common.utilities.exceptions import (
+    SimulatorDataNotMocked, SimulatorNotSetupException,
+    SimulatorDataNotYetAvialable, SimulatorShutdownException)
+
+
+class Data_Status(Enum):
+    """ Different states the Data can be in.
+    """
+    NOT_SETUP = (
+        0, SimulatorNotSetupException)
+    MOCKED = (
+        1, SimulatorDataNotMocked)
+    SETUP = (
+        2, SimulatorDataNotYetAvialable)
+
+    def __new__(cls, value, exception):
+        # pylint: disable=protected-access
+        obj = object.__new__(cls)
+        obj._value_ = value
+        obj.exception = exception
+        return obj

--- a/spinn_front_end_common/data/data_status.py
+++ b/spinn_front_end_common/data/data_status.py
@@ -28,6 +28,12 @@ class Data_Status(Enum):
         1, SimulatorDataNotMocked)
     SETUP = (
         2, SimulatorDataNotYetAvialable)
+    IN_RUN = (
+        3, SimulatorDataNotYetAvialable)
+    FINISHED = (
+        4, SimulatorDataNotYetAvialable)
+    SHUTDOWN = (
+        5, SimulatorShutdownException)
 
     def __new__(cls, value, exception):
         # pylint: disable=protected-access

--- a/spinn_front_end_common/data/fec_data_model.py
+++ b/spinn_front_end_common/data/fec_data_model.py
@@ -24,6 +24,10 @@ class FecDataModel(object):
     DataWriter classes.
     Accessing or editing the data held here directly is NOT SUPPORTED
 
+    There may be other DataModel classes which sit next to this one and hold
+    additional data. The DataView and DataWriter classes will combine these
+    as needed.
+
     What data is held where and how can change without notice.
     """
 
@@ -31,6 +35,7 @@ class FecDataModel(object):
 
     __slots__ = [
         # Data values cached
+        "__app_id",
         "__machine_time_step",
         "__provenance_file_path",
         "__machine_time_step_ms",
@@ -54,6 +59,7 @@ class FecDataModel(object):
         """
         Clears out all data returns to the NOT_SETUP state
         """
+        self.__app_id = None
         self.__machine_time_step = None
         self.__provenance_file_path = None
         self.__n_calls_to_run = None

--- a/spinn_front_end_common/data/fec_data_model.py
+++ b/spinn_front_end_common/data/fec_data_model.py
@@ -61,4 +61,3 @@ class FecDataModel(object):
         self.__report_default_directory = None
         self.__time_scale_factor = None
         self.__status = Data_Status.NOT_SETUP
-

--- a/spinn_front_end_common/data/fec_data_model.py
+++ b/spinn_front_end_common/data/fec_data_model.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2017-2019 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from spinn_front_end_common.data.data_status import Data_Status
+
+
+class FecDataModel(object):
+    """
+    Singleton data model
+
+    This class should not be accessed directly please use the DataView and
+    DataWriter classes.
+    Accessing or editing the data held here directly is NOT SUPPORTED
+
+    What data is held where and how can change without notice.
+    """
+
+    __singleton = None
+
+    __slots__ = [
+        # Data values cached
+        #"__app_provenance_file_path",
+        "__machine_time_step",
+        "__provenance_file_path",
+        "__machine_time_step_ms",
+        #"__machine_time_step_per_ms",
+        "__report_default_directory",
+        "__time_scale_factor",
+        #
+        "__status"
+    ]
+
+    def __new__(cls):
+        if cls.__singleton:
+            return cls.__singleton
+        # pylint: disable=protected-access
+        obj = object.__new__(cls)
+        cls.__singleton = obj
+        obj.__clear()
+        return obj
+
+    def __clear(self):
+        """
+        Clears out all data returns to the NOT_SETUP state
+        """
+        self.__machine_time_step = None
+        self.__provenance_file_path = None
+        self.__machine_time_step_ms = None
+        self.__report_default_directory = None
+        self.__time_scale_factor = None
+        self.__status = Data_Status.NOT_SETUP
+

--- a/spinn_front_end_common/data/fec_data_model.py
+++ b/spinn_front_end_common/data/fec_data_model.py
@@ -31,14 +31,13 @@ class FecDataModel(object):
 
     __slots__ = [
         # Data values cached
-        #"__app_provenance_file_path",
         "__machine_time_step",
         "__provenance_file_path",
         "__machine_time_step_ms",
-        #"__machine_time_step_per_ms",
+        "__n_calls_to_run",
         "__report_default_directory",
         "__time_scale_factor",
-        #
+        # Data status mainly to raise best Exception
         "__status"
     ]
 
@@ -57,6 +56,7 @@ class FecDataModel(object):
         """
         self.__machine_time_step = None
         self.__provenance_file_path = None
+        self.__n_calls_to_run = None
         self.__machine_time_step_ms = None
         self.__report_default_directory = None
         self.__time_scale_factor = None

--- a/spinn_front_end_common/data/fec_data_view.py
+++ b/spinn_front_end_common/data/fec_data_view.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2017-2019 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from .fec_data_model import FecDataModel
+
+
+class FecDataView(object):
+    """
+    A read only view of the data available at FEC level
+
+    The property methods will either return a valid value or
+    raise an Exception if the data is currently not available
+
+    While how and where the underpinning DataModel(s) store data can change
+    without notice, methods in this class can be considered a supported API
+    """
+
+    _fec_data = FecDataModel()
+
+    __slots__ = []
+
+    @property
+    def status(self):
+        return self._fec_data._FecDataModel__status
+
+    @property
+    def machine_time_step(self):
+        """ The machine timestep, in microseconds
+
+        :rtype: int
+        :raises SpinnFrontEndException:
+            If the machine_time_step is currently unavailable
+        """
+        if self._fec_data._FecDataModel__machine_time_step is None:
+            raise self.status.exception("machine_time_step")
+        return self._fec_data._FecDataModel__machine_time_step
+
+    def has_machine_time_step(self):
+        return self._fec_data._FecDataModel__machine_time_step is not None
+
+
+"""   
+     # Data values cached
+        #"__app_provenance_file_path",
+        "__machine_time_step",
+        "__provenance_file_path",
+        "__machine_time_step_ms",
+        #"__machine_time_step_per_ms",
+        "__report_default_directory",
+        "__time_scale_factor",
+        #
+        "__status"
+
+
+    def machine_time_step(self, new_value):
+#        self.__machine_time_step = new_value
+#        self.__machine_time_step_ms = (
+#                new_value / MICRO_TO_MILLISECOND_CONVERSION)
+#        self.__machine_time_step_per_ms = (
+#                MICRO_TO_MILLISECOND_CONVERSION / new_value)
+
+"""

--- a/spinn_front_end_common/data/fec_data_view.py
+++ b/spinn_front_end_common/data/fec_data_view.py
@@ -39,6 +39,22 @@ class FecDataView(object):
         return self._fec_data._FecDataModel__status
 
     @property
+    def app_id(self):
+        """
+        The current application id
+
+        :rtype: int
+        :raises SpinnFrontEndException:
+            If the app_id is currently unavailable
+        """
+        if self._fec_data._FecDataModel__app_id is None:
+            raise self.status.exception("machine_time_step")
+        return self._fec_data._FecDataModel__app_id
+
+    def has_app_id(self):
+        return self._fec_data._FecDataModel__app_id is not None
+
+    @property
     def machine_time_step(self):
         """ The machine timestep, in microseconds
 
@@ -129,7 +145,7 @@ class FecDataView(object):
         :raise KeyError: the error message will say if the item is not known
             now or not provided
         """
-        value = self.__unchecked_gettiem(item)
+        value = self._unchecked_getitem(item)
         if value is None:
             raise KeyError(f"Item {item} is currently not set")
         return value
@@ -144,7 +160,7 @@ class FecDataView(object):
         :return: True if the items is currently know
         :rtype: bool
         """
-        if self.__unchecked_gettiem(item) is not None:
+        if self._unchecked_getitem(item) is not None:
             return True
         return False
 
@@ -166,12 +182,12 @@ class FecDataView(object):
                     "MachinePartitionNKeysMap", "Placements", "RoutingInfos",
                     "RunUntilTimeSteps", "SystemMulticastRouterTimeoutKeys",
                     "Tags"]:
-            item = self.__unchecked_gettiem(key)
+            item = self._unchecked_getitem(key)
             if item is not None:
                 results.append((key, item))
         return results
 
-    def __unchecked_gettiem(self, item):
+    def _unchecked_getitem(self, item):
         """
         Returns the data for this item or None if currently unknown.
 
@@ -182,11 +198,15 @@ class FecDataView(object):
         :rtype: Object or None
         :raise KeyError: It the item is one that is never provided
         """
+        if item == "APPID":
+            if self.has_app_id():
+                return self.app_id
+            else:
+                return None
+
         # TODO Actually add these items to this code
 
         """
-        if item == "APPID":
-            return self.__app_id
         if item == "ApplicationGraph":
             return self.__application_graph
         if item == "DataInMulticastKeyToChipMap":

--- a/spinn_front_end_common/data/fec_data_view.py
+++ b/spinn_front_end_common/data/fec_data_view.py
@@ -14,6 +14,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from .fec_data_model import FecDataModel
+from .data_status import Data_Status
+from spinn_front_end_common.utilities.constants import (
+    MICRO_TO_MILLISECOND_CONVERSION)
 
 
 class FecDataView(object):
@@ -50,25 +53,63 @@ class FecDataView(object):
     def has_machine_time_step(self):
         return self._fec_data._FecDataModel__machine_time_step is not None
 
+    @property
+    def machine_time_step_ms(self):
+        """ The machine timestep, in microseconds
 
-"""   
-     # Data values cached
-        #"__app_provenance_file_path",
-        "__machine_time_step",
-        "__provenance_file_path",
-        "__machine_time_step_ms",
-        #"__machine_time_step_per_ms",
-        "__report_default_directory",
-        "__time_scale_factor",
-        #
-        "__status"
+        Semantic sugar for machine_time_step() / 1000.
 
+        :rtype: float
+        :raises SpinnFrontEndException:
+            If the machine_time_step_ms is currently unavailable
+        """
+        if self._fec_data._FecDataModel__machine_time_step_ms is None:
+            raise self.status.exception("machine_time_step_ms")
+        return self._fec_data._FecDataModel__machine_time_step_ms
 
-    def machine_time_step(self, new_value):
-#        self.__machine_time_step = new_value
-#        self.__machine_time_step_ms = (
-#                new_value / MICRO_TO_MILLISECOND_CONVERSION)
-#        self.__machine_time_step_per_ms = (
-#                MICRO_TO_MILLISECOND_CONVERSION / new_value)
+    def has_machine_time_step_ms(self):
+        return self._fec_data._FecDataModel__machine_time_step_ms is not None
 
-"""
+    # semantic sugar without caching
+    @property
+    def machine_time_step_per_ms(self):
+        """ The machine timesteps in a microseconds
+
+        Semantic sugar for 1000 / machine_time_step()
+
+        :rtype: float
+        :raises SpinnFrontEndException:
+            If the machine_time_step is currently unavailable
+        """
+        return MICRO_TO_MILLISECOND_CONVERSION / self.machine_time_step
+
+    def has_machine_time_step_per_ms(self):
+        return self._fec_data._FecDataModel__machine_time_step is not None
+
+    # The data the user gets needs not be the exact data cached
+    @property
+    def n_calls_to_run(self):
+        """
+        The number of this or the next call to run
+
+        :rtpye: int
+        """
+        if self._fec_data._FecDataModel__n_calls_to_run is None:
+            raise self.status.exception("n_calls_to_run")
+        if self._fec_data._FecDataModel__status == Data_Status.IN_RUN:
+            return self._fec_data._FecDataModel__n_calls_to_run
+        else:
+            # This is the current behaviour in ASB
+            return self._fec_data._FecDataModel__n_calls_to_run + 1
+
+    @property
+    def report_default_directory(self):
+        if self._fec_data._FecDataModel__report_default_directory is None:
+            raise self.status.exception("report_default_directory")
+        return self._fec_data._FecDataModel__report_default_directory
+
+    @property
+    def provenance_file_path(self):
+        if self._fec_data._FecDataModel__provenance_file_path is None:
+            raise self.status.exception("provenance_file_path")
+        return self._fec_data._FecDataModel__provenance_file_path

--- a/spinn_front_end_common/data/fec_data_view.py
+++ b/spinn_front_end_common/data/fec_data_view.py
@@ -113,3 +113,108 @@ class FecDataView(object):
         if self._fec_data._FecDataModel__provenance_file_path is None:
             raise self.status.exception("provenance_file_path")
         return self._fec_data._FecDataModel__provenance_file_path
+
+    def __getitem__(self, item):
+        """
+        Provides dict style access to the key data.
+
+        Allow this class to be passed into the do_injection method
+
+        Values exposed this way are currently limited to the ones needed for
+        injection
+
+        :param str item: key to object wanted
+        :return: Object asked for
+        :rtype: Object
+        :raise KeyError: the error message will say if the item is not known
+            now or not provided
+        """
+        value = self.__unchecked_gettiem(item)
+        if value is None:
+            raise KeyError(f"Item {item} is currently not set")
+        return value
+
+    def __contains__(self, item):
+        """
+        Provides dict style in checks to the key data.
+
+        Keys check this way are limited to the ones needed for injection
+
+        :param str item:
+        :return: True if the items is currently know
+        :rtype: bool
+        """
+        if self.__unchecked_gettiem(item) is not None:
+            return True
+        return False
+
+    def items(self):
+        """
+        Lists the keys of the data currently available.
+
+        Keys exposed this way are limited to the ones needed for injection
+
+        :return: List of the keys for which there is data
+        :rtype: list(str)
+        :raise KeyError:  Amethod this call depends on could raise this
+            exception, but that indicates a programming mismatch
+        """
+        results = []
+        for key in ["APPID", "ApplicationGraph", "DataInMulticastKeyToChipMap",
+                    "DataInMulticastRoutingTables", "DataNTimeSteps",
+                    "ExtendedMachine", "FirstMachineTimeStep", "MachineGraph",
+                    "MachinePartitionNKeysMap", "Placements", "RoutingInfos",
+                    "RunUntilTimeSteps", "SystemMulticastRouterTimeoutKeys",
+                    "Tags"]:
+            item = self.__unchecked_gettiem(key)
+            if item is not None:
+                results.append((key, item))
+        return results
+
+    def __unchecked_gettiem(self, item):
+        """
+        Returns the data for this item or None if currently unknown.
+
+        Values exposed this way are limited to the ones needed for injection
+
+        :param str item:
+        :return: The value for this item or None is currently unkwon
+        :rtype: Object or None
+        :raise KeyError: It the item is one that is never provided
+        """
+        # TODO Actually add these items to this code
+
+        """
+        if item == "APPID":
+            return self.__app_id
+        if item == "ApplicationGraph":
+            return self.__application_graph
+        if item == "DataInMulticastKeyToChipMap":
+            return self.__data_in_multicast_key_to_chip_map
+        if item == "DataInMulticastRoutingTables":
+            return self.__data_in_multicast_routing_tables
+        if item == "DataNTimeSteps":
+            return self.__max_run_time_steps
+        if item == "DataNSteps":
+            return self.__max_run_time_steps
+        if item == "ExtendedMachine":
+            return self.__machine
+        if item == "FirstMachineTimeStep":
+            return self.__first_machine_time_step
+        if item == "MachineGraph":
+            return self.__machine_graph
+        if item == "MachinePartitionNKeysMap":
+            return self.__machine_partition_n_keys_map
+        if item == "Placements":
+            return self.__placements
+        if item == "RoutingInfos":
+            return self.__routing_infos
+        if item == "RunUntilTimeSteps":
+            return self.__current_run_timesteps
+        if item == "SystemMulticastRouterTimeoutKeys":
+            return self.__system_multicast_router_timeout_keys
+        if item == "Tags":
+            return self.__tags
+        """
+
+        raise KeyError(f"Unexpected Item {item}")

--- a/spinn_front_end_common/data/fec_data_writer.py
+++ b/spinn_front_end_common/data/fec_data_writer.py
@@ -13,10 +13,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from .data_status import Data_Status
-from .fec_data_view import FecDataView
+import os
+from spinn_utilities.config_holder import get_config_int
 from spinn_front_end_common.utilities.constants import (
     MICRO_TO_MILLISECOND_CONVERSION)
+from .data_status import Data_Status
+from .fec_data_view import FecDataView
 
 
 class FecDataWriter(FecDataView):
@@ -30,9 +32,33 @@ class FecDataWriter(FecDataView):
         :return:
         """
         self._fec_data._FecDataModel__clear()
+        self._fec_data._FecDataModel__n_calls_to_run = 0
         self._fec_data._FecDataModel__status = Data_Status.SETUP
 
-    def set_machine_time_step(self, new_value):
-        self._fec_data._FecDataModel__machine_time_step = new_value
+    def start_run(self):
+        self._fec_data._FecDataModel__n_calls_to_run += 1
+        self._fec_data._FecDataModel__status = Data_Status.IN_RUN
+        self.__set_up_report_specifics()
+
+    def finish_run(self):
+        self._fec_data._FecDataModel__status = Data_Status.FINISHED
+
+    def __set_up_report_specifics(self):
+        """
+        :param int n_calls_to_run:
+            the counter of how many times run has been called.
+        """
+        # This is a highly simplified example
+        report_simulation_top_directory = os.getcwd()
+        self._fec_data._FecDataModel__report_default_directory = os.path.join(
+            report_simulation_top_directory, f"run_{self.n_calls_to_run}")
+        self._fec_data._FecDataModel__provenance_file_path = os.path.join(
+            self._fec_data._FecDataModel__report_default_directory,
+            "provenance_data")
+
+    def set_machine_time_step(self, machine_time_step):
+        if machine_time_step is None:
+            machine_time_step = get_config_int("Machine", "machine_time_step")
+        self._fec_data._FecDataModel__machine_time_step = machine_time_step
         self._fec_data._FecDataModel__machine_time_step_ms = (
-                new_value / MICRO_TO_MILLISECOND_CONVERSION)
+                machine_time_step / MICRO_TO_MILLISECOND_CONVERSION)

--- a/spinn_front_end_common/data/fec_data_writer.py
+++ b/spinn_front_end_common/data/fec_data_writer.py
@@ -61,6 +61,16 @@ class FecDataWriter(FecDataView):
             self._fec_data._FecDataModel__report_default_directory,
             "provenance_data")
 
+    def set_app_id(self, app_id):
+        """
+        Sets the app_id value
+
+        :param int app_id: new value
+        """
+        if not isinstance(app_id, int):
+            raise TypeError("app_id should be an int")
+        self._fec_data._FecDataModel__app_id = app_id
+
     def set_machine_time_step(self, machine_time_step):
         if machine_time_step is None:
             machine_time_step = get_config_int("Machine", "machine_time_step")

--- a/spinn_front_end_common/data/fec_data_writer.py
+++ b/spinn_front_end_common/data/fec_data_writer.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2017-2019 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from .data_status import Data_Status
+from .fec_data_view import FecDataView
+from spinn_front_end_common.utilities.constants import (
+    MICRO_TO_MILLISECOND_CONVERSION)
+
+
+class FecDataWriter(FecDataView):
+    """
+    Writer class for the Fec Data
+
+    """
+    def setup(self):
+        """
+        Clears out all data
+        :return:
+        """
+        self._fec_data._FecDataModel__clear()
+        self._fec_data._FecDataModel__status = Data_Status.SETUP
+
+    def set_machine_time_step(self, new_value):
+        self._fec_data._FecDataModel__machine_time_step = new_value
+        self._fec_data._FecDataModel__machine_time_step_ms = (
+                new_value / MICRO_TO_MILLISECOND_CONVERSION)

--- a/spinn_front_end_common/data/fec_data_writer.py
+++ b/spinn_front_end_common/data/fec_data_writer.py
@@ -13,12 +13,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
 import os
 from spinn_utilities.config_holder import get_config_int
+from spinn_utilities.log import FormatAdapter
 from spinn_front_end_common.utilities.constants import (
     MICRO_TO_MILLISECOND_CONVERSION)
 from .data_status import Data_Status
 from .fec_data_view import FecDataView
+
+logger = FormatAdapter(logging.getLogger(__name__))
 
 
 class FecDataWriter(FecDataView):
@@ -34,11 +38,11 @@ class FecDataWriter(FecDataView):
         self._fec_data._FecDataModel__clear()
         self._fec_data._FecDataModel__n_calls_to_run = 0
         self._fec_data._FecDataModel__status = Data_Status.SETUP
+        self.__set_up_report_specifics()
 
     def start_run(self):
         self._fec_data._FecDataModel__n_calls_to_run += 1
         self._fec_data._FecDataModel__status = Data_Status.IN_RUN
-        self.__set_up_report_specifics()
 
     def finish_run(self):
         self._fec_data._FecDataModel__status = Data_Status.FINISHED
@@ -52,6 +56,7 @@ class FecDataWriter(FecDataView):
         report_simulation_top_directory = os.getcwd()
         self._fec_data._FecDataModel__report_default_directory = os.path.join(
             report_simulation_top_directory, f"run_{self.n_calls_to_run}")
+        logger.info(self.report_default_directory)
         self._fec_data._FecDataModel__provenance_file_path = os.path.join(
             self._fec_data._FecDataModel__report_default_directory,
             "provenance_data")

--- a/spinn_front_end_common/utilities/exceptions.py
+++ b/spinn_front_end_common/utilities/exceptions.py
@@ -64,14 +64,35 @@ class CantFindSDRAMToUseException(SpinnFrontEndException):
 
 class SimulatorNotSetupException(SpinnFrontEndException):
     """
-    Raised when trying to get simulator before it has been setup
+    Raised when trying to get data before simulator has been setup
     """
+
+    def __init__(self, data):
+        super().__init__(f"Requesting {data} is not valid before setup")
+
+
+class SimulatorDataNotYetAvialable(SpinnFrontEndException):
+    """
+    Raised when trying to get data before simulator has created it
+    """
+    def __init__(self, data):
+        super().__init__(f"{data} has not yet been created.")
+
+
+class SimulatorDataNotMocked(SimulatorDataNotYetAvialable):
+    """
+    Raised when trying to get data before a mocked simulator has created it
+    """
+    def __init__(self, data):
+        super().__init__(f"MOCK {data} has not yet been created.")
 
 
 class SimulatorShutdownException(SpinnFrontEndException):
     """
     Raised when trying to get simulator after it has been shit down
     """
+    def __init__(self, data):
+        super().__init__(f"Requesting {data} is not valid after end")
 
 
 class SimulatorRunningException(SpinnFrontEndException):

--- a/unittests/data/__init__.py
+++ b/unittests/data/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2017-2019 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/unittests/data/manual_check.py
+++ b/unittests/data/manual_check.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2021 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from spinn_front_end_common.utilities.exceptions import (
+    SimulatorDataNotYetAvialable, SimulatorNotSetupException)
+from spinn_front_end_common.data import FecDataView, FecDataWriter
+
+# This can not be a unittest as the unitest suite would use the same
+# python console and therefor the same singleton multiple times
+
+# It can be run multiple time as each run is a new python console
+
+view = FecDataView()
+writer = FecDataWriter()
+try:
+    view.machine_time_step
+    raise Exception("OOPS")
+except SimulatorNotSetupException:
+    pass
+writer.setup()
+try:
+    view.machine_time_step
+    raise Exception("OOPS")
+except SimulatorDataNotYetAvialable:
+    pass
+writer.set_machine_time_step(1000)
+print(view.machine_time_step)

--- a/unittests/data/test_simulator_data.py
+++ b/unittests/data/test_simulator_data.py
@@ -46,4 +46,3 @@ class TestSimulatorData(unittest.TestCase):
         writer.start_run()
         self.assertEqual(2, view.n_calls_to_run)
         self.assertIn("run_1", view.report_default_directory)
-

--- a/unittests/data/test_simulator_data.py
+++ b/unittests/data/test_simulator_data.py
@@ -45,4 +45,5 @@ class TestSimulatorData(unittest.TestCase):
         self.assertEqual(2, view.n_calls_to_run)
         writer.start_run()
         self.assertEqual(2, view.n_calls_to_run)
+        self.assertIn("run_1", view.report_default_directory)
 

--- a/unittests/data/test_simulator_data.py
+++ b/unittests/data/test_simulator_data.py
@@ -46,3 +46,19 @@ class TestSimulatorData(unittest.TestCase):
         writer.start_run()
         self.assertEqual(2, view.n_calls_to_run)
         self.assertIn("run_1", view.report_default_directory)
+
+    def test_dict(self):
+        view = FecDataView()
+        writer = FecDataWriter()
+        writer.setup()
+        self.assertFalse(view.has_app_id())
+        self.assertFalse("APPID" in view)
+        with self.assertRaises(KeyError):
+            view["APPID"]
+        with self.assertRaises(SimulatorDataNotYetAvialable):
+            view.app_id
+        writer.set_app_id(6)
+        self.assertTrue(view.has_app_id())
+        self.assertEqual(6, view.app_id)
+        self.assertEqual(6, view["APPID"])
+        self.assertTrue("APPID" in view)

--- a/unittests/data/test_simulator_data.py
+++ b/unittests/data/test_simulator_data.py
@@ -62,3 +62,26 @@ class TestSimulatorData(unittest.TestCase):
         self.assertEqual(6, view.app_id)
         self.assertEqual(6, view["APPID"])
         self.assertTrue("APPID" in view)
+
+    def test_mock(self):
+        view = FecDataView()
+        writer = FecDataWriter()
+        writer.mock()
+        # check there is a value not what it is
+        self.assertIsNotNone(view.app_id)
+        self.assertIsNotNone(view.machine_time_step)
+        self.assertIsNotNone(view.machine_time_step_ms)
+        self.assertIsNotNone(view.machine_time_step_per_ms)
+        self.assertIsNotNone(view.report_default_directory)
+        self.assertIsNotNone(view.provenance_file_path)
+
+    def test_multiple(self):
+        view = FecDataView()
+        writer = FecDataWriter()
+        view2 = FecDataView()
+        writer2 = FecDataWriter()
+        writer2.set_app_id(7)
+        self.assertEqual(7, view.app_id)
+        self.assertEqual(7, view2.app_id)
+        self.assertEqual(7, writer.app_id)
+        self.assertEqual(7, writer2.app_id)

--- a/unittests/data/test_simulator_data.py
+++ b/unittests/data/test_simulator_data.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2021 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from spinn_front_end_common.utilities.exceptions import (
+    SimulatorDataNotYetAvialable)
+from spinn_front_end_common.data import FecDataView, FecDataWriter
+
+
+class TestSimulatorData(unittest.TestCase):
+
+    def test_setup(self):
+        view = FecDataView()
+        writer = FecDataWriter()
+        # What happens before setup depends on the previous test
+        # Use manual_check to verify this without dependency
+        writer.setup()
+        with self.assertRaises(SimulatorDataNotYetAvialable):
+            view.machine_time_step
+        writer.set_machine_time_step(10)
+        view.machine_time_step

--- a/unittests/data/test_simulator_data.py
+++ b/unittests/data/test_simulator_data.py
@@ -27,7 +27,22 @@ class TestSimulatorData(unittest.TestCase):
         # What happens before setup depends on the previous test
         # Use manual_check to verify this without dependency
         writer.setup()
+        self.assertIn("run_1", view.report_default_directory)
+        self.assertIn("provenance_data", view.provenance_file_path)
         with self.assertRaises(SimulatorDataNotYetAvialable):
             view.machine_time_step
         writer.set_machine_time_step(10)
         view.machine_time_step
+
+    def test_run(self):
+        view = FecDataView()
+        writer = FecDataWriter()
+        writer.setup()
+        self.assertEqual(1, view.n_calls_to_run)
+        writer.start_run()
+        self.assertEqual(1, view.n_calls_to_run)
+        writer.finish_run()
+        self.assertEqual(2, view.n_calls_to_run)
+        writer.start_run()
+        self.assertEqual(2, view.n_calls_to_run)
+


### PR DESCRIPTION
At this point this is an example of how the global data object would look.

Model
- One (or more DataModel) singleton classes with only double underscore variables

View
Wrapping the model(s) with methods that raise the correct exception if the data is not available

DataStatus
What state the data is in and throwing the correct Exception

Writer
Extends View but also adds methods to change the state and data
- this would included validation that data is legal ect.

--

There will be more that one model for example FecDataModel, SpyDataModel
See https://github.com/SpiNNakerManchester/sPyNNaker/pull/1125
They would be independent each with their own data
A model could also be a database

There will be more than one Viewer where the later ones will extend the earlier ones therefor exposing both sets of methods in one API
For example 
class SpyDataView(FecDataView):
which adds methods for the SpyDataModel

There will be more than one Writer where the later extend both the Viewer at its level and the Writer below.
For example
class SpyDataSetter(SpyDataView, FecDataSetter):
which adds methods for changing the SpyDataModel

Technically the read (@property) methods could easily be classless just be imported where needed.
Even the write methods could be classes.
Much in the same style as the config_holder ones 

However I definitely don't want the write methods to be classless as I want to discourage use of these outside of the sim and ASB stacks. I prefer having clear View Objects we can pass to users and algorithms to highlight this is a bound together set of data and not stuff from all over the place.
