### PR TITLE
no job to destroy if init fails

### DIFF
--- a/spinn_front_end_common/interface/interface_functions/spalloc_allocator.py
+++ b/spinn_front_end_common/interface/interface_functions/spalloc_allocator.py
@@ -186,6 +186,7 @@ def _launch_job(n_boards, spalloc_kw_args):
     :param dict(str, str or int) spalloc_kw_args:
     :rtype: tuple(~.Job, str)
     """
+    job = None
     try:
         job = Job(n_boards, **spalloc_kw_args)
         job.wait_until_ready()
@@ -193,5 +194,6 @@ def _launch_job(n_boards, spalloc_kw_args):
         # occur
         return job, job.hostname
     except Exception as ex:
-        job.destroy(str(ex))
+        if job:
+            job.destroy(str(ex))
         raise


### PR DESCRIPTION
If there is no network the call to create a spalloc job fails.

Rather hard to destroy a job that was never created.
