### PR TITLE
Always app graph

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -142,7 +142,8 @@ from spinn_front_end_common.utilities.utility_objs import (
     ExecutableType)
 from spinn_front_end_common.utility_models import (
     CommandSender, CommandSenderMachineVertex,
-    DataSpeedUpPacketGatherMachineVertex)
+    DataSpeedUpPacketGatherMachineVertex,
+    WrapperApplicationEdge, WrapperApplicationVertex)
 from spinn_front_end_common.utilities import FecTimer
 from spinn_front_end_common.utilities.report_functions.reports import (
     generate_comparison_router_report, partitioner_report,
@@ -3367,10 +3368,6 @@ class AbstractSpinnakerBase(ConfigHandler):
         :raises PacmanConfigurationException:
             If there is an attempt to add the same vertex more than once
         """
-        if self._original_machine_graph.n_vertices:
-            raise ConfigurationException(
-                "Cannot add vertices to both the machine and application"
-                " graphs")
         self._original_application_graph.add_vertex(vertex)
         self._vertices_or_edges_added = True
 
@@ -3383,12 +3380,8 @@ class AbstractSpinnakerBase(ConfigHandler):
             If there is an attempt to add the same vertex more than once
         """
         # check that there's no application vertices added so far
-        if self._original_application_graph.n_vertices:
-            raise ConfigurationException(
-                "Cannot add vertices to both the machine and application"
-                " graphs")
-        self._original_machine_graph.add_vertex(vertex)
-        self._vertices_or_edges_added = True
+        wrapped = WrapperApplicationVertex(vertex)
+        self.add_application_vertex(wrapped)
 
     def add_application_edge(self, edge_to_add, partition_identifier):
         """
@@ -3408,8 +3401,8 @@ class AbstractSpinnakerBase(ConfigHandler):
         :param str partition_id:
             the partition identifier for the outgoing edge partition
         """
-        self._original_machine_graph.add_edge(edge, partition_id)
-        self._vertices_or_edges_added = True
+        wrapper = WrapperApplicationEdge(edge)
+        self.add_application_edge(wrapper, partition_id)
 
     def _shutdown(self):
         self._status = Simulator_Status.SHUTDOWN

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -205,7 +205,7 @@ class AbstractSpinnakerBase(ConfigHandler):
         # the pacman machine graph, used to hold vertices which represent cores
         "_machine_graph",
 
-       # The holder for where machine graph vertices are placed.
+        # The holder for where machine graph vertices are placed.
         "_placements",
 
         # The holder for the routing table entries for all used routers in this

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -205,12 +205,7 @@ class AbstractSpinnakerBase(ConfigHandler):
         # the pacman machine graph, used to hold vertices which represent cores
         "_machine_graph",
 
-        # the end user pacman machine graph, used to hold vertices which
-        # represent cores.
-        # Object created by init. Added to but never new object
-        "_original_machine_graph",
-
-        # The holder for where machine graph vertices are placed.
+       # The holder for where machine graph vertices are placed.
         "_placements",
 
         # The holder for the routing table entries for all used routers in this
@@ -439,9 +434,6 @@ class AbstractSpinnakerBase(ConfigHandler):
 
         # pacman objects
         self._original_application_graph = ApplicationGraph(label=graph_label)
-        self._original_machine_graph = MachineGraph(
-            label=graph_label,
-            application_graph=self._original_application_graph)
 
         self._machine_allocation_controller = None
         self._txrx = None
@@ -785,8 +777,6 @@ class AbstractSpinnakerBase(ConfigHandler):
 
         if self._original_application_graph.n_vertices:
             return True
-        if self._original_machine_graph.n_vertices:
-            return True
         logger.warning(
             "Your graph has no vertices in it. "
             "Therefor the run call will exit immediately.")
@@ -817,14 +807,10 @@ class AbstractSpinnakerBase(ConfigHandler):
         self._run(run_time, sync_time)
 
     def _build_graphs_for_usage(self):
-        if self._original_application_graph.n_vertices:
-            if self._original_machine_graph.n_vertices:
-                raise ConfigurationException(
-                    "Illegal state where both original_application and "
-                    "original machine graph have vertices in them")
-
         self._application_graph = self._original_application_graph.clone()
-        self._machine_graph = self._original_machine_graph.clone()
+        self._machine_graph = MachineGraph(
+            label=self._application_graph.label,
+            application_graph=self._application_graph)
 
     def __timesteps(self, time_in_ms):
         """ Get a number of timesteps for a given time in milliseconds.
@@ -3185,26 +3171,6 @@ class AbstractSpinnakerBase(ConfigHandler):
                         if reset_flags:
                             edge.mark_no_changes()
 
-        # if no application, but a machine graph, check for changes there
-        elif self._original_machine_graph.n_vertices:
-            for machine_vertex in self._original_machine_graph.vertices:
-                if isinstance(machine_vertex, AbstractChangableAfterRun):
-                    if machine_vertex.requires_mapping:
-                        changed = True
-                    if machine_vertex.requires_data_generation:
-                        data_changed = True
-                    if reset_flags:
-                        machine_vertex.mark_no_changes()
-            for partition in \
-                    self._original_machine_graph.outgoing_edge_partitions:
-                for machine_edge in partition.edges:
-                    if isinstance(machine_edge, AbstractChangableAfterRun):
-                        if machine_edge.requires_mapping:
-                            changed = True
-                        if machine_edge.requires_data_generation:
-                            data_changed = True
-                        if reset_flags:
-                            machine_edge.mark_no_changes()
         return changed, data_changed
 
     @property
@@ -3239,13 +3205,6 @@ class AbstractSpinnakerBase(ConfigHandler):
         :rtype: ~pacman.model.graphs.machine.MachineGraph
         """
         return MachineGraphView(self._machine_graph)
-
-    @property
-    def original_machine_graph(self):
-        """
-        :rtype: ~pacman.model.graphs.machine.MachineGraph
-        """
-        return self._original_machine_graph
 
     @property
     def original_application_graph(self):
@@ -3572,15 +3531,8 @@ class AbstractSpinnakerBase(ConfigHandler):
 
     def __reset_graph_elements(self):
         # Reset any object that can reset
-        if self._original_application_graph.n_vertices:
-            for vertex in self._original_application_graph.vertices:
-                self.__reset_object(vertex)
-            for p in self._original_application_graph.outgoing_edge_partitions:
-                for edge in p.edges:
-                    self.__reset_object(edge)
-        elif self._original_machine_graph.n_vertices:
-            for machine_vertex in self._original_machine_graph.vertices:
-                self.__reset_object(machine_vertex)
-            for p in self._original_machine_graph.outgoing_edge_partitions:
-                for machine_edge in p.edges:
-                    self.__reset_object(machine_edge)
+        for vertex in self._original_application_graph.vertices:
+            self.__reset_object(vertex)
+        for p in self._original_application_graph.outgoing_edge_partitions:
+            for edge in p.edges:
+                self.__reset_object(edge)

--- a/spinn_front_end_common/utility_models/__init__.py
+++ b/spinn_front_end_common/utility_models/__init__.py
@@ -30,6 +30,8 @@ from .reverse_ip_tag_multi_cast_source import ReverseIpTagMultiCastSource
 from .reverse_ip_tag_multicast_source_machine_vertex import (
     ReverseIPTagMulticastSourceMachineVertex)
 from .streaming_context_manager import StreamingContextManager
+from .wrapper_application_edge import WrapperApplicationEdge
+from .wrapper_application_vertex import WrapperApplicationVertex
 
 __all__ = ["CommandSender", "CommandSenderMachineVertex",
            "ChipPowerMonitor", "ChipPowerMonitorMachineVertex",
@@ -38,4 +40,5 @@ __all__ = ["CommandSender", "CommandSenderMachineVertex",
            "LivePacketGather", "LivePacketGatherMachineVertex",
            "MultiCastCommand", "ReverseIpTagMultiCastSource",
            "ReverseIPTagMulticastSourceMachineVertex",
-           "StreamingContextManager"]
+           "StreamingContextManager",
+           "WrapperApplicationEdge", "WrapperApplicationVertex"]

--- a/spinn_front_end_common/utility_models/wrapper_application_edge.py
+++ b/spinn_front_end_common/utility_models/wrapper_application_edge.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2022-202 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pacman.model.graphs.application import ApplicationEdge
+
+
+class WrapperApplicationEdge(ApplicationEdge):
+
+    def __init__(self, machine_edge):
+        pre_vertex = machine_edge.pre_vertex.app_vertex
+        post_vertex = machine_edge.post_vertex.app_vertex
+        super().__init__(pre_vertex, post_vertex, machine_edge.label)
+        machine_edge._app_edge = self

--- a/spinn_front_end_common/utility_models/wrapper_application_vertex.py
+++ b/spinn_front_end_common/utility_models/wrapper_application_vertex.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2022-202 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pacman.model.graphs import AbstractSupportsSDRAMEdges, AbstractVirtual
+from pacman.model.graphs.application.abstract import (
+    AbstractOneAppOneMachineVertex)
+
+
+class WrapperApplicationVertex(AbstractOneAppOneMachineVertex):
+
+    def __init__(self, machine_vertex, constraints=None):
+        """
+        Creates an ApplicationVertex which has exactly one predefined \
+        MachineVertex
+
+        :param machine_vertex: MachineVertex
+        :param iterable(AbstractConstraint) constraints:
+            The optional initial constraints of the vertex.
+        :raise PacmanInvalidParameterException:
+            If one of the constraints is not valid
+        """
+        if isinstance(machine_vertex, AbstractSupportsSDRAMEdges):
+            raise NotImplementedError(
+                "Wrapping a vertex which implements "
+                "AbstractSupportsSDRAMEdges is not supported yet")
+        if isinstance(machine_vertex, AbstractVirtual):
+            raise NotImplementedError(
+                "Wrapping a virtual vertex is not supported yet")
+        super().__init__(
+            machine_vertex, machine_vertex.label, constraints,
+            machine_vertex.vertex_slice.n_atoms)
+        machine_vertex._app_vertex = self


### PR DESCRIPTION
Cherry pick from https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/884/

This PR guarantees there is always an Application graph.

But at the price that GFE users will see (fast) partitioning even when they only supplied machine vertices.

The main purpose of this PR is to support the work in reduce overhead.

That is why all the check for Machine vs application graph are left in to avoid clashes.

Tested by
http://apollo.cs.man.ac.uk:8080/blue/organizations/jenkins/Integration%20Tests/detail/always_app/1/pipeline