### PR TITLE
We do support runforever more than once

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -799,8 +799,6 @@ class AbstractSpinnakerBase(ConfigHandler):
             requested to run for the given number of steps.  The host will
             still wait until the simulation itself says it has completed
         """
-        if self._run_until_complete:
-            raise NotImplementedError("Second  run_until_complete")
         self._run_until_complete = True
         self._run(n_steps, sync_time=0)
 


### PR DESCRIPTION
Alternative to https://github.com/SpiNNakerManchester/SpiNNakerGraphFrontEnd/pull/213

Turns out do even test multiple run forever.

As there Not Implemented was more of a check of do we need to worry it.

As it worked before no good reason to remove the functionality,

tested by 
https://github.com/SpiNNakerManchester/IntegrationTests/pull/116