### PR TITLE
No Monitors list use dict.values()

### DIFF
--- a/fec_integration_tests/test_buffer_manager_listener_creation.py
+++ b/fec_integration_tests/test_buffer_manager_listener_creation.py
@@ -73,7 +73,7 @@ class TestBufferManagerListenerCreation(unittest.TestCase):
 
         # Create buffer manager
         bm = BufferManager(
-            placements=pl, tags=t, transceiver=trnx, extra_monitor_cores=None,
+            placements=pl, tags=t, transceiver=trnx,
             packet_gather_cores_to_ethernet_connection_map=None,
             extra_monitor_to_chip_mapping=None, machine=None,
             fixed_routes=None)

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -2542,6 +2542,7 @@ class AbstractSpinnakerBase(ConfigHandler):
             return execute_application_data_specs(
                 self._txrx, self._machine, self._app_id, self._dsg_targets,
                 self._executable_targets, self._region_sizes, self._placements,
+                self._extra_monitor_to_chip_mapping,
                 self._vertex_to_ethernet_connected_chip_mapping,
                 self._java_caller, processor_to_app_data_base_address)
 

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -342,9 +342,6 @@ class AbstractSpinnakerBase(ConfigHandler):
         # version of the board to requested or discovered
         "_board_version",
 
-        # vertices added to support Buffer Extractor
-        "_extra_monitor_vertices",
-
         # Start timestep of a do_run cycle
         # Set by data generation and do_run cleared by do_run
         "_first_machine_time_step",
@@ -511,7 +508,6 @@ class AbstractSpinnakerBase(ConfigHandler):
         self._executable_targets = None
         self._executable_types = None
         self._extra_monitor_to_chip_mapping = None
-        self._extra_monitor_vertices = None
         self._fixed_routes = None
         self._java_caller = None
         self._live_packet_recorder_parameters_mapping = None
@@ -1546,7 +1542,6 @@ class AbstractSpinnakerBase(ConfigHandler):
                 return
             # inserter checks for None app graph not an empty one
         (self._vertex_to_ethernet_connected_chip_mapping,
-         self._extra_monitor_vertices,
          self._extra_monitor_to_chip_mapping) = \
             insert_extra_monitor_vertices_to_graphs(
                 self._machine, self._machine_graph, self._application_graph)
@@ -2038,7 +2033,6 @@ class AbstractSpinnakerBase(ConfigHandler):
 
             self._buffer_manager = buffer_manager_creator(
                 self._placements, self._tags, self._txrx,
-                self._extra_monitor_vertices,
                 self._extra_monitor_to_chip_mapping,
                 self._vertex_to_ethernet_connected_chip_mapping,
                 self._machine, self._fixed_routes, self._java_caller)
@@ -2548,7 +2542,6 @@ class AbstractSpinnakerBase(ConfigHandler):
             return execute_application_data_specs(
                 self._txrx, self._machine, self._app_id, self._dsg_targets,
                 self._executable_targets, self._region_sizes, self._placements,
-                self._extra_monitor_vertices,
                 self._vertex_to_ethernet_connected_chip_mapping,
                 self._java_caller, processor_to_app_data_base_address)
 
@@ -2772,7 +2765,7 @@ class AbstractSpinnakerBase(ConfigHandler):
                 return []
             router_provenance_gatherer(
                 self._txrx, self._machine, self._router_tables,
-                self._extra_monitor_vertices, self._placements)
+                self._extra_monitor_to_chip_mapping, self._placements)
 
     def _execute_profile_data_gatherer(self):
         """
@@ -3057,7 +3050,7 @@ class AbstractSpinnakerBase(ConfigHandler):
             router_provenance_gatherer(
                 transceiver=self._txrx, machine=self._machine,
                 router_tables=self._router_tables,
-                extra_monitor_vertices=self._extra_monitor_vertices,
+                extra_monitor_vertices=self._extra_monitor_to_chip_mapping,
                 placements=self._placements)
         except Exception:
             logger.exception("Error reading router provenance")

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -42,6 +42,8 @@ from spinn_front_end_common.interface.buffer_management.buffer_models \
     import AbstractReceiveBuffersToHost
 from spinn_front_end_common.interface.provenance import (
     BUFFER, ProvenanceWriter)
+from spinn_front_end_common.utility_models.streaming_context_manager import (
+    StreamingContextManager)
 from .recording_utilities import get_recording_header_size
 
 logger = FormatAdapter(logging.getLogger(__name__))
@@ -633,8 +635,7 @@ class BufferManager(object):
         for extra_mon in self._extra_monitor_cores:
             extra_mon.update_transaction_id_from_machine(self._transceiver)
 
-        # Ugly, to avoid an import loop...
-        with receivers[0].streaming(
+        with StreamingContextManager(
                 receivers, self._transceiver, self._extra_monitor_cores,
                 self._placements):
             # get data

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -115,9 +115,6 @@ class BufferManager(object):
         # listener port
         "_listener_port",
 
-        # the extra monitor cores which support faster data extraction
-        "_extra_monitor_cores",
-
         # the extra_monitor to Ethernet connection map
         "_packet_gather_cores_to_ethernet_connection_map",
 
@@ -134,7 +131,7 @@ class BufferManager(object):
         "_java_caller"
     ]
 
-    def __init__(self, placements, tags, transceiver, extra_monitor_cores,
+    def __init__(self, placements, tags, transceiver,
                  packet_gather_cores_to_ethernet_connection_map,
                  extra_monitor_to_chip_mapping, machine, fixed_routes,
                  java_caller=None):
@@ -144,8 +141,6 @@ class BufferManager(object):
         :param ~pacman.model.tags.Tags tags: The tags assigned to the vertices
         :param ~spinnman.transceiver.Transceiver transceiver:
             The transceiver to use for sending and receiving information
-        :param list(ExtraMonitorSupportMachineVertex) extra_monitor_cores:
-            The monitors.
         :param packet_gather_cores_to_ethernet_connection_map:
             mapping of cores to the gatherer vertex placed on them
         :type packet_gather_cores_to_ethernet_connection_map:
@@ -163,7 +158,6 @@ class BufferManager(object):
         self._placements = placements
         self._tags = tags
         self._transceiver = transceiver
-        self._extra_monitor_cores = extra_monitor_cores
         self._packet_gather_cores_to_ethernet_connection_map = \
             packet_gather_cores_to_ethernet_connection_map
         self._extra_monitor_cores_by_chip = extra_monitor_to_chip_mapping
@@ -632,12 +626,12 @@ class BufferManager(object):
             for placement in placements))
 
         # update transaction id from the machine for all extra monitors
-        for extra_mon in self._extra_monitor_cores:
+        for extra_mon in self._extra_monitor_cores_by_chip.values():
             extra_mon.update_transaction_id_from_machine(self._transceiver)
 
         with StreamingContextManager(
-                receivers, self._transceiver, self._extra_monitor_cores,
-                self._placements):
+                receivers, self._transceiver,
+                self._extra_monitor_cores_by_chip, self._placements):
             # get data
             self.__old_get_data_for_placements(placements, progress)
 

--- a/spinn_front_end_common/interface/interface_functions/buffer_manager_creator.py
+++ b/spinn_front_end_common/interface/interface_functions/buffer_manager_creator.py
@@ -21,8 +21,7 @@ from spinn_front_end_common.interface.buffer_management.buffer_models \
 
 
 def buffer_manager_creator(
-        placements, tags, txrx, extra_monitor_cores=None,
-        extra_monitor_to_chip_mapping=None,
+        placements, tags, txrx, extra_monitor_to_chip_mapping=None,
         packet_gather_cores_to_ethernet_connection_map=None, machine=None,
         fixed_routes=None, java_caller=None):
     """ Creates a buffer manager.
@@ -31,7 +30,6 @@ def buffer_manager_creator(
     :param ~pacman.model.tags.Tags tags:
     :param ~spinnman.transceiver.Transceiver txrx:
     :param bool uses_advanced_monitors:
-    :param list(ExtraMonitorSupportMachineVertex) extra_monitor_cores:
     :param extra_monitor_to_chip_mapping:
     :type extra_monitor_to_chip_mapping:
         dict(tuple(int,int),ExtraMonitorSupportMachineVertex)
@@ -50,7 +48,6 @@ def buffer_manager_creator(
     # Create the buffer manager
     buffer_manager = BufferManager(
         placements=placements, tags=tags, transceiver=txrx,
-        extra_monitor_cores=extra_monitor_cores,
         packet_gather_cores_to_ethernet_connection_map=(
             packet_gather_cores_to_ethernet_connection_map),
         extra_monitor_to_chip_mapping=extra_monitor_to_chip_mapping,

--- a/spinn_front_end_common/interface/interface_functions/host_execute_data_specification.py
+++ b/spinn_front_end_common/interface/interface_functions/host_execute_data_specification.py
@@ -307,7 +307,7 @@ def execute_system_data_specs(
 def execute_application_data_specs(
         transceiver, machine, app_id, dsg_targets,
         executable_targets, region_sizes,
-        placements=None,
+        placements=None, extra_monitor_cores=None,
         extra_monitor_cores_to_ethernet_connection_map=None,
         java_caller=None, processor_to_app_data_base_address=None):
     """ Execute the data specs for all non-system targets.
@@ -327,6 +327,8 @@ def execute_application_data_specs(
         what core will running what binary
     :param ~pacman.model.placements.Placements placements:
         where vertices are located
+    :param list(ExtraMonitorSupportMachineVertex) extra_monitor_cores:
+        the deployed extra monitors, if any
     :param extra_monitor_cores_to_ethernet_connection_map:
         how to talk to extra monitor cores
     :type extra_monitor_cores_to_ethernet_connection_map:
@@ -343,7 +345,7 @@ def execute_application_data_specs(
         processor_to_app_data_base_address)
     return specifier.execute_application_data_specs(
         dsg_targets, executable_targets, region_sizes, placements,
-        extra_monitor_cores_to_ethernet_connection_map)
+        extra_monitor_cores, extra_monitor_cores_to_ethernet_connection_map)
 
 
 class _HostExecuteDataSpecification(object):
@@ -358,6 +360,7 @@ class _HostExecuteDataSpecification(object):
         "_java",
         # The python representation of the SpiNNaker machine.
         "_machine",
+        "_monitors",
         "_placements",
         # The spinnman instance.
         "_txrx",
@@ -383,6 +386,7 @@ class _HostExecuteDataSpecification(object):
         self._core_to_conn_map = None
         self._java = java_caller
         self._machine = machine
+        self._monitors = None
         self._placements = None
         self._txrx = transceiver
         if processor_to_app_data_base_address:
@@ -473,7 +477,7 @@ class _HostExecuteDataSpecification(object):
     def execute_application_data_specs(
             self, dsg_targets,
             executable_targets, region_sizes,
-            placements=None,
+            placements=None, extra_monitor_cores=None,
             extra_monitor_cores_to_ethernet_connection_map=None,
             processor_to_app_data_base_address=None):
         """ Execute the data specs for all non-system targets.
@@ -488,6 +492,10 @@ class _HostExecuteDataSpecification(object):
             what core will running what binary
         :param ~pacman.model.placements.Placements placements:
             where vertices are located
+        :param extra_monitor_cores:
+            the deployed extra monitors, if any
+        :type extra_monitor_cores:
+            dict(tuple(int,int),ExtraMonitorSupportMachineVertex))
         :param extra_monitor_cores_to_ethernet_connection_map:
             how to talk to extra monitor cores
         :type extra_monitor_cores_to_ethernet_connection_map:
@@ -498,6 +506,7 @@ class _HostExecuteDataSpecification(object):
         :rtype: dict(tuple(int,int,int),DataWritten) or DsWriteInfo
         """
         # pylint: disable=too-many-arguments
+        self._monitors = extra_monitor_cores
         self._placements = placements
         self._core_to_conn_map = extra_monitor_cores_to_ethernet_connection_map
 
@@ -522,18 +531,18 @@ class _HostExecuteDataSpecification(object):
     def __set_router_timeouts(self):
         for receiver in self._core_to_conn_map.values():
             receiver.load_system_routing_tables(
-                self._txrx, self._core_to_conn_map, self._placements)
+                self._txrx, self._monitors, self._placements)
             receiver.set_cores_for_data_streaming(
-                self._txrx, self._core_to_conn_map, self._placements)
+                self._txrx, self._monitors, self._placements)
 
     def __reset_router_timeouts(self):
         # reset router timeouts
         for receiver in self._core_to_conn_map.values():
             receiver.unset_cores_for_data_streaming(
-                self._txrx, self._core_to_conn_map, self._placements)
+                self._txrx, self._monitors, self._placements)
             # reset router tables
             receiver.load_application_routing_tables(
-                self._txrx, self._core_to_conn_map, self._placements)
+                self._txrx, self._monitors, self._placements)
 
     def __select_writer(self, x, y):
         chip = self._machine.get_chip_at(x, y)

--- a/spinn_front_end_common/interface/interface_functions/insert_extra_monitor_vertices_to_graphs.py
+++ b/spinn_front_end_common/interface/interface_functions/insert_extra_monitor_vertices_to_graphs.py
@@ -52,11 +52,11 @@ def insert_extra_monitor_vertices_to_graphs(
 
     # handle reinjector and chip based data extractor functionality.
     if application_graph.n_vertices > 0:
-        extra_monitors = __add_second_monitors_application_graph(
+        __add_second_monitors_application_graph(
             progress, machine, application_graph, machine_graph,
             vertex_to_chip_map)
     else:
-        extra_monitors = __add_second_monitors_machine_graph(
+        __add_second_monitors_machine_graph(
             progress, machine, machine_graph, vertex_to_chip_map)
 
     # progress data receiver for data extraction functionality
@@ -69,7 +69,7 @@ def insert_extra_monitor_vertices_to_graphs(
             progress, machine, machine_graph, chip_to_gatherer_map,
             vertex_to_chip_map)
 
-    return chip_to_gatherer_map, extra_monitors, vertex_to_chip_map
+    return chip_to_gatherer_map, vertex_to_chip_map
 
 
 def __add_second_monitors_application_graph(
@@ -88,8 +88,6 @@ def __add_second_monitors_application_graph(
     """
     # pylint: disable=too-many-arguments
 
-    extra_monitor_vertices = list()
-
     for chip in progress.over(machine.chips, finish_at_end=False):
         if chip.virtual:
             continue
@@ -99,9 +97,6 @@ def __add_second_monitors_application_graph(
         machine_vertex = app_vertex.machine_vertex
         machine_graph.add_vertex(machine_vertex)
         vertex_to_chip_map[chip.x, chip.y] = machine_vertex
-        extra_monitor_vertices.append(machine_vertex)
-
-    return extra_monitor_vertices
 
 
 def __add_second_monitors_machine_graph(
@@ -118,8 +113,6 @@ def __add_second_monitors_machine_graph(
     """
     # pylint: disable=too-many-arguments
 
-    extra_monitor_vertices = list()
-
     for chip in progress.over(machine.chips, finish_at_end=False):
         if chip.virtual:
             continue
@@ -127,9 +120,6 @@ def __add_second_monitors_machine_graph(
         vertex = __new_mach_monitor(chip)
         machine_graph.add_vertex(vertex)
         vertex_to_chip_map[chip.x, chip.y] = vertex
-        extra_monitor_vertices.append(vertex)
-
-    return extra_monitor_vertices
 
 
 def __add_data_extraction_vertices_app_graph(

--- a/spinn_front_end_common/interface/interface_functions/router_provenance_gatherer.py
+++ b/spinn_front_end_common/interface/interface_functions/router_provenance_gatherer.py
@@ -32,8 +32,10 @@ def router_provenance_gatherer(transceiver, machine, router_tables,
     :param router_tables: the router tables that have been generated
     :type router_tables:
         ~pacman.model.routing_tables.MulticastRoutingTables
-    :param list(ExtraMonitorSupportMachineVertex) extra_monitor_vertices:
+    :param extra_monitor_vertices:
         vertices which represent the extra monitor code
+    :type extra_monitor_vertices:
+        dict(tuple(int,int),ExtraMonitorSupportMachineVertex))
     :param ~pacman.model.placements.Placements placements:
         the placements object
     """
@@ -72,6 +74,8 @@ class _RouterProvenanceGatherer(object):
             ~pacman.model.routing_tables.MulticastRoutingTables
         :param list(ExtraMonitorSupportMachineVertex) extra_monitor_vertices:
             vertices which represent the extra monitor code
+        :type extra_monitor_vertices:
+            dict(tuple(int,int),ExtraMonitorSupportMachineVertex))
         :param ~pacman.model.placements.Placements placements:
             the placements object
         """
@@ -94,7 +98,7 @@ class _RouterProvenanceGatherer(object):
         # get all extra monitor core data if it exists
         reinjection_data = None
         if self._extra_monitor_vertices is not None:
-            monitor = self._extra_monitor_vertices[0]
+            monitor = self._extra_monitor_vertices[(0, 0)]
             reinjection_data = monitor.get_reinjection_status_for_vertices(
                 placements=self._placements,
                 extra_monitor_cores_for_data=self._extra_monitor_vertices,

--- a/spinn_front_end_common/utility_models/__init__.py
+++ b/spinn_front_end_common/utility_models/__init__.py
@@ -29,6 +29,7 @@ from .multi_cast_command import MultiCastCommand
 from .reverse_ip_tag_multi_cast_source import ReverseIpTagMultiCastSource
 from .reverse_ip_tag_multicast_source_machine_vertex import (
     ReverseIPTagMulticastSourceMachineVertex)
+from .streaming_context_manager import StreamingContextManager
 
 __all__ = ["CommandSender", "CommandSenderMachineVertex",
            "ChipPowerMonitor", "ChipPowerMonitorMachineVertex",
@@ -36,4 +37,5 @@ __all__ = ["CommandSender", "CommandSenderMachineVertex",
            "ExtraMonitorSupport", "ExtraMonitorSupportMachineVertex",
            "LivePacketGather", "LivePacketGatherMachineVertex",
            "MultiCastCommand", "ReverseIpTagMultiCastSource",
-           "ReverseIPTagMulticastSourceMachineVertex"]
+           "ReverseIPTagMulticastSourceMachineVertex",
+           "StreamingContextManager"]

--- a/spinn_front_end_common/utility_models/data_speed_up_packet_gatherer_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/data_speed_up_packet_gatherer_machine_vertex.py
@@ -927,12 +927,14 @@ class DataSpeedUpPacketGatherMachineVertex(
 
         :param ~spinnman.transceiver.Transceiver transceiver:
             the SpiNNMan instance
-        :param list(ExtraMonitorSupportMachineVertex) extra_monitor_cores:
+        :param extra_monitor_cores:
             the extra monitor cores to set
+        :type extra_monitor_cores:
+            dict(tuple(int,int),ExtraMonitorSupportMachineVertex))
         :param ~pacman.model.placements.Placements placements:
             placements object
         """
-        lead_monitor = extra_monitor_cores[0]
+        lead_monitor = extra_monitor_cores[(0, 0)]
         # Store the last reinjection status for resetting
         # NOTE: This assumes the status is the same on all cores
         self._last_status = lead_monitor.get_reinjection_status(
@@ -960,12 +962,14 @@ class DataSpeedUpPacketGatherMachineVertex(
 
         :param ~spinnman.transceiver.Transceiver transceiver:
             the SpiNNMan instance
-        :param list(ExtraMonitorSupportMachineVertex) extra_monitor_cores:
+        :param extra_monitor_cores:
             the extra monitor cores to set
+        :type extra_monitor_cores:
+            dict(tuple(int,int),ExtraMonitorSupportMachineVertex))
         :param ~pacman.model.placements.Placements placements:
             placements object
         """
-        extra_monitor_cores[0].load_application_mc_routes(
+        extra_monitor_cores[(0, 0)].load_application_mc_routes(
             placements, extra_monitor_cores, transceiver)
 
     @staticmethod
@@ -975,12 +979,14 @@ class DataSpeedUpPacketGatherMachineVertex(
 
         :param ~spinnman.transceiver.Transceiver transceiver:
             the SpiNNMan instance
-        :param list(ExtraMonitorSupportMachineVertex) extra_monitor_cores:
+        :param extra_monitor_cores:
             the extra monitor cores to set
+        :type extra_monitor_cores:
+            dict(tuple(int,int),ExtraMonitorSupportMachineVertex))
         :param ~pacman.model.placements.Placements placements:
             placements object
         """
-        extra_monitor_cores[0].load_system_mc_routes(
+        extra_monitor_cores[(0, 0)].load_system_mc_routes(
             placements, extra_monitor_cores, transceiver)
 
     def set_router_wait1_timeout(self, timeout, transceiver, placements):
@@ -1046,8 +1052,10 @@ class DataSpeedUpPacketGatherMachineVertex(
 
         :param ~spinnman.transceiver.Transceiver transceiver:
             the SpiNNMan instance
-        :param list(ExtraMonitorSupportMachineVertex) extra_monitor_cores:
+        :param extra_monitor_cores:
             the extra monitor cores to set
+        :type extra_monitor_cores:
+            dict(tuple(int,int),ExtraMonitorSupportMachineVertex))
         :param ~pacman.model.placements.Placements placements:
             placements object
         """
@@ -1069,7 +1077,7 @@ class DataSpeedUpPacketGatherMachineVertex(
                 self._last_status.router_wait2_timeout_parameters,
                 transceiver, placements)
 
-            lead_monitor = extra_monitor_cores[0]
+            lead_monitor = extra_monitor_cores[(0, 0)]
             lead_monitor.set_reinjection_packets(
                 placements, extra_monitor_cores, transceiver,
                 point_to_point=self._last_status.is_reinjecting_point_to_point,

--- a/spinn_front_end_common/utility_models/extra_monitor_support_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/extra_monitor_support_machine_vertex.py
@@ -667,7 +667,7 @@ class ExtraMonitorSupportMachineVertex(
             the spinnMan interface
         """
         core_subsets = self._convert_vertices_to_core_subset(
-            extra_monitor_cores_for_data, placements)
+            extra_monitor_cores_for_data.values(), placements)
         process = LoadSystemMCRoutesProcess(
             transceiver.scamp_connection_selector)
         try:
@@ -693,7 +693,7 @@ class ExtraMonitorSupportMachineVertex(
             the spinnMan interface
         """
         core_subsets = self._convert_vertices_to_core_subset(
-            extra_monitor_cores_for_data, placements)
+            extra_monitor_cores_for_data.values(), placements)
         process = LoadApplicationMCRoutesProcess(
             transceiver.scamp_connection_selector)
         try:

--- a/spinn_front_end_common/utility_models/extra_monitor_support_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/extra_monitor_support_machine_vertex.py
@@ -593,13 +593,13 @@ class ExtraMonitorSupportMachineVertex(
         :param extra_monitor_cores_for_data:
             the extra monitor cores to get status from
         :type extra_monitor_cores_for_data:
-            iterable(ExtraMonitorSupportMachineVertex)
+            dict(tuple(int,int),ExtraMonitorSupportMachineVertex))
         :param ~spinnman.transceiver.Transceiver transceiver:
             the spinnMan interface
         :rtype: dict(tuple(int,int), ReInjectionStatus)
         """
         core_subsets = convert_vertices_to_core_subset(
-            extra_monitor_cores_for_data, placements)
+            extra_monitor_cores_for_data.values(), placements)
         process = ReadStatusProcess(transceiver.scamp_connection_selector)
         return process.get_reinjection_status_for_core_subsets(core_subsets)
 
@@ -613,7 +613,7 @@ class ExtraMonitorSupportMachineVertex(
         :param extra_monitor_cores_for_data:
             the extra monitor cores to set the packets of
         :type extra_monitor_cores_for_data:
-            iterable(ExtraMonitorSupportMachineVertex)
+            dict(tuple(int,int),ExtraMonitorSupportMachineVertex))
         :param ~spinnman.transceiver.Transceiver transceiver: spinnman instance
         :param point_to_point:
             If point to point should be set, or None if left as before
@@ -639,7 +639,7 @@ class ExtraMonitorSupportMachineVertex(
             self._reinject_fixed_route = fixed_route
 
         core_subsets = convert_vertices_to_core_subset(
-            extra_monitor_cores_for_data, placements)
+            extra_monitor_cores_for_data.values(), placements)
         process = SetPacketTypesProcess(transceiver.scamp_connection_selector)
         try:
             process.set_packet_types(
@@ -662,7 +662,7 @@ class ExtraMonitorSupportMachineVertex(
         :param extra_monitor_cores_for_data:
             the extra monitor cores to get status from
         :type extra_monitor_cores_for_data:
-            iterable(ExtraMonitorSupportMachineVertex)
+            dict(tuple(int,int),ExtraMonitorSupportMachineVertex))
         :param ~spinnman.transceiver.Transceiver transceiver:
             the spinnMan interface
         """
@@ -688,7 +688,7 @@ class ExtraMonitorSupportMachineVertex(
         :param extra_monitor_cores_for_data:
             the extra monitor cores to get status from
         :type extra_monitor_cores_for_data:
-            iterable(ExtraMonitorSupportMachineVertex)
+            dict(tuple(int,int),ExtraMonitorSupportMachineVertex))
         :param ~spinnman.transceiver.Transceiver transceiver:
             the spinnMan interface
         """
@@ -709,8 +709,10 @@ class ExtraMonitorSupportMachineVertex(
         """ Convert vertices into the subset of cores where they've been\
             placed.
 
-        :param iterable(ExtraMonitorSupportMachineVertex) extra_monitor_cores:
+        :param extra_monitor_cores:
             the vertices to convert to core subsets
+        :type extra_monitor_cores:
+            dict(tuple(int,int),ExtraMonitorSupportMachineVertex))
         :param ~.Placements placements: the placements object
         :return: where the vertices have been placed
         :rtype: ~.CoreSubsets

--- a/spinn_front_end_common/utility_models/streaming_context_manager.py
+++ b/spinn_front_end_common/utility_models/streaming_context_manager.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2017-2022 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class StreamingContextManager(object):
+    """ The implementation of the context manager object for streaming \
+        configuration control.
+    """
+    __slots__ = ["_gatherers", "_monitors", "_placements", "_txrx"]
+
+    def __init__(self, gatherers, txrx, monitors, placements):
+        """
+        :param iterable(DataSpeedUpPacketGatherMachineVertex) gatherers:
+        :param ~spinnman.transceiver.Transceiver txrx:
+        :param list(ExtraMonitorSupportMachineVertex) monitors:
+        :param ~pacman.model.placements.Placements placements:
+        """
+        self._gatherers = list(gatherers)
+        self._txrx = txrx
+        self._monitors = monitors
+        self._placements = placements
+
+    def __enter__(self):
+        for gatherer in self._gatherers:
+            gatherer.load_system_routing_tables(
+                self._txrx, self._monitors, self._placements)
+        for gatherer in self._gatherers:
+            gatherer.set_cores_for_data_streaming(
+                self._txrx, self._monitors, self._placements)
+
+    def __exit__(self, _type, _value, _tb):
+        for gatherer in self._gatherers:
+            gatherer.unset_cores_for_data_streaming(
+                self._txrx, self._monitors, self._placements)
+        for gatherer in self._gatherers:
+            gatherer.load_application_routing_tables(
+                self._txrx, self._monitors, self._placements)
+        return False

--- a/spinn_front_end_common/utility_models/streaming_context_manager.py
+++ b/spinn_front_end_common/utility_models/streaming_context_manager.py
@@ -24,7 +24,7 @@ class StreamingContextManager(object):
         """
         :param iterable(DataSpeedUpPacketGatherMachineVertex) gatherers:
         :param ~spinnman.transceiver.Transceiver txrx:
-        :param list(ExtraMonitorSupportMachineVertex) monitors:
+        :param dict(tuple(int,int),ExtraMonitorSupportMachineVertex)) monitors:
         :param ~pacman.model.placements.Placements placements:
         """
         self._gatherers = list(gatherers)


### PR DESCRIPTION
This Pr makes 2 changes.
 1. StreamingContextManager is a stand alone objects.
      - This avoids the ugly receivers[0].streaming

 2. The list of ExtraMontiors is gone as it duplicates info in the dict
      - The conversion from Dict to dict.values() is done as late as possible to make replacing with View data as easy as possible.
      - the call Monitors[(0, 0)] is safe as there is always a monitor on chip 0,0. But could be added in safety code when moved to the View.

Must be done at the same time as:
https://github.com/SpiNNakerManchester/SpiNNakerGraphFrontEnd/pull/210
-No spy branch

Tested by:
http://apollo.cs.man.ac.uk:8080/blue/organizations/jenkins/Integration%20Tests/detail/monitors/4/pipeline

