### PR TITLE
App graph is never None but may be empty

### DIFF
--- a/fec_integration_tests/interface/interface_functions/test_front_end_common_insert_edges_to_live_packet_gatherers.py
+++ b/fec_integration_tests/interface/interface_functions/test_front_end_common_insert_edges_to_live_packet_gatherers.py
@@ -118,7 +118,8 @@ class TestInsertLPGEdges(unittest.TestCase):
             placements=placements,
             live_packet_gatherers_to_vertex_mapping=(
                 live_packet_gatherers_to_vertex_mapping),
-            machine=machine, machine_graph=graph, application_graph=None)
+            machine=machine, machine_graph=graph,
+            application_graph=ApplicationGraph("Empty"))
 
         # verify edges are in the right place
         for chip in machine.ethernet_connected_chips:

--- a/fec_integration_tests/interface/interface_functions/test_front_end_common_insert_lpgs.py
+++ b/fec_integration_tests/interface/interface_functions/test_front_end_common_insert_lpgs.py
@@ -18,6 +18,7 @@ from spinn_machine import virtual_machine
 from spinnman.messages.eieio import EIEIOType
 from pacman.model.graphs.application import ApplicationGraph, ApplicationVertex
 from pacman.model.graphs.machine import MachineGraph
+from pacman_test_objects import SimpleTestVertex
 from spinn_front_end_common.interface.config_setup import unittest_setup
 from spinn_front_end_common.interface.interface_functions import (
     InsertLivePacketGatherersToGraphs)
@@ -62,7 +63,8 @@ class TestInsertLPGs(unittest.TestCase):
         edge_inserter = InsertLivePacketGatherersToGraphs()
         lpg_verts_mapping = edge_inserter(
             live_packet_gatherer_parameters=live_packet_gatherers,
-            machine=machine, machine_graph=graph, application_graph=None)
+            machine=machine, machine_graph=graph,
+            application_graph=ApplicationGraph("empty"))
 
         self.assertEqual(len(lpg_verts_mapping[default_params_holder][1]), 3)
         locs = [(0, 0), (4, 8), (8, 4)]
@@ -81,6 +83,8 @@ class TestInsertLPGs(unittest.TestCase):
     def test_that_3_lpgs_are_generated_on_3_board_app_graph(self):
         machine = virtual_machine(width=12, height=12)
         app_graph = ApplicationGraph("Test")
+        app_graph.add_vertex(
+            SimpleTestVertex(10, "New AbstractConstrainedVertex 1", 256))
         graph = MachineGraph("Test", app_graph)
 
         default_params = {
@@ -131,7 +135,7 @@ class TestInsertLPGs(unittest.TestCase):
         app_verts = set()
         for vertex in lpg_verts_mapping[default_params_holder][1].values():
             app_vertex = vertex.app_vertex
-            self.assertNotEqual(app_vertex, None)
+            self.assertIsNotNone(app_vertex)
             self.assertIsInstance(app_vertex, ApplicationVertex)
             app_verts.add(app_vertex)
         # Should only be a single app vertex for one set of params

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1617,15 +1617,10 @@ class AbstractSpinnakerBase(ConfigHandler):
                     "enable_reinjection"):
                 return
             inserter = InsertExtraMonitorVerticesToGraphs()
-            # inserter checks for None app graph not an empty one
-            if self._application_graph.n_vertices > 0:
-                app_graph = self._application_graph
-            else:
-                app_graph = None
         (self._vertex_to_ethernet_connected_chip_mapping,
          self._extra_monitor_vertices,
          self._extra_monitor_to_chip_mapping) = inserter(
-            self._machine, self._machine_graph, app_graph)
+            self._machine, self._machine_graph, self._application_graph)
 
     def _execute_partitioner_report(self):
         """
@@ -1782,15 +1777,10 @@ class AbstractSpinnakerBase(ConfigHandler):
                     "Machine", "enable_advanced_monitor_support",
                     "enable_reinjection"):
                 return
-            # inserter checks for None app graph not an empty one
-            if self._application_graph.n_vertices > 0:
-                app_graph = self._application_graph
-            else:
-                app_graph = None
             inserter = InsertEdgesToExtraMonitorFunctionality()
             inserter(self._machine_graph, self._placements, self._machine,
                      self._vertex_to_ethernet_connected_chip_mapping,
-                     app_graph)
+                     self._application_graph)
 
     def _execute_system_multicast_routing_generator(self):
         """

--- a/spinn_front_end_common/interface/interface_functions/graph_provenance_gatherer.py
+++ b/spinn_front_end_common/interface/interface_functions/graph_provenance_gatherer.py
@@ -32,8 +32,7 @@ class GraphProvenanceGatherer(object):
             ~pacman.model.graphs.application.ApplicationGraph
         """
         self._get_machine_graph_provenance(machine_graph)
-        if application_graph is not None:
-            self._get_app_graph_provenance(application_graph)
+        self._get_app_graph_provenance(application_graph)
 
     @staticmethod
     def _get_machine_graph_provenance(machine_graph):

--- a/spinn_front_end_common/interface/interface_functions/insert_chip_power_monitors_to_graphs.py
+++ b/spinn_front_end_common/interface/interface_functions/insert_chip_power_monitors_to_graphs.py
@@ -46,7 +46,7 @@ class InsertChipPowerMonitorsToGraphs(object):
         progress = ProgressBar(
             machine.n_chips, "Adding Chip power monitors to Graph")
 
-        if application_graph is not None:
+        if application_graph.n_vertices > 0:
             self.__add_app(
                 application_graph, machine_graph, machine,
                 sampling_frequency, progress)

--- a/spinn_front_end_common/interface/interface_functions/insert_edges_to_extra_monitor_functionality.py
+++ b/spinn_front_end_common/interface/interface_functions/insert_edges_to_extra_monitor_functionality.py
@@ -65,7 +65,7 @@ class InsertEdgesToExtraMonitorFunctionality(object):
             "Inserting edges between vertices which require FR speed up "
             "functionality.")
 
-        if application_graph == 0:
+        if application_graph.n_vertices == 0:
             for vertex in progress.over(machine_graph.vertices):
                 if isinstance(vertex, ExtraMonitorSupportMachineVertex):
                     self._process_mach_graph_vertex(vertex, machine_graph)

--- a/spinn_front_end_common/interface/interface_functions/insert_edges_to_extra_monitor_functionality.py
+++ b/spinn_front_end_common/interface/interface_functions/insert_edges_to_extra_monitor_functionality.py
@@ -55,9 +55,7 @@ class InsertEdgesToExtraMonitorFunctionality(object):
             ~pacman.model.graphs.application.ApplicationGraph
         """
         # pylint: disable=too-many-arguments, attribute-defined-outside-init
-        n_app_vertices = 0
-        if application_graph is not None:
-            n_app_vertices = application_graph.n_vertices
+        n_app_vertices = application_graph.n_vertices
         self._chip_to_gatherer_map = vertex_to_ethernet_connected_chip_mapping
         self._machine = machine
         self._placements = placements
@@ -67,7 +65,7 @@ class InsertEdgesToExtraMonitorFunctionality(object):
             "Inserting edges between vertices which require FR speed up "
             "functionality.")
 
-        if application_graph is None:
+        if application_graph == 0:
             for vertex in progress.over(machine_graph.vertices):
                 if isinstance(vertex, ExtraMonitorSupportMachineVertex):
                     self._process_mach_graph_vertex(vertex, machine_graph)

--- a/spinn_front_end_common/interface/interface_functions/insert_edges_to_live_packet_gatherers.py
+++ b/spinn_front_end_common/interface/interface_functions/insert_edges_to_live_packet_gatherers.py
@@ -74,7 +74,7 @@ class InsertEdgesToLivePacketGatherers(object):
                 "which live output has been requested and its local Live "
                 "Packet Gatherer"))
 
-        if application_graph is None:
+        if application_graph.n_vertices == 0:
             for lpg_params in progress.over(live_packet_gatherer_parameters):
                 # locate vertices to connect to a LPG with these params
                 for vertex, p_ids in live_packet_gatherer_parameters[
@@ -82,7 +82,6 @@ class InsertEdgesToLivePacketGatherers(object):
                     self._connect_lpg_vertex_in_machine_graph(
                         machine_graph, vertex, lpg_params, p_ids, n_keys_map)
         else:
-
             for lpg_params in progress.over(live_packet_gatherer_parameters):
                 # locate vertices to connect to a LPG with these params
                 for vertex, p_ids in live_packet_gatherer_parameters[

--- a/spinn_front_end_common/interface/interface_functions/insert_extra_monitor_vertices_to_graphs.py
+++ b/spinn_front_end_common/interface/interface_functions/insert_extra_monitor_vertices_to_graphs.py
@@ -56,7 +56,7 @@ class InsertExtraMonitorVerticesToGraphs(object):
         vertex_to_chip_map = dict()
 
         # handle reinjector and chip based data extractor functionality.
-        if application_graph is not None:
+        if application_graph.n_vertices > 0:
             extra_monitors = self._add_second_monitors_application_graph(
                 progress, machine, application_graph, machine_graph,
                 vertex_to_chip_map)
@@ -65,7 +65,7 @@ class InsertExtraMonitorVerticesToGraphs(object):
                 progress, machine, machine_graph, vertex_to_chip_map)
 
         # progress data receiver for data extraction functionality
-        if application_graph is not None:
+        if application_graph.n_verticese > 0:
             self._add_data_extraction_vertices_app_graph(
                 progress, machine, application_graph, machine_graph,
                 chip_to_gatherer_map, vertex_to_chip_map)

--- a/spinn_front_end_common/interface/interface_functions/insert_extra_monitor_vertices_to_graphs.py
+++ b/spinn_front_end_common/interface/interface_functions/insert_extra_monitor_vertices_to_graphs.py
@@ -65,7 +65,7 @@ class InsertExtraMonitorVerticesToGraphs(object):
                 progress, machine, machine_graph, vertex_to_chip_map)
 
         # progress data receiver for data extraction functionality
-        if application_graph.n_verticese > 0:
+        if application_graph.n_vertices > 0:
             self._add_data_extraction_vertices_app_graph(
                 progress, machine, application_graph, machine_graph,
                 chip_to_gatherer_map, vertex_to_chip_map)

--- a/spinn_front_end_common/interface/interface_functions/insert_live_packet_gatherers_to_graphs.py
+++ b/spinn_front_end_common/interface/interface_functions/insert_live_packet_gatherers_to_graphs.py
@@ -65,7 +65,7 @@ class InsertLivePacketGatherersToGraphs(object):
         lpg_params_to_vertices = defaultdict(dict)
 
         # for every Ethernet connected chip, add the gatherers required
-        if application_graph is not None:
+        if application_graph.n_vertices > 0:
             for params in live_packet_gatherer_parameters:
                 lpg_app_vtx = LivePacketGather(params)
                 self._application_graph.add_vertex(lpg_app_vtx)

--- a/spinn_front_end_common/interface/interface_functions/local_tdma_builder.py
+++ b/spinn_front_end_common/interface/interface_functions/local_tdma_builder.py
@@ -98,7 +98,7 @@ class LocalTDMABuilder(object):
         :type application_graph:
             ~pacman.model.graphs.application.ApplicationGraph or None
         """
-        if application_graph is None:
+        if application_graph.n_vertices == 0:
             return
 
         # get config params

--- a/spinn_front_end_common/utilities/database/database_writer.py
+++ b/spinn_front_end_common/utilities/database/database_writer.py
@@ -260,7 +260,7 @@ class DatabaseWriter(SQLiteDB):
                     for edge in machine_graph.get_edges_starting_at_vertex(
                         vertex)))
 
-            if application_graph is not None:
+            if application_graph.n_vertices > 0:
                 cur.executemany(
                     """
                     INSERT INTO graph_mapper_vertex (
@@ -390,7 +390,7 @@ class DatabaseWriter(SQLiteDB):
         :param ~pacman.model.graphs.machine.MachineGraph machine_graph:
         :param ~pacman.model.routing_info.RoutingInfo routing_infos:
         """
-        if application_graph is not None and application_graph.n_vertices:
+        if application_graph.n_vertices:
             # We will be asking application vertices for key/atom mappings
             vertices_and_partitions = (
                 (vertex.app_vertex, partition)


### PR DESCRIPTION
In the release 6.0.0 if there was no app vertices the algorithms would be passed a None

No app vertices can come from either GFE machine level only or an empty graph.

The no executor branch changed the behaviour to always pass the app graph even if empty.

This made the algorithms that just for loop the app graph a little cleaner.

The issue was the algorithms that have an app and a machine version.

As there is separate work which may remove the machine_graph or at least require there always to be an app graph the choice is to change the if app_grap is None test ti ones that check n_vertices.

If this PR is refused ASB must revert to checking app_graph n_vertices before passing it.