### PR TITLE
Add tags where malloc is used

### DIFF
--- a/spinn_front_end_common/interface/interface_functions/host_execute_data_specification.py
+++ b/spinn_front_end_common/interface/interface_functions/host_execute_data_specification.py
@@ -31,6 +31,7 @@ from spinn_front_end_common.utilities.utility_objs import (
     ExecutableType, DataWritten)
 from spinn_front_end_common.utilities.emergency_recovery import (
     emergency_recover_states_from_failure)
+from spinn_front_end_common.utilities.constants import CORE_DATA_SDRAM_BASE_TAG
 
 logger = FormatAdapter(logging.getLogger(__name__))
 _MEM_REGIONS = range(MAX_MEM_REGIONS)
@@ -725,7 +726,8 @@ class _HostExecuteDataSpecification(object):
 
         # allocate memory where the app data is going to be written; this
         # raises an exception in case there is not enough SDRAM to allocate
-        start_address = self._txrx.malloc_sdram(x, y, size, self._app_id)
+        start_address = self._txrx.malloc_sdram(
+            x, y, size, self._app_id, tag=CORE_DATA_SDRAM_BASE_TAG + p)
 
         # set user 0 register appropriately to the application data
         write_address_to_user0(self._txrx, x, y, p, start_address)

--- a/spinn_front_end_common/interface/interface_functions/host_no_bitfield_router_compression.py
+++ b/spinn_front_end_common/interface/interface_functions/host_no_bitfield_router_compression.py
@@ -28,10 +28,9 @@ from spinn_front_end_common.utilities.system_control_logic import (
 from spinn_front_end_common.utilities.utility_objs import ExecutableType
 from spinn_front_end_common.utilities.helpful_functions import (
     get_defaultable_source_id)
+from spinn_front_end_common.utilities.constants import COMPRESSOR_SDRAM_TAG
 _FOUR_WORDS = struct.Struct("<IIII")
 _THREE_WORDS = struct.Struct("<III")
-# The SDRAM Tag used by the application - note this is fixed in the APLX
-_SDRAM_TAG = 1
 
 logger = FormatAdapter(logging.getLogger(__name__))
 
@@ -242,7 +241,8 @@ class Compression(object):
 
         # go to spinnman and ask for a memory region of that size per chip.
         base_address = self._transceiver.malloc_sdram(
-            table.x, table.y, len(data), self._compressor_app_id, _SDRAM_TAG)
+            table.x, table.y, len(data), self._compressor_app_id,
+            COMPRESSOR_SDRAM_TAG)
 
         # write SDRAM requirements per chip
         self._transceiver.write_memory(table.x, table.y, base_address, data)

--- a/spinn_front_end_common/interface/interface_functions/machine_bit_field_router_compressor.py
+++ b/spinn_front_end_common/interface/interface_functions/machine_bit_field_router_compressor.py
@@ -44,6 +44,9 @@ from spinn_front_end_common.utilities.helpful_functions import (
 from spinn_front_end_common.utilities.system_control_logic import (
     run_system_application)
 from spinn_front_end_common.utilities.utility_objs import ExecutableType
+from spinn_front_end_common.utilities.constants import (
+    BIT_FIELD_COMMS_SDRAM_TAG, BIT_FIELD_USABLE_SDRAM_TAG,
+    BIT_FIELD_ADDRESSES_SDRAM_TAG, BIT_FIELD_ROUTING_TABLE_SDRAM_TAG)
 from .load_executable_images import filter_targets
 from .host_bit_field_router_compressor import (
     generate_key_to_atom_map, generate_report_path,
@@ -393,7 +396,8 @@ class _MachineBitFieldRouterCompressor(object):
 
                     comms_sdram = transceiver.malloc_sdram(
                         table.x, table.y, SIZE_OF_COMMS_SDRAM,
-                        routing_table_compressor_app_id)
+                        routing_table_compressor_app_id,
+                        BIT_FIELD_COMMS_SDRAM_TAG)
 
                     self._load_address_data(
                         addresses, table.x, table.y, transceiver,
@@ -479,7 +483,8 @@ class _MachineBitFieldRouterCompressor(object):
         try:
             sdram_address = transceiver.malloc_sdram(
                 chip_x, chip_y, len(address_data),
-                routing_table_compressor_app_id)
+                routing_table_compressor_app_id,
+                BIT_FIELD_USABLE_SDRAM_TAG)
         except (SpinnmanInvalidParameterException,
                 SpinnmanUnexpectedResponseCodeException):
             sdram_address = self._steal_from_matrix_addresses(
@@ -551,7 +556,8 @@ class _MachineBitFieldRouterCompressor(object):
         try:
             sdram_address = transceiver.malloc_sdram(
                 chip_x, chip_y, len(address_data),
-                routing_table_compressor_app_id)
+                routing_table_compressor_app_id,
+                BIT_FIELD_ADDRESSES_SDRAM_TAG)
         except (SpinnmanInvalidParameterException,
                 SpinnmanUnexpectedResponseCodeException):
             sdram_address = self._steal_from_matrix_addresses(
@@ -595,7 +601,8 @@ class _MachineBitFieldRouterCompressor(object):
         try:
             base_address = transceiver.malloc_sdram(
                 table.x, table.y, len(routing_table_data),
-                routing_table_compressor_app_id)
+                routing_table_compressor_app_id,
+                BIT_FIELD_ROUTING_TABLE_SDRAM_TAG)
         except (SpinnmanInvalidParameterException,
                 SpinnmanUnexpectedResponseCodeException):
             base_address = self._steal_from_matrix_addresses(

--- a/spinn_front_end_common/interface/interface_functions/sdram_outgoing_partition_allocator.py
+++ b/spinn_front_end_common/interface/interface_functions/sdram_outgoing_partition_allocator.py
@@ -17,6 +17,7 @@ from collections import defaultdict
 from spinn_utilities.progress_bar import ProgressBar
 from pacman.model.graphs.machine import SourceSegmentedSDRAMMachinePartition
 from spinn_front_end_common.utilities.exceptions import SpinnFrontEndException
+from spinn_front_end_common.utilities.constants import SDRAM_EDGE_BASE_TAG
 
 
 def sdram_outgoing_partition_allocator(
@@ -29,6 +30,9 @@ def sdram_outgoing_partition_allocator(
 
     if transceiver is None:
         virtual_usage = defaultdict(int)
+
+    # Keep track of SDRAM tags used
+    next_tag = defaultdict(lambda: SDRAM_EDGE_BASE_TAG)
 
     for machine_vertex in machine_graph.vertices:
         sdram_partitions = (
@@ -57,8 +61,10 @@ def sdram_outgoing_partition_allocator(
 
             # allocate
             if transceiver is not None:
+                tag = next_tag[placement.x, placement.y]
+                next_tag[placement.x, placement.y] = tag + 1
                 sdram_base_address = transceiver.malloc_sdram(
-                    placement.x, placement.y, total_sdram, app_id)
+                    placement.x, placement.y, total_sdram, app_id, tag)
             else:
                 sdram_base_address = virtual_usage[
                     placement.x, placement.y]

--- a/spinn_front_end_common/utilities/constants.py
+++ b/spinn_front_end_common/utilities/constants.py
@@ -124,3 +124,20 @@ NOTIFY_PORT = 19999
 CLOCKS_PER_US = 200
 
 PROVENANCE_DB = "provenance.sqlite3"
+
+#: SDRAM Tag used by the compressor to find the routing tables
+COMPRESSOR_SDRAM_TAG = 1
+
+#: SDRAM Tags used for bitfield compressor
+BIT_FIELD_COMMS_SDRAM_TAG = 2
+BIT_FIELD_USABLE_SDRAM_TAG = 3
+BIT_FIELD_ADDRESSES_SDRAM_TAG = 4
+BIT_FIELD_ROUTING_TABLE_SDRAM_TAG = 5
+
+#: Base SDRAM tag used by SDRAM edges when allocating
+#: (allows up to 100 edges per chip)
+SDRAM_EDGE_BASE_TAG = 100
+
+#: Base SDRAM tag used by cores when loading data
+#: (tags 201-217 will be used by cores 1-17)
+CORE_DATA_SDRAM_BASE_TAG = 200


### PR DESCRIPTION
Add tags to SDRAM allocations to make use of SpiNNakerManchester/spinnaker_tools#159.  This ensures any allocations that are done will survive retries of the SCP messages.