### PR TITLE
Dont save config values in ASB

### DIFF
--- a/fec_integration_tests/file_convertor_tests/test_write_json_machine.py
+++ b/fec_integration_tests/file_convertor_tests/test_write_json_machine.py
@@ -143,7 +143,6 @@ class TestWriteJson(unittest.TestCase):
         set_config("Machine", "spalloc_server", self.spalloc)
         set_config("Machine", "spalloc_port", self.spin2Port)
 
-
         try:
             (hostname, version, _, _, _, _, _, m_allocation_controller) = \
                 spalloc_allocator(n_chips=20)

--- a/fec_integration_tests/file_convertor_tests/test_write_json_machine.py
+++ b/fec_integration_tests/file_convertor_tests/test_write_json_machine.py
@@ -140,11 +140,13 @@ class TestWriteJson(unittest.TestCase):
             raise unittest.SkipTest(self.spalloc + " appears to be down")
         set_config(
             "Machine", "spalloc_user", "Integration testing ok to kill")
+        set_config("Machine", "spalloc_server", self.spalloc)
         set_config("Machine", "spalloc_port", self.spin2Port)
+
 
         try:
             (hostname, version, _, _, _, _, _, m_allocation_controller) = \
-                spalloc_allocator(spalloc_server=self.spalloc, n_chips=20)
+                spalloc_allocator(n_chips=20)
         except (JobDestroyedError):
             self.skipTest("Skipping as getting Job failed")
 

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -526,6 +526,8 @@ class AbstractSpinnakerBase(ConfigHandler):
         # Safety in case a previous run left a bad state
         clear_injectables()
 
+        self.check_machine_specifics()
+
     def _new_run_clear(self):
         """
         This clears all data that if no longer valid after a hard reset
@@ -764,24 +766,6 @@ class AbstractSpinnakerBase(ConfigHandler):
                 "Only one of machineName, spalloc_server, "
                 "remote_spinnaker_url and virtual_board should be specified "
                 "in your configuration files")
-
-    @property
-    def hostname(self):
-        """
-        The machine_name, spalloc_server, remote_spinnaker_url or Virtual
-
-        This method assume one and only one of those is set
-
-        :rtype: str
-        """
-        hostname = get_config_str("Machine", "machine_name")
-        if hostname is None:
-            hostname = get_config_str("Machine", "spalloc_server")
-            if hostname is None:
-                hostname = get_config_str("Machine", "remote_spinnaker_url")
-                if hostname is None:
-                    hostname = "Virtual_machine"
-        return hostname
 
     def _setup_java_caller(self):
         if get_config_bool("Java", "use_java"):
@@ -3401,7 +3385,7 @@ class AbstractSpinnakerBase(ConfigHandler):
         return 0.0
 
     def __repr__(self):
-        return f"general front end instance for machine {self.hostname}"
+        return f"general front end instance for machine {self._ipaddress}"
 
     def add_application_vertex(self, vertex):
         """

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -190,7 +190,7 @@ class AbstractSpinnakerBase(ConfigHandler):
         # Either hostname or the ipaddress form the allocator
         "_ipaddress",
 
-         # the connection to allocted spalloc and HBP machines
+        # the connection to allocted spalloc and HBP machines
         "_machine_allocation_controller",
 
         # the pacman application graph, used to hold vertices which need to be

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -526,8 +526,6 @@ class AbstractSpinnakerBase(ConfigHandler):
         # Safety in case a previous run left a bad state
         clear_injectables()
 
-        self.check_machine_specifics()
-
     def _new_run_clear(self):
         """
         This clears all data that if no longer valid after a hard reset
@@ -742,6 +740,8 @@ class AbstractSpinnakerBase(ConfigHandler):
     def check_machine_specifics(self):
         """ Checks machine specifics for the different modes of execution.
 
+        Not this can only be called from a class that sets the config file
+        to read this data from.
         """
         n_items_specified = 0
         if get_config_str("Machine", "machine_name"):

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -187,24 +187,10 @@ class AbstractSpinnakerBase(ConfigHandler):
         "_n_chips_required",
 
         # The IP-address of the SpiNNaker machine
-        # provided during init and never changed
-        # init or cfg param and never changed
-        "_hostname",
-
-        # The IP-address of the SpiNNaker machine
         # Either hostname or the ipaddress form the allocator
         "_ipaddress",
 
-        # the ip_address of the spalloc server
-        # provided during init and never changed
-        # cfg param and never changed
-        "_spalloc_server",
-
-        # the URL for the HBP platform interface
-        # cfg param and never changed
-        "_remote_spinnaker_url",
-
-        # the connection to allocted spalloc and HBP machines
+         # the connection to allocted spalloc and HBP machines
         "_machine_allocation_controller",
 
         # the pacman application graph, used to hold vertices which need to be
@@ -475,8 +461,6 @@ class AbstractSpinnakerBase(ConfigHandler):
             raise ConfigurationException(
                 "Please use at most one of n_chips_required or "
                 "n_boards_required")
-        self._spalloc_server = None
-        self._remote_spinnaker_url = None
 
         # store for Live Packet Gatherers
         self._live_packet_recorder_params = defaultdict(list)
@@ -536,7 +520,6 @@ class AbstractSpinnakerBase(ConfigHandler):
         self._vertices_or_edges_added = False
         self._first_machine_time_step = None
         self._compressor_provenance = None
-        self._hostname = None
 
         FecTimer.setup(self)
 
@@ -754,46 +737,51 @@ class AbstractSpinnakerBase(ConfigHandler):
                 "Only one type of graph can be used during live output. "
                 "Please fix and try again")
 
-    def set_up_machine_specifics(self, hostname):
-        """ Adds machine specifics for the different modes of execution.
+    def check_machine_specifics(self):
+        """ Checks machine specifics for the different modes of execution.
 
-        :param str hostname: machine name
         """
-        if hostname is not None:
-            self._hostname = hostname
-            logger.warning("The machine name from setup call is overriding "
-                           "the machine name defined in the config file")
-        else:
-            self._hostname = get_config_str("Machine", "machine_name")
-            self._spalloc_server = get_config_str(
-                "Machine", "spalloc_server")
-            self._remote_spinnaker_url = get_config_str(
-                "Machine", "remote_spinnaker_url")
+        n_items_specified = 0
+        if get_config_str("Machine", "machine_name"):
+            n_items_specified += 1
+        if get_config_str("Machine", "spalloc_server"):
+            if get_config_str("Machine", "spalloc_user") is None:
+                raise Exception(
+                    "A spalloc_user must be specified with a spalloc_server")
+            n_items_specified += 1
+        if get_config_str("Machine", "remote_spinnaker_url"):
+            n_items_specified += 1
+        if get_config_bool("Machine", "virtual_board"):
+            n_items_specified += 1
 
-        if (self._hostname is None and self._spalloc_server is None and
-                self._remote_spinnaker_url is None and
-                not self._use_virtual_board):
+        if n_items_specified == 0:
             raise ConfigurationException(
                 "See http://spinnakermanchester.github.io/spynnaker/"
                 "PyNNOnSpinnakerInstall.html Configuration Section")
 
-        n_items_specified = sum(
-            item is not None
-            for item in [
-                self._hostname, self._spalloc_server,
-                self._remote_spinnaker_url])
-
-        if (n_items_specified > 1 or
-                (n_items_specified == 1 and self._use_virtual_board)):
+        if n_items_specified > 1:
             raise Exception(
                 "Only one of machineName, spalloc_server, "
                 "remote_spinnaker_url and virtual_board should be specified "
                 "in your configuration files")
 
-        if self._spalloc_server is not None:
-            if get_config_str("Machine", "spalloc_user") is None:
-                raise Exception(
-                    "A spalloc_user must be specified with a spalloc_server")
+    @property
+    def hostname(self):
+        """
+        The machine_name, spalloc_server, remote_spinnaker_url or Virtual
+
+        This method assume one and only one of those is set
+
+        :rtype: str
+        """
+        hostname = get_config_str("Machine", "machine_name")
+        if hostname is None:
+            hostname = get_config_str("Machine", "spalloc_server")
+            if hostname is None:
+                hostname = get_config_str("Machine", "remote_spinnaker_url")
+                if hostname is None:
+                    hostname = "Virtual_machine"
+        return hostname
 
     def _setup_java_caller(self):
         if get_config_bool("Java", "use_java"):
@@ -1270,24 +1258,20 @@ class AbstractSpinnakerBase(ConfigHandler):
         """
         if self._machine:
             return None
-        if self._hostname:
-            return None
         if self._n_chips_needed:
             n_chips_required = self._n_chips_needed
         else:
             n_chips_required = self._n_chips_required
         if n_chips_required is None and self._n_boards_required is None:
             return None
-        if self._spalloc_server is not None:
+        if get_config_str("Machine", "spalloc_server") is not None:
             with FecTimer(category, "SpallocAllocator"):
                 return spalloc_allocator(
-                    self._spalloc_server, n_chips_required,
-                    self._n_boards_required)
-        else:
+                    n_chips_required, self._n_boards_required)
+        if get_config_str("Machine", "remote_spinnaker_url") is not None:
             with FecTimer(category, "HBPAllocator"):
                 return hbp_allocator(
-                    self._remote_spinnaker_url, total_run_time,
-                    n_chips_required, self._n_boards_required)
+                    total_run_time, n_chips_required, self._n_boards_required)
 
     def _execute_machine_generator(self, category, allocator_data):
         """
@@ -1306,8 +1290,8 @@ class AbstractSpinnakerBase(ConfigHandler):
         """
         if self._machine:
             return
-        if self._hostname:
-            self._ipaddress = self._hostname
+        if get_config_str("Machine", "machine_name"):
+            self._ipaddress = get_config_str("Machine", "machine_name")
             bmp_details = get_config_str("Machine", "bmp_names")
             auto_detect_bmp = get_config_bool(
                 "Machine", "auto_detect_bmp")
@@ -1351,16 +1335,13 @@ class AbstractSpinnakerBase(ConfigHandler):
             return self._machine
 
         self._max_machine = True
-        if self._spalloc_server:
+        if get_config_str("Machine", "spalloc_server"):
             with FecTimer(GET_MACHINE, "Spalloc max machine generator"):
-                self._machine = spalloc_max_machine_generator(
-                    self._spalloc_server)
+                self._machine = spalloc_max_machine_generator()
 
-        elif self._remote_spinnaker_url:
+        elif get_config_str("Machine", "remote_spinnaker_url"):
             with FecTimer(GET_MACHINE, "HBPMaxMachineGenerator"):
-                self._machine = hbp_max_machine_generator(
-                    self._remote_spinnaker_url, total_run_time,
-                    )
+                self._machine = hbp_max_machine_generator(total_run_time)
 
         else:
             raise NotImplementedError("No machine generataion possible")
@@ -2838,15 +2819,12 @@ class AbstractSpinnakerBase(ConfigHandler):
                 run_time, self._buffer_manager, self._mapping_time,
                 self._load_time, self._execute_time, self._dsg_time,
                 self._extraction_time,
-                self._spalloc_server, self._remote_spinnaker_url,
                 self._machine_allocation_controller)
 
             energy_provenance_reporter(power_used, self._placements)
 
             # create energy reporter
-            energy_reporter = EnergyReport(
-                get_config_int("Machine", "version"), self._spalloc_server,
-                self._remote_spinnaker_url)
+            energy_reporter = EnergyReport()
 
             # run energy report
             energy_reporter.write_energy_report(
@@ -3423,10 +3401,7 @@ class AbstractSpinnakerBase(ConfigHandler):
         return 0.0
 
     def __repr__(self):
-        if self._ipaddress:
-            return f"general front end instance for machine {self._ipaddress}"
-        else:
-            return f"general front end instance for machine {self._hostname}"
+        return f"general front end instance for machine {self.hostname}"
 
     def add_application_vertex(self, vertex):
         """

--- a/spinn_front_end_common/interface/interface_functions/compute_energy_used.py
+++ b/spinn_front_end_common/interface/interface_functions/compute_energy_used.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import itertools
-from spinn_utilities.config_holder import get_config_int
+from spinn_utilities.config_holder import (get_config_int, get_config_str)
 from spinn_utilities.ordered_set import OrderedSet
 from spinn_front_end_common.interface.provenance import ProvenanceReader
 from spinn_front_end_common.utilities.utility_objs import PowerUsed
@@ -63,7 +63,6 @@ N_MONITORS_ACTIVE_DURING_COMMS = 2
 def compute_energy_used(
         placements, machine, version, runtime, buffer_manager, mapping_time,
         load_time, execute_time, dsg_time, extraction_time,
-        spalloc_server=None, remote_spinnaker_url=None,
         machine_allocation_controller=None):
     """ This algorithm does the actual work of computing energy used by a\
         simulation (or other application) running on SpiNNaker.
@@ -105,10 +104,9 @@ def compute_energy_used(
     power_used.data_gen_time_secs = dsg_time / _MS_PER_SECOND
     power_used.mapping_time_secs = mapping_time / _MS_PER_SECOND
 
-    using_spalloc = bool(spalloc_server or remote_spinnaker_url)
     runtime_total_ms = runtime * time_scale_factor()
     _compute_energy_consumption(
-         placements, machine, version, using_spalloc,
+         placements, machine, version,
          dsg_time, buffer_manager, load_time,
          mapping_time, execute_time + load_time + extraction_time,
          machine_allocation_controller,
@@ -118,14 +116,13 @@ def compute_energy_used(
 
 
 def _compute_energy_consumption(
-        placements, machine, version, using_spalloc, dsg_time, buffer_manager,
+        placements, machine, version, dsg_time, buffer_manager,
         load_time, mapping_time, total_booted_time, job, runtime_total_ms,
         power_used):
     """
     :param ~.Placements placements:
     :param ~.Machine machine:
     :param int version:
-    :param bool using_spalloc:
     :param float dsg_time:
     :param BufferManager buffer_manager:
     :param float load_time:
@@ -143,7 +140,7 @@ def _compute_energy_consumption(
 
     # figure FPGA cost over all booted and during runtime cost
     _calculate_fpga_energy(
-        machine, version, using_spalloc, total_booted_time,
+        machine, version, total_booted_time,
         runtime_total_ms, power_used)
 
     # figure how many frames are using, as this is a constant cost of
@@ -291,12 +288,11 @@ def __get_chip_power_monitor(chip, placements):
 
 
 def _calculate_fpga_energy(
-        machine, version, using_spalloc, total_runtime, runtime_total_ms,
+        machine, version, total_runtime, runtime_total_ms,
         power_used):
     """
     :param ~.Machine machine:
     :param int version:
-    :param bool using_spalloc:
     :param float total_runtime:
     :param float runtime_total_ms:
     :param PowerUsed power_used:
@@ -305,7 +301,8 @@ def _calculate_fpga_energy(
 
     total_fpgas = 0
     # if not spalloc, then could be any type of board
-    if not using_spalloc:
+    if (not get_config_str("Machine", "spalloc_server") and
+            not get_config_str("Machine", "remote_spinnaker_url")):
         # if a spinn2 or spinn3 (4 chip boards) then they have no fpgas
         if int(version) in (2, 3):
             return 0, 0

--- a/spinn_front_end_common/interface/interface_functions/hbp_allocator.py
+++ b/spinn_front_end_common/interface/interface_functions/hbp_allocator.py
@@ -126,7 +126,7 @@ def hbp_allocator(total_run_time, n_chips=None, n_boards=None):
         If neither `n_chips` or `n_boards` provided
     """
 
-    url = get_config_str("Machine", "remote_spinnaker_url")
+    url = str(get_config_str("Machine", "remote_spinnaker_url"))
     if url.endswith("/"):
         url = url[:-1]
 

--- a/spinn_front_end_common/interface/interface_functions/hbp_allocator.py
+++ b/spinn_front_end_common/interface/interface_functions/hbp_allocator.py
@@ -15,6 +15,7 @@
 
 import logging
 import requests
+from spinn_utilities.config_holder import get_config_str
 from spinn_utilities.overrides import overrides
 from spinn_front_end_common.abstract_models.impl import (
     MachineAllocationController)
@@ -108,12 +109,10 @@ class _HBPJobController(MachineAllocationController):
         return self._check_lease(self._WAIT_TIME_MS)["allocated"]
 
 
-def hbp_allocator(hbp_server_url, total_run_time, n_chips=None, n_boards=None):
+def hbp_allocator(total_run_time, n_chips=None, n_boards=None):
     """ Request a machine from the HBP remote access server that will fit\
         a number of chips.
 
-    :param str hbp_server_url:
-        The URL of the HBP server from which to get the machine
     :param int total_run_time: The total run time to request
     :param int n_chips: The number of chips required.
         Only used if n_boards is None
@@ -127,7 +126,7 @@ def hbp_allocator(hbp_server_url, total_run_time, n_chips=None, n_boards=None):
         If neither `n_chips` or `n_boards` provided
     """
 
-    url = hbp_server_url
+    url = get_config_str("Machine", "remote_spinnaker_url")
     if url.endswith("/"):
         url = url[:-1]
 

--- a/spinn_front_end_common/interface/interface_functions/hbp_max_machine_generator.py
+++ b/spinn_front_end_common/interface/interface_functions/hbp_max_machine_generator.py
@@ -14,23 +14,22 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import requests
-from spinn_utilities.config_holder import get_config_int
+from spinn_utilities.config_holder import (get_config_int, get_config_str)
 from spinn_machine import Machine
 from spinn_machine.virtual_machine import virtual_machine
 
 
-def hbp_max_machine_generator(hbp_server_url, total_run_time):
+def hbp_max_machine_generator(total_run_time):
     """ Generates a virtual machine of the width and height of the maximum\
         machine a given HBP server can generate.
 
-    :param str hbp_server_url:
-        The URL of the HBP server from which to get the machine
     :param int total_run_time: The total run time to request
     :rtype: ~spinn_machine.Machine
     """
     max_machine_core_reduction = get_config_int(
         "Machine", "max_machine_core_reduction")
-    max_machine = _max_machine_request(hbp_server_url, total_run_time)
+    max_machine = _max_machine_request(
+        get_config_str("Machine", "remote_spinnaker_url"), total_run_time)
 
     n_cpus_per_chip = (Machine.max_cores_per_chip() -
                        max_machine_core_reduction)

--- a/spinn_front_end_common/interface/interface_functions/spalloc_allocator.py
+++ b/spinn_front_end_common/interface/interface_functions/spalloc_allocator.py
@@ -104,12 +104,10 @@ class _SpallocJobController(MachineAllocationController):
 _MACHINE_VERSION = 5
 
 
-def spalloc_allocator(spalloc_server, n_chips=None, n_boards=None):
+def spalloc_allocator(n_chips=None, n_boards=None):
     """ Request a machine from a SPALLOC server that will fit the given\
         number of chips.
 
-    :param str spalloc_server:
-        The server from which the machine should be requested
     :param n_chips: The number of chips required.
         IGNORED if n_boards is not None
     :type n_chips: int or None
@@ -130,7 +128,7 @@ def spalloc_allocator(spalloc_server, n_chips=None, n_boards=None):
         n_boards = int(math.ceil(n_boards))
 
     spalloc_kw_args = {
-        'hostname': spalloc_server,
+        'hostname': get_config_str("Machine", "spalloc_server"),
         'owner': get_config_str("Machine", "spalloc_user")
     }
     spalloc_port = get_config_int("Machine", "spalloc_port")

--- a/spinn_front_end_common/interface/interface_functions/spalloc_max_machine_generator.py
+++ b/spinn_front_end_common/interface/interface_functions/spalloc_max_machine_generator.py
@@ -19,14 +19,14 @@ from spinn_machine.virtual_machine import virtual_machine
 from spinn_machine.machine import Machine
 
 
-def spalloc_max_machine_generator(spalloc_server):
+def spalloc_max_machine_generator():
     """
     Generates a maximum virtual machine a given allocation server can generate.
 
-    :param str spalloc_server:
     :return: A virtual machine
     :rtype: ~spinn_machine.Machine
     """
+    spalloc_server = get_config_str("Machine", "spalloc_server")
     spalloc_port = get_config_int("Machine", "spalloc_port")
     spalloc_machine = get_config_str("Machine", "spalloc_machine")
     max_machine_core_reduction = get_config_int(

--- a/spinn_front_end_common/utilities/report_functions/energy_report.py
+++ b/spinn_front_end_common/utilities/report_functions/energy_report.py
@@ -233,11 +233,11 @@ class EnergyReport(object):
         :param ~io.TextIOBase f: the file writer
         """
 
+        version = get_config_int("Machine", "version")
         # if not spalloc, then could be any type of board
         if (not get_config_str("Machine", "spalloc_server") and
                 not get_config_str("Machine", "remote_spinnaker_url")):
             # if a spinn2 or spinn3 (4 chip boards) then they have no fpgas
-            version = get_config_int("Machine", "version")
             if int(version) in (2, 3):
                 f.write(
                     f"A SpiNN-{version} board does not contain any FPGA's,"

--- a/spinn_front_end_common/utilities/report_functions/energy_report.py
+++ b/spinn_front_end_common/utilities/report_functions/energy_report.py
@@ -16,6 +16,7 @@
 from collections import defaultdict
 import logging
 import os
+from spinn_utilities.config_holder import (get_config_int, get_config_str)
 from spinn_utilities.log import FormatAdapter
 from spinn_front_end_common.interface.provenance import (
     APPLICATION_RUNNER, LOADING, ProvenanceReader)
@@ -39,7 +40,7 @@ class EnergyReport(object):
         consumed by a SpiNNaker job execution.
     """
 
-    __slots__ = ("__version", "__uses_spalloc")
+    __slots__ = ()
 
     #: converter between joules to kilowatt hours
     JOULES_TO_KILOWATT_HOURS = 3600000
@@ -47,15 +48,6 @@ class EnergyReport(object):
     # energy report file name
     _DETAILED_FILENAME = "detailed_energy_report.rpt"
     _SUMMARY_FILENAME = "summary_energy_report.rpt"
-
-    def __init__(self, version, spalloc_server, remote_spinnaker_url):
-        """
-        :param int version: version of machine
-        :param str spalloc_server: spalloc server IP
-        :param str remote_spinnaker_url: remote SpiNNaker URL
-        """
-        self.__version = version
-        self.__uses_spalloc = bool(spalloc_server or remote_spinnaker_url)
 
     def write_energy_report(
             self, placements, machine, runtime, buffer_manager, power_used):
@@ -242,14 +234,16 @@ class EnergyReport(object):
         """
 
         # if not spalloc, then could be any type of board
-        if not self.__uses_spalloc:
+        if (not get_config_str("Machine", "spalloc_server") and
+                not get_config_str("Machine", "remote_spinnaker_url")):
             # if a spinn2 or spinn3 (4 chip boards) then they have no fpgas
-            if int(self.__version) in (2, 3):
+            version = get_config_int("Machine", "version")
+            if int(version) in (2, 3):
                 f.write(
-                    "A SpiNN-{} board does not contain any FPGA's, and so "
-                    "its energy cost is 0 \n".format(self.__version))
+                    f"A SpiNN-{version} board does not contain any FPGA's,"
+                    f" and so its energy cost is 0 \n")
                 return
-            elif int(self.__version) not in (4, 5):
+            elif int(version) not in (4, 5):
                 # no idea where we are; version unrecognised
                 raise ConfigurationException(
                     "Do not know what the FPGA setup is for this version of "
@@ -260,14 +254,13 @@ class EnergyReport(object):
             if power_used.num_fpgas == 0:
                 # no active fpgas
                 f.write(
-                    "The FPGA's on the SpiNN-{} board are turned off and "
-                    "therefore the energy used by the FPGA is 0\n".format(
-                        self.__version))
+                    f"The FPGA's on the SpiNN-{version} board are turned off "
+                    f"and therefore the energy used by the FPGA is 0\n")
                 return
             # active fpgas; fall through to shared main part report
 
         # print out as needed for spalloc and non-spalloc versions
-        if self.__version is None:
+        if version is None:
             f.write(
                 "{} FPGAs on the Spalloc-ed boards are turned on and "
                 "therefore the energy used by the FPGA during the entire time "
@@ -282,7 +275,7 @@ class EnergyReport(object):
                 "therefore the energy used by the FPGA during the entire time "
                 "the machine was booted (which was {} ms) is {}. "
                 "The usage during execution was {}".format(
-                    power_used.num_fpgas, self.__version,
+                    power_used.num_fpgas, version,
                     power_used.total_time_secs * 1000,
                     power_used.fpga_total_energy_joules,
                     power_used.fpga_exec_energy_joules))

--- a/unittests/interface/interface_functions/test_front_end_common_spalloc_max_machine_generator.py
+++ b/unittests/interface/interface_functions/test_front_end_common_spalloc_max_machine_generator.py
@@ -65,7 +65,8 @@ class TestFrontEndCommonSpallocMaxMachineGenerator(unittest.TestCase):
             "test", 1, 1, [(0, 0, 1), (0, 0, 2)], [], ["default"])
         server.start()
         set_config("Machine", "spalloc_port", server.port)
-        machine = spalloc_max_machine_generator("localhost")
+        set_config("Machine", "spalloc_server", "localhost")
+        machine = spalloc_max_machine_generator()
         self.assertEqual(machine.max_chip_x, 7)
         self.assertEqual(machine.max_chip_y, 7)
 
@@ -74,7 +75,8 @@ class TestFrontEndCommonSpallocMaxMachineGenerator(unittest.TestCase):
             "test", 1, 1, [], [], ["default"])
         server.start()
         set_config("Machine", "spalloc_port", server.port)
-        machine = spalloc_max_machine_generator("localhost")
+        set_config("Machine", "spalloc_server", "localhost")
+        machine = spalloc_max_machine_generator()
         self.assertEqual(machine.max_chip_x, 11)
         self.assertEqual(machine.max_chip_y, 11)
 
@@ -84,7 +86,8 @@ class TestFrontEndCommonSpallocMaxMachineGenerator(unittest.TestCase):
         server.start()
         set_config("Machine", "spalloc_port", server.port)
         set_config("Machine", "spalloc_machine", "test")
-        machine = spalloc_max_machine_generator("localhost")
+        set_config("Machine", "spalloc_server", "localhost")
+        machine = spalloc_max_machine_generator()
         self.assertEqual(machine.max_chip_x, (12 * 3) - 1)
         self.assertEqual(machine.max_chip_y, (12 * 2) - 1)
 


### PR DESCRIPTION
This pr stops the saving of 
get_config_str("Machine", "machine_name")
get_config_str("Machine", "spalloc_server")
get_config_str("Machine", "remote_spinnaker_url")

as Values in AbstractSpinnakerBase

Instead the values are retrieved from configs as needed.

While this is similar to the global data work it is in a separate PR due to a few minor code changes.

hostname param has been removed.
Due to safety checks it would rarely have worked even had it been used.

repr methods just use ipaddress as if there is a machine_name (ex self._hostname) ipaddress is set to that anyway

set_up_machine_specifics replaced with check_machine_specifics 
Checks and errors should sill be the same.
Not moved inside ASB init as it depends on reading the spynnaker.cfg or spiNNakerGraphFrontEnd.cfg file 

default n_boards for spalloc removed from GFE
calling get_machine before run will now fails if on spalloc and no n_boards/n_chips provided. Same as Spynnaker

Must be done at the same time as:
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1145
https://github.com/SpiNNakerManchester/SpiNNakerGraphFrontEnd/pull/207

Tested by
https://github.com/SpiNNakerManchester/IntegrationTests/pull/94





