### PR TITLE
Category timing into provenance database

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -128,8 +128,6 @@ from spinn_front_end_common.utilities import globals_variables
 from spinn_front_end_common.utilities.constants import (
     SARK_PER_MALLOC_SDRAM_USAGE)
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
-from spinn_front_end_common.utilities.helpful_functions import (
-    convert_time_diff_to_total_milliseconds)
 from spinn_front_end_common.utilities.report_functions import (
     bitfield_compressor_report, board_chip_report, EnergyReport,
     fixed_route_from_machine_report, memory_map_on_host_report,
@@ -327,29 +325,9 @@ class AbstractSpinnakerBase(ConfigHandler):
         # mapping of live packet recorder parameters to vertex
         "_live_packet_recorder_parameters_mapping",
 
-        # the time the process takes to do mapping
-        # TODO energy report cleanup
-        "_mapping_time",
-
-        # the time the process takes to do load
-        # TODO energy report cleanup
-        "_load_time",
-
-        # the time takes to execute the simulation
-        # TODO energy report cleanup
-        "_execute_time",
-
         # the timer used to log the execute time
         # TODO energy report cleanup
         "_run_timer",
-
-        # time takes to do data generation
-        # TODO energy report cleanup
-        "_dsg_time",
-
-        # time taken by the front end extracting things
-        # TODO energy report cleanup
-        "_extraction_time",
 
         # Version information from the front end
         # TODO provenance cleanup
@@ -453,13 +431,6 @@ class AbstractSpinnakerBase(ConfigHandler):
         """
         # pylint: disable=too-many-arguments
         super().__init__()
-
-        # timings
-        self._mapping_time = 0.0
-        self._load_time = 0.0
-        self._execute_time = 0.0
-        self._dsg_time = 0.0
-        self._extraction_time = 0.0
 
         self._executable_finder = executable_finder
 
@@ -712,14 +683,6 @@ class AbstractSpinnakerBase(ConfigHandler):
             raise ConfigurationException(
                 "Clash with n_chips_required.")
         self._n_boards_required = n_boards_required
-
-    def add_extraction_timing(self, timing):
-        """ Record the time taken for doing data extraction.
-
-        :param ~datetime.timedelta timing:
-        """
-        ms = convert_time_diff_to_total_milliseconds(timing)
-        self._extraction_time += ms
 
     def add_live_packet_gatherer_parameters(
             self, live_packet_gatherer_params, vertex_to_record_from,
@@ -2193,8 +2156,10 @@ class AbstractSpinnakerBase(ConfigHandler):
         self._execute_sdram_outgoing_partition_allocator()
 
         clear_injectables()
-        self._mapping_time += convert_time_diff_to_total_milliseconds(
-            mapping_total_timer.take_sample())
+        with ProvenanceWriter() as db:
+            db.insert_category_timing(
+                MAPPING, mapping_total_timer.take_sample(),
+                self._n_calls_to_run, self._n_loops)
 
     # Overridden by spy which adds placement_order
     def _execute_graph_data_specification_writer(self):
@@ -2224,8 +2189,10 @@ class AbstractSpinnakerBase(ConfigHandler):
         self._execute_graph_data_specification_writer()
         clear_injectables()
 
-        self._dsg_time += convert_time_diff_to_total_milliseconds(
-            data_gen_timer.take_sample())
+        with ProvenanceWriter() as db:
+            db.insert_category_timing(
+                DATA_GENERATION, data_gen_timer.take_sample(),
+                self._n_calls_to_run, self._n_loops)
 
     def _execute_routing_setup(self,):
         """
@@ -2735,8 +2702,10 @@ class AbstractSpinnakerBase(ConfigHandler):
             self._report_fixed_routes()
         self._execute_application_load_executables()
 
-        self._load_time += convert_time_diff_to_total_milliseconds(
-            load_timer.take_sample())
+        with ProvenanceWriter() as db:
+            db.insert_category_timing(
+                LOADING, load_timer.take_sample(),
+                self._n_calls_to_run, self._n_loops)
 
     def _execute_sdram_usage_report_per_chip(self):
         # TODO why in do run
@@ -2835,9 +2804,7 @@ class AbstractSpinnakerBase(ConfigHandler):
             # TODO runtime is None
             power_used = compute_energy_used(
                 self._placements, self._machine, self._board_version,
-                run_time, self._buffer_manager, self._mapping_time,
-                self._load_time, self._execute_time, self._dsg_time,
-                self._extraction_time,
+                run_time, self._buffer_manager,
                 self._spalloc_server, self._remote_spinnaker_url,
                 self._machine_allocation_controller)
 
@@ -2984,8 +2951,11 @@ class AbstractSpinnakerBase(ConfigHandler):
 
         # FinaliseTimingData never needed as just pushed self._ to inputs
         self._do_read_provenance()
-        self._execute_time += convert_time_diff_to_total_milliseconds(
-            self._run_timer.take_sample())
+        with ProvenanceWriter() as db:
+            db.insert_category_timing(
+                RUN_LOOP, self._run_timer.take_sample(),
+                self._n_calls_to_run, self._n_loops)
+
         self._report_energy(run_time)
         self._do_provenance_reports()
 

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -36,11 +36,12 @@ from spinn_front_end_common.utilities.exceptions import (
     BufferableRegionTooSmall, SpinnFrontEndException)
 from spinn_front_end_common.utilities.helpful_functions import (
     locate_memory_region_for_placement, locate_extra_monitor_mc_receiver)
-from spinn_front_end_common.utilities.globals_variables import get_simulator
 from spinn_front_end_common.interface.buffer_management.storage_objects \
     import (BuffersSentDeque, BufferedReceivingData)
 from spinn_front_end_common.interface.buffer_management.buffer_models \
     import AbstractReceiveBuffersToHost
+from spinn_front_end_common.interface.provenance import (
+    BUFFER, ProvenanceWriter)
 from .recording_utilities import get_recording_header_size
 
 logger = FormatAdapter(logging.getLogger(__name__))
@@ -609,7 +610,9 @@ class BufferManager(object):
                         placements, progress)
                 else:
                     self.__old_get_data_for_placements(placements, progress)
-        get_simulator().add_extraction_timing(timer.measured_interval)
+        with ProvenanceWriter() as db:
+            db.insert_category_timing(
+                BUFFER, timer.measured_interval, None, None)
 
     def __old_get_data_for_placements_with_monitors(
             self, placements, progress):

--- a/spinn_front_end_common/interface/interface_functions/compute_energy_used.py
+++ b/spinn_front_end_common/interface/interface_functions/compute_energy_used.py
@@ -23,7 +23,7 @@ from spinn_front_end_common.utility_models import (
     ChipPowerMonitorMachineVertex)
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from spinn_front_end_common.utilities.globals_variables import (
-    get_simulator, time_scale_factor)
+    time_scale_factor)
 
 #: milliseconds per second
 _MS_PER_SECOND = 1000.0

--- a/spinn_front_end_common/interface/interface_functions/compute_energy_used.py
+++ b/spinn_front_end_common/interface/interface_functions/compute_energy_used.py
@@ -16,7 +16,8 @@
 import itertools
 from spinn_utilities.config_holder import get_config_int
 from spinn_utilities.ordered_set import OrderedSet
-from spinn_front_end_common.interface.provenance import ProvenanceReader
+from spinn_front_end_common.interface.provenance import (
+    BUFFER, DATA_GENERATION, LOADING, MAPPING, ProvenanceReader, RUN_LOOP)
 from spinn_front_end_common.utilities.utility_objs import PowerUsed
 from spinn_front_end_common.utility_models import (
     ChipPowerMonitorMachineVertex)
@@ -61,8 +62,7 @@ N_MONITORS_ACTIVE_DURING_COMMS = 2
 
 
 def compute_energy_used(
-        placements, machine, version, runtime, buffer_manager, mapping_time,
-        load_time, execute_time, dsg_time, extraction_time,
+        placements, machine, version, runtime, buffer_manager,
         spalloc_server=None, remote_spinnaker_url=None,
         machine_allocation_controller=None):
     """ This algorithm does the actual work of computing energy used by a\
@@ -93,7 +93,14 @@ def compute_energy_used(
     :rtype: PowerUsed
     """
     # pylint: disable=too-many-arguments
-
+    db = ProvenanceReader()
+    dsg_time = db.get_category_timer_sum(DATA_GENERATION)
+    execute_time = db.get_category_timer_sum(RUN_LOOP)
+    # TODO some extraction time is also execute_time
+    extraction_time = db.get_category_timer_sum(BUFFER)
+    load_time = db.get_category_timer_sum(LOADING)
+    mapping_time = db.get_category_timer_sum(MAPPING)
+    # TODO get_machine not include here
     power_used = PowerUsed()
 
     power_used.num_chips = machine.n_chips
@@ -460,7 +467,7 @@ def _calculate_data_extraction_energy(machine, active_chips, n_frames):
 
     # find time
     # TODO is this what was desired
-    total_time_ms = get_simulator()._execute_time
+    total_time_ms = ProvenanceReader().get_category_timer_sum(BUFFER)
 
     # min between chips that are active and fixed monitor, as when 1
     # chip is used its one monitor, if more than 1 chip,

--- a/spinn_front_end_common/interface/provenance/__init__.py
+++ b/spinn_front_end_common/interface/provenance/__init__.py
@@ -30,6 +30,7 @@ LOADING = "loading"
 RUN_LOOP = "running"
 # Algorithm Names used elsewhere
 APPLICATION_RUNNER = "Application runner"
+BUFFER = "BufferExtraction"
 
 __all__ = ["AbstractProvidesLocalProvenanceData",
            "AbstractProvidesProvenanceDataFromMachine",

--- a/spinn_front_end_common/interface/provenance/db.sql
+++ b/spinn_front_end_common/interface/provenance/db.sql
@@ -32,7 +32,7 @@ CREATE TABLE IF NOT EXISTS power_provenance(
     the_value FLOAT NOT NULL);
 
 -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
--- A table holding the values for versions
+-- A table holding the values for algorithm timings
 CREATE TABLE IF NOT EXISTS timer_provenance(
     timer_id INTEGER PRIMARY KEY AUTOINCREMENT,
     category STRING NOT NULL,
@@ -47,6 +47,15 @@ CREATE VIEW IF NOT EXISTS timer_view AS
     FROM timer_provenance
     WHERE skip_reason is NULL
     ORDER BY timer_id;
+
+-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+-- A table holding the values for category timings
+CREATE TABLE IF NOT EXISTS category_timer_provenance(
+    timer_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    category STRING NOT NULL,
+    the_value INTEGER NOT NULL,
+    n_run INTEGER NOT NULL,
+    n_loop INTEGER);
 
 -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -- A table holding the values for uncategorised general provenance

--- a/spinn_front_end_common/interface/provenance/db.sql
+++ b/spinn_front_end_common/interface/provenance/db.sql
@@ -54,7 +54,7 @@ CREATE TABLE IF NOT EXISTS category_timer_provenance(
     timer_id INTEGER PRIMARY KEY AUTOINCREMENT,
     category STRING NOT NULL,
     the_value INTEGER NOT NULL,
-    n_run INTEGER NOT NULL,
+    n_run INTEGER,
     n_loop INTEGER);
 
 -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/spinn_front_end_common/interface/provenance/provenance_reader.py
+++ b/spinn_front_end_common/interface/provenance/provenance_reader.py
@@ -221,6 +221,25 @@ class ProvenanceReader(object):
         """
         return self.get_timer_provenance("%BufferExtractor")
 
+    def get_category_time(self, category):
+        """
+        Gets the total time for a category
+
+        :param str category: Category of the Algorithms run
+        :return: sum of all times for this category
+        :rtype: int
+        """
+        query = """
+            SELECT the_sum
+            FROM category_timer_view
+            WHERE category = ?
+            """
+        data = self.run_query(query, [category])
+        try:
+            return data
+        except IndexError:
+            return None
+
     def get_provenance_for_router(self, x, y):
         """
         Gets the provenance item(s) from the last run relating to a chip
@@ -297,6 +316,25 @@ class ProvenanceReader(object):
         data = self.run_query(query, [description])
         try:
             return data
+        except IndexError:
+            return None
+
+    def get_category_timer_sum(self, category):
+        """
+        Get the total runtime for one category of algorithms
+
+        :param str category:
+        :return: total off all runtimes with this category
+        :rtype: int
+        """
+        query = """
+             SELECT sum(the_value)
+             FROM category_timer_provenance
+             WHERE category = ?
+             """
+        data = self.run_query(query, [category])
+        try:
+            return data[0][0]
         except IndexError:
             return None
 

--- a/spinn_front_end_common/interface/provenance/provenance_reader.py
+++ b/spinn_front_end_common/interface/provenance/provenance_reader.py
@@ -221,25 +221,6 @@ class ProvenanceReader(object):
         """
         return self.get_timer_provenance("%BufferExtractor")
 
-    def get_category_time(self, category):
-        """
-        Gets the total time for a category
-
-        :param str category: Category of the Algorithms run
-        :return: sum of all times for this category
-        :rtype: int
-        """
-        query = """
-            SELECT the_sum
-            FROM category_timer_view
-            WHERE category = ?
-            """
-        data = self.run_query(query, [category])
-        try:
-            return data
-        except IndexError:
-            return None
-
     def get_provenance_for_router(self, x, y):
         """
         Gets the provenance item(s) from the last run relating to a chip

--- a/spinn_front_end_common/interface/provenance/provenance_writer.py
+++ b/spinn_front_end_common/interface/provenance/provenance_writer.py
@@ -93,6 +93,25 @@ class ProvenanceWriter(SQLiteDB):
                 VALUES(?, ?)
                 """, [description, the_value])
 
+    def insert_category_timing(self, category, the_value, n_run, n_loop):
+        """
+        Inserts algorithms run times into the timer_provenance table
+
+        :param str category: Category of the Algorithms run
+        :param int the_value: Runtime
+        :param int n_run: The end user run number
+        :param n_loop: The run loop within the ned user run
+        :type n_loop: int or None
+        """
+        with self.transaction() as cur:
+            cur.execute(
+                """
+                INSERT INTO category_timer_provenance(
+                    category, the_value, n_run, n_loop)
+                VALUES(?, ?, ?, ?)
+                """,
+                [category, the_value, n_run, n_loop])
+
     def insert_timing(
             self, category, algorithm, the_value, n_run, n_loop, skip_reason):
         """

--- a/spinn_front_end_common/interface/provenance/provenance_writer.py
+++ b/spinn_front_end_common/interface/provenance/provenance_writer.py
@@ -19,7 +19,8 @@ import re
 from spinn_utilities.config_holder import get_config_int
 from spinn_utilities.log import FormatAdapter
 from spinn_front_end_common.utilities import globals_variables
-from spinn_front_end_common.utilities.constants import PROVENANCE_DB
+from spinn_front_end_common.utilities.constants import (
+    MICRO_TO_MILLISECOND_CONVERSION, PROVENANCE_DB)
 from spinn_front_end_common.utilities.sqlite_db import SQLiteDB
 
 logger = FormatAdapter(logging.getLogger(__name__))
@@ -93,16 +94,20 @@ class ProvenanceWriter(SQLiteDB):
                 VALUES(?, ?)
                 """, [description, the_value])
 
-    def insert_category_timing(self, category, the_value, n_run, n_loop):
+    def insert_category_timing(self, category, timedelta, n_run, n_loop):
         """
         Inserts algorithms run times into the timer_provenance table
 
         :param str category: Category of the Algorithms run
-        :param int the_value: Runtime
+        :param ~datetime.timedelta timedelta: Time to be recorded
         :param int n_run: The end user run number
         :param n_loop: The run loop within the ned user run
         :type n_loop: int or None
         """
+        the_value = (
+                (timedelta.total_seconds() * MICRO_TO_MILLISECOND_CONVERSION) +
+                (timedelta.microseconds / MICRO_TO_MILLISECOND_CONVERSION))
+
         with self.transaction() as cur:
             cur.execute(
                 """

--- a/spinn_front_end_common/utilities/helpful_functions.py
+++ b/spinn_front_end_common/utilities/helpful_functions.py
@@ -22,7 +22,6 @@ from spinnman.model.enums import CPUState
 from . import utility_calls
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from spinn_front_end_common.utilities.utility_objs import ExecutableType
-from .constants import MICRO_TO_MILLISECOND_CONVERSION
 
 logger = FormatAdapter(logging.getLogger(__name__))
 _n_word_structs = []
@@ -182,17 +181,6 @@ def get_ethernet_chip(machine, board_address):
     raise ConfigurationException(
         "cannot find the Ethernet connected chip with the board address {}"
         .format(board_address))
-
-
-def convert_time_diff_to_total_milliseconds(sample):
-    """ Convert between a time diff and total milliseconds.
-
-    :param ~datetime.timedelta sample:
-    :return: total milliseconds
-    :rtype: float
-    """
-    return ((sample.total_seconds() * MICRO_TO_MILLISECOND_CONVERSION) +
-            (sample.microseconds / MICRO_TO_MILLISECOND_CONVERSION))
 
 
 def determine_flow_states(executable_types, no_sync_changes):

--- a/unittests/interface/provenance/test_provenance_database.py
+++ b/unittests/interface/provenance/test_provenance_database.py
@@ -77,6 +77,17 @@ class TestProvenanceDatabase(unittest.TestCase):
         data = reader.get_timer_sum_by_algorithm("junk")
         self.assertIsNone(data)
 
+    def test_category_timings(self):
+        with ProvenanceWriter() as db:
+            db.insert_category_timing("mapping", 12, 1, 1)
+            db.insert_category_timing("mapping", 123, 1, 2)
+            db.insert_category_timing("execute", 134, 1, None)
+            db.insert_category_timing("execute", 344, 1, 2)
+        reader = ProvenanceReader()
+        data = reader.get_category_timer_sum("mapping")
+        self.assertEqual(12 + 123, data)
+
+
     def test_other(self):
         with ProvenanceWriter() as db:
             db.insert_other("foo", "bar", 12)

--- a/unittests/interface/provenance/test_provenance_database.py
+++ b/unittests/interface/provenance/test_provenance_database.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from datetime import timedelta
 from testfixtures.logcapture import LogCapture
 import unittest
 from spinn_utilities.config_holder import set_config
@@ -79,13 +80,14 @@ class TestProvenanceDatabase(unittest.TestCase):
 
     def test_category_timings(self):
         with ProvenanceWriter() as db:
-            db.insert_category_timing("mapping", 12, 1, 1)
-            db.insert_category_timing("mapping", 123, 1, 2)
-            db.insert_category_timing("execute", 134, 1, None)
-            db.insert_category_timing("execute", 344, 1, 2)
+            db.insert_category_timing("mapping", timedelta(seconds=12), 1, 1)
+            db.insert_category_timing("mapping", timedelta(seconds=123), 1, 2)
+            db.insert_category_timing(
+                "execute", timedelta(seconds=134), 1, None)
+            db.insert_category_timing("execute", timedelta(seconds=344), 1, 2)
         reader = ProvenanceReader()
         data = reader.get_category_timer_sum("mapping")
-        self.assertEqual(12 + 123, data)
+        self.assertEqual((12 + 123) * 1000, data)
 
 
     def test_other(self):

--- a/unittests/interface/provenance/test_provenance_database.py
+++ b/unittests/interface/provenance/test_provenance_database.py
@@ -89,7 +89,6 @@ class TestProvenanceDatabase(unittest.TestCase):
         data = reader.get_category_timer_sum("mapping")
         self.assertEqual((12 + 123) * 1000, data)
 
-
     def test_other(self):
         with ProvenanceWriter() as db:
             db.insert_other("foo", "bar", 12)


### PR DESCRIPTION
Warning Energy reporting was broken and still is https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/issues/866
Just a little less.

This PR replaced the ASB._xxx_time variables with data in the Provenance databse

ASB and BufferManager write the data in.

Energy function read it out ASAP.  this could often be done later but cleaning up the Energy Stuff is out of scope.

One change it that timing from before a hard reset which where not cleared now are.
