### PR TITLE
Key translation

### DIFF
--- a/fec_integration_tests/interface/interface_functions/test_front_end_common_insert_edges_to_live_packet_gatherers.py
+++ b/fec_integration_tests/interface/interface_functions/test_front_end_common_insert_edges_to_live_packet_gatherers.py
@@ -31,6 +31,7 @@ from spinn_front_end_common.utility_models import (
     LivePacketGather, LivePacketGatherMachineVertex)
 from pacman_test_objects import SimpleTestVertex
 from pacman.model.partitioner_splitters import SplitterSliceLegacy
+from pacman.model.graphs.application.application_edge import ApplicationEdge
 
 
 class TestInsertLPGEdges(unittest.TestCase):
@@ -200,6 +201,9 @@ class TestInsertLPGEdges(unittest.TestCase):
             vertex = SimpleTestVertex(1)
             vertex.splitter = SplitterSliceLegacy()
             app_graph.add_vertex(vertex)
+            app_edge = ApplicationEdge(vertex, lpg_app_vertex)
+            app_graph.add_edge(app_edge, "EVENTS")
+            lpg_app_vertex.add_incoming_edge(app_edge)
             vertex_slice = Slice(0, 0)
             resources_required = vertex.get_resources_used_by_atoms(
                 vertex_slice)

--- a/spinn_front_end_common/interface/interface_functions/insert_edges_to_live_packet_gatherers.py
+++ b/spinn_front_end_common/interface/interface_functions/insert_edges_to_live_packet_gatherers.py
@@ -161,7 +161,7 @@ class _InsertEdgesToLivePacketGatherers(object):
         for p_id in p_ids:
             part = app_graph.get_outgoing_edge_partition_starting_at_vertex(
                 app_vertex, p_id)
-            app_edge = next(iter(part.edges[0]))
+            app_edge = next(iter(part.edges))
 
             m_vertices = app_vertex.splitter.get_out_going_vertices(
                 app_edge, part)

--- a/spinn_front_end_common/interface/interface_functions/insert_edges_to_live_packet_gatherers.py
+++ b/spinn_front_end_common/interface/interface_functions/insert_edges_to_live_packet_gatherers.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from spinn_utilities.progress_bar import ProgressBar
-from pacman.model.graphs.application import ApplicationEdge
 from pacman.model.graphs.machine import MachineEdge
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 
@@ -158,11 +157,11 @@ class _InsertEdgesToLivePacketGatherers(object):
 
         m_partitions = set()
 
-        lpg_app_vertex, machine_lpgs = self._lpg_to_vertex[lpg_params]
+        _, machine_lpgs = self._lpg_to_vertex[lpg_params]
         for p_id in p_ids:
-            app_edge = ApplicationEdge(app_vertex, lpg_app_vertex)
-            app_graph.add_edge(app_edge, p_id)
-            part = app_graph.get_outgoing_partition_for_edge(app_edge)
+            part = app_graph.get_outgoing_edge_partition_starting_at_vertex(
+                app_vertex, p_id)
+            app_edge = next(iter(part.edges[0]))
 
             m_vertices = app_vertex.splitter.get_out_going_vertices(
                 app_edge, part)

--- a/spinn_front_end_common/interface/interface_functions/insert_edges_to_live_packet_gatherers.py
+++ b/spinn_front_end_common/interface/interface_functions/insert_edges_to_live_packet_gatherers.py
@@ -170,6 +170,7 @@ class _InsertEdgesToLivePacketGatherers(object):
                     vertex, machine_lpgs)
                 machine_edge = MachineEdge(vertex, lpg, app_edge=app_edge)
                 m_graph.add_edge(machine_edge, p_id)
+                lpg.add_incoming_edge(machine_edge)
 
                 # add to n_keys_map if needed
                 if n_keys_map:

--- a/spinn_front_end_common/interface/interface_functions/insert_live_packet_gatherers_to_graphs.py
+++ b/spinn_front_end_common/interface/interface_functions/insert_live_packet_gatherers_to_graphs.py
@@ -108,6 +108,7 @@ class _InsertLivePacketGatherersToGraphs(object):
                     for p_id in p_ids:
                         app_edge = ApplicationEdge(app_vertex, lpg_app_vtx)
                         self._application_graph.add_edge(app_edge, p_id)
+                        lpg_app_vtx.add_incoming_edge(app_edge)
         else:
             for params in live_packet_gatherer_parameters:
                 mac_vtxs = dict()

--- a/spinn_front_end_common/interface/interface_functions/insert_live_packet_gatherers_to_graphs.py
+++ b/spinn_front_end_common/interface/interface_functions/insert_live_packet_gatherers_to_graphs.py
@@ -16,6 +16,7 @@
 from collections import defaultdict
 from spinn_utilities.progress_bar import ProgressBar
 from pacman.model.constraints.placer_constraints import ChipAndCoreConstraint
+from pacman.model.graphs.application import ApplicationEdge
 from spinn_front_end_common.utility_models import (
     LivePacketGather, LivePacketGatherMachineVertex)
 
@@ -102,6 +103,11 @@ class _InsertLivePacketGatherersToGraphs(object):
                     mac_vtxs[chip.x, chip.y] = self._add_app_lpg_vertex(
                         lpg_app_vtx, chip)
                 lpg_params_to_vertices[params] = (lpg_app_vtx, mac_vtxs)
+                for app_vertex, p_ids in live_packet_gatherer_parameters[
+                        params]:
+                    for p_id in p_ids:
+                        app_edge = ApplicationEdge(app_vertex, lpg_app_vtx)
+                        self._application_graph.add_edge(app_edge, p_id)
         else:
             for params in live_packet_gatherer_parameters:
                 mac_vtxs = dict()

--- a/spinn_front_end_common/utilities/utility_objs/live_packet_gather_parameters.py
+++ b/spinn_front_end_common/utilities/utility_objs/live_packet_gather_parameters.py
@@ -32,7 +32,8 @@ class LivePacketGatherParameters(object):
         '_port', '_hostname', "_tag", "_strip_sdp", "_use_prefix",
         "_key_prefix", "_prefix_type", "_message_type", "_right_shift",
         "_payload_as_time_stamps", "_use_payload_prefix", "_payload_prefix",
-        "_payload_right_shift", "_n_packets_per_time_step", "_label"
+        "_payload_right_shift", "_n_packets_per_time_step", "_label",
+        "_translate_keys"
     ]
 
     def __init__(
@@ -41,7 +42,8 @@ class LivePacketGatherParameters(object):
             message_type=EIEIOType.KEY_32_BIT, right_shift=0,
             payload_as_time_stamps=True, use_payload_prefix=True,
             payload_prefix=None, payload_right_shift=0,
-            number_of_packets_sent_per_time_step=0, label=None):
+            number_of_packets_sent_per_time_step=0, label=None,
+            translate_keys=False):
         """
         :raises ConfigurationException:
             If the parameters passed are known to be an invalid combination.
@@ -81,6 +83,7 @@ class LivePacketGatherParameters(object):
         self._payload_right_shift = payload_right_shift
         self._n_packets_per_time_step = number_of_packets_sent_per_time_step
         self._label = label
+        self._translate_keys = translate_keys
 
     @property
     def port(self):
@@ -142,6 +145,10 @@ class LivePacketGatherParameters(object):
     def label(self):
         return self._label
 
+    @property
+    def translate_keys(self):
+        return self._translate_keys
+
     def get_iptag_resource(self):
         """ Get a description of the IPtag that the LPG for these parameters \
             will require.
@@ -170,7 +177,8 @@ class LivePacketGatherParameters(object):
                 self._payload_right_shift == other.payload_right_shift and
                 self._n_packets_per_time_step ==
                 other.number_of_packets_sent_per_time_step and
-                self._label == other.label)
+                self._label == other.label and
+                self._translate_keys == other.translate_keys)
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -182,5 +190,5 @@ class LivePacketGatherParameters(object):
             self._right_shift, self._payload_as_time_stamps,
             self._use_payload_prefix, self._payload_prefix,
             self._payload_right_shift, self._n_packets_per_time_step,
-            self._label)
+            self._label, self._translate_keys)
         return hash(data)

--- a/spinn_front_end_common/utility_models/live_packet_gather_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/live_packet_gather_machine_vertex.py
@@ -232,8 +232,8 @@ class LivePacketGatherMachineVertex(
             spec.write_value(len(self._incoming_edges))
             for edge in self._incoming_edges:
                 r_info = routing_info.get_routing_info_for_edge(edge)
-                spec.write_value(r_info.key)
-                spec.write_value(r_info.mask)
+                spec.write_value(r_info.first_key)
+                spec.write_value(r_info.first_mask)
                 spec.write_value(edge.pre_vertex.vertex_slice.lo_atom)
 
     def _write_setup_info(self, spec):

--- a/spinn_front_end_common/utility_models/live_packet_gather_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/live_packet_gather_machine_vertex.py
@@ -53,8 +53,9 @@ class LivePacketGatherMachineVertex(
     TRAFFIC_IDENTIFIER = "LPG_EVENT_STREAM"
 
     _N_ADDITIONAL_PROVENANCE_ITEMS = 4
-    _CONFIG_SIZE = 12 * BYTES_PER_WORD
+    _CONFIG_SIZE = 13 * BYTES_PER_WORD
     _PROVENANCE_REGION_SIZE = 2 * BYTES_PER_WORD
+    _KEY_ENTRY_SIZE = 3 * BYTES_PER_WORD
 
     def __init__(
             self, lpg_params, constraints=None, app_vertex=None, label=None):
@@ -71,14 +72,12 @@ class LivePacketGatherMachineVertex(
             label or lpg_params.label, constraints=constraints,
             app_vertex=app_vertex)
 
-        self._resources_required = ResourceContainer(
-            cpu_cycles=CPUCyclesPerTickResource(self.get_cpu_usage()),
-            dtcm=DTCMResource(self.get_dtcm_usage()),
-            sdram=ConstantSDRAM(self.get_sdram_usage()),
-            iptags=[lpg_params.get_iptag_resource()])
-
         # app specific data items
         self._lpg_params = lpg_params
+        self._incoming_edges = list()
+
+    def add_incoming_edge(self, edge):
+        self._incoming_edges.append(edge)
 
     @property
     @overrides(ProvidesProvenanceDataFromMachineImpl._provenance_region_id)
@@ -90,10 +89,20 @@ class LivePacketGatherMachineVertex(
     def _n_additional_data_items(self):
         return self._N_ADDITIONAL_PROVENANCE_ITEMS
 
+    def _get_key_translation_sdram(self):
+        if not self._lpg_params.translate_keys:
+            return 0
+        return len(self._incoming_edges) * self._KEY_ENTRY_SIZE
+
     @property
     @overrides(MachineVertex.resources_required)
     def resources_required(self):
-        return self._resources_required
+        return ResourceContainer(
+            cpu_cycles=CPUCyclesPerTickResource(self.get_cpu_usage()),
+            dtcm=DTCMResource(self.get_dtcm_usage()),
+            sdram=ConstantSDRAM(self.get_sdram_usage() +
+                                self._get_key_translation_sdram()),
+            iptags=[self._lpg_params.get_iptag_resource()])
 
     @property
     @overrides(AbstractSupportsDatabaseInjection.is_in_injection_mode)
@@ -138,13 +147,14 @@ class LivePacketGatherMachineVertex(
     def get_binary_start_type(self):
         return ExecutableType.USES_SIMULATION_INTERFACE
 
-    @inject_items({"tags": "Tags"})
+    @inject_items({"tags": "Tags",
+                   "routing_info": "RoutingInfos"})
     @overrides(
         AbstractGeneratesDataSpecification.generate_data_specification,
-        additional_arguments={"tags"})
+        additional_arguments={"tags", "routing_info"})
     def generate_data_specification(
             self, spec, placement,  # @UnusedVariable
-            tags):
+            tags, routing_info):
         """
         :param ~pacman.model.tags.Tags tags:
         """
@@ -155,7 +165,7 @@ class LivePacketGatherMachineVertex(
         self._reserve_memory_regions(spec)
         self._write_setup_info(spec)
         self._write_configuration_region(
-            spec, tags.get_ip_tags_for_vertex(self))
+            spec, tags.get_ip_tags_for_vertex(self), routing_info)
 
         # End-of-Spec:
         spec.end_specification()
@@ -173,15 +183,18 @@ class LivePacketGatherMachineVertex(
             size=SIMULATION_N_BYTES, label='system')
         spec.reserve_memory_region(
             region=self._REGIONS.CONFIG,
-            size=self._CONFIG_SIZE, label='config')
+            size=self._CONFIG_SIZE + self._get_key_translation_sdram(),
+            label='config')
         self.reserve_provenance_data_region(spec)
 
-    def _write_configuration_region(self, spec, iptags):
+    def _write_configuration_region(self, spec, iptags, routing_info):
         """ Write the configuration region to the spec
 
         :param ~.DataSpecificationGenerator spec:
         :param iterable(~.IPTag) iptags:
             The set of IP tags assigned to the object
+        :param RoutingInfo routing_info:
+            Routing information for incoming keys if needed
         :raise ConfigurationException: if `iptags` is empty
         :raise DataSpecificationException:
             when something goes wrong with the DSG generation
@@ -211,6 +224,17 @@ class LivePacketGatherMachineVertex(
 
         # number of packets to send per time stamp
         spec.write_value(self._lpg_params.number_of_packets_sent_per_time_step)
+
+        # Key Translation
+        if not self._lpg_params.translate_keys:
+            spec.write_value(0)
+        else:
+            spec.write_value(len(self._incoming_edges))
+            for edge in self._incoming_edges:
+                r_info = routing_info.get_routing_info_for_edge(edge)
+                spec.write_value(r_info.key)
+                spec.write_value(r_info.mask)
+                spec.write_value(edge.pre_vertex.vertex_slice.lo_atom)
 
     def _write_setup_info(self, spec):
         """ Write basic info to the system region


### PR DESCRIPTION
Updates Live Packet Gather to add a translation function.  This allows multiple keys coming from different cores to be translated into simple neuron IDs.  Other features already present in the LPG then allow a global key to be added to this if required.

See SpiNNakerManchester/sPyNNaker#1138 for integration test, which also shows the key prefixing (note this is not required, just an option).