### PR TITLE
changed options rarely if ever used to cfg only

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -3004,9 +3004,7 @@ class AbstractSpinnakerBase(ConfigHandler):
             # if in debug mode, do not shut down machine
             if get_config_str("Mode", "mode") != "Debug":
                 try:
-                    self.stop(
-                        turn_off_machine=False, clear_routing_tables=False,
-                        clear_tags=False)
+                    self.stop()
                 except Exception as stop_e:
                     logger.exception(f"Error {stop_e} when attempting to stop")
 
@@ -3431,36 +3429,18 @@ class AbstractSpinnakerBase(ConfigHandler):
         self._original_machine_graph.add_edge(edge, partition_id)
         self._vertices_or_edges_added = True
 
-    def _shutdown(
-            self, turn_off_machine=None, clear_routing_tables=None,
-            clear_tags=None):
-        """
-        :param bool turn_off_machine:
-        :param bool clear_routing_tables:
-        :param bool clear_tags:
-        """
+    def _shutdown(self):
         self._status = Simulator_Status.SHUTDOWN
-
-        if turn_off_machine is None:
-            turn_off_machine = get_config_bool(
-                "Machine", "turn_off_machine")
-
-        if clear_routing_tables is None:
-            clear_routing_tables = get_config_bool(
-                "Machine", "clear_routing_tables")
-
-        if clear_tags is None:
-            clear_tags = get_config_bool("Machine", "clear_tags")
 
         if self._txrx is not None:
             # if stopping on machine, clear IP tags and routing table
-            self.__clear(clear_tags, clear_routing_tables)
+            self.__clear()
 
         # Fully stop the application
         self.__stop_app()
 
         # stop the transceiver and allocation controller
-        self.__close_transceiver(turn_off_machine)
+        self.__close_transceiver()
         self.__close_allocation_controller()
 
         try:
@@ -3471,13 +3451,9 @@ class AbstractSpinnakerBase(ConfigHandler):
             logger.exception(
                 "Error when closing Notifications")
 
-    def __clear(self, clear_tags, clear_routing_tables):
-        """
-        :param bool clear_tags:
-        :param bool clear_routing_tables:
-        """
+    def __clear(self):
         # if stopping on machine, clear IP tags and
-        if clear_tags:
+        if get_config_bool("Machine", "clear_tags"):
             for ip_tag in self._tags.ip_tags:
                 self._txrx.clear_ip_tag(
                     ip_tag.tag, board_address=ip_tag.board_address)
@@ -3487,7 +3463,7 @@ class AbstractSpinnakerBase(ConfigHandler):
                     board_address=reverse_ip_tag.board_address)
 
         # if clearing routing table entries, clear
-        if clear_routing_tables:
+        if get_config_bool("Machine", "clear_routing_tables"):
             for router_table in self._router_tables.routing_tables:
                 if not self._machine.get_chip_at(
                         router_table.x, router_table.y).virtual:
@@ -3501,15 +3477,9 @@ class AbstractSpinnakerBase(ConfigHandler):
         if self._txrx is not None and self._app_id is not None:
             self._txrx.stop_application(self._app_id)
 
-    def __close_transceiver(self, turn_off_machine):
-        """
-        :param bool turn_off_machine:
-        """
+    def __close_transceiver(self):
         if self._txrx is not None:
-            if turn_off_machine:
-                logger.info("Turning off machine")
-
-            self._txrx.close(power_off_machine=turn_off_machine)
+            self._txrx.close()
             self._txrx = None
 
     def __close_allocation_controller(self):
@@ -3517,19 +3487,10 @@ class AbstractSpinnakerBase(ConfigHandler):
             self._machine_allocation_controller.close()
             self._machine_allocation_controller = None
 
-    def stop(self, turn_off_machine=None,  # pylint: disable=arguments-differ
-             clear_routing_tables=None, clear_tags=None):
+    def stop(self):
         """
         End running of the simulation.
 
-        :param bool turn_off_machine:
-            decides if the machine should be powered down after running the
-            execution. Note that this powers down all boards connected to the
-            BMP connections given to the transceiver
-        :param bool clear_routing_tables: informs the tool chain if it
-            should turn off the clearing of the routing tables
-        :param bool clear_tags: informs the tool chain if it should clear the
-            tags off the machine at stop
         """
         if self._status in [Simulator_Status.SHUTDOWN]:
             raise ConfigurationException("Simulator has already been shutdown")
@@ -3549,7 +3510,7 @@ class AbstractSpinnakerBase(ConfigHandler):
                 self._recover_from_error(e)
 
         # shut down the machine properly
-        self._shutdown(turn_off_machine, clear_routing_tables, clear_tags)
+        self._shutdown()
 
         if exn is not None:
             self.write_errored_file()

--- a/spinn_front_end_common/interface/spinnaker.cfg
+++ b/spinn_front_end_common/interface/spinnaker.cfg
@@ -149,7 +149,6 @@ scamp_connections_data = None
 boot_connection_port_num = None
 
 auto_detect_bmp = False
-turn_off_machine = False
 clear_routing_tables = False
 clear_tags = False
 

--- a/unittests/test_spinnaker_main_interface.py
+++ b/unittests/test_spinnaker_main_interface.py
@@ -51,12 +51,10 @@ class TestSpinnakerMainInterface(unittest.TestCase):
         mock_contoller = Close_Once()
         interface._machine_allocation_controller = mock_contoller
         self.assertFalse(mock_contoller.closed)
-        interface.stop(turn_off_machine=False, clear_routing_tables=False,
-                       clear_tags=False)
+        interface.stop()
         self.assertTrue(mock_contoller.closed)
         with self.assertRaises(ConfigurationException):
-            interface.stop(turn_off_machine=False, clear_routing_tables=False,
-                           clear_tags=False)
+            interface.stop()
 
     def test_min_init(self):
         class_file = sys.modules[self.__module__].__file__


### PR DESCRIPTION
turn_off_machine
clear_routing_tables
clear_tags

Are to the best of my knowledge never used.

The only place they could come from is user changed cfg files.

Rather than get the values early and passing them down these PR reads them from the cfg at the last possible minutes.

This gives cleaner code and more constant behaviour

Must be done at the same time as:
https://github.com/SpiNNakerManchester/SpiNNMan/pull/272
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1159


Fixes: https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/issues/903

tested by https://github.com/SpiNNakerManchester/IntegrationTests/pull/106