### PR TITLE
 run_until_complete once and then never run again

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -799,9 +799,10 @@ class AbstractSpinnakerBase(ConfigHandler):
             requested to run for the given number of steps.  The host will
             still wait until the simulation itself says it has completed
         """
+        if self._run_until_complete:
+            raise NotImplementedError("Second  run_until_complete")
         self._run_until_complete = True
         self._run(n_steps, sync_time=0)
-        self._run_until_complete = False
 
     def run(self, run_time, sync_time=0):
         """ Run a simulation for a fixed amount of time
@@ -812,6 +813,8 @@ class AbstractSpinnakerBase(ConfigHandler):
             this duration.  The continue_simulation() method must then be
             called for the simulation to continue.
         """
+        if self._run_until_complete:
+            raise NotImplementedError("run after run_until_complete")
         self._run(run_time, sync_time)
 
     def _build_graphs_for_usage(self):


### PR DESCRIPTION
reverts https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/864

Adds safety code which just raises not implemented in places we never expect to happen.

Hopefully better fix for https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/issues/858