### PR TITLE
Use the correct runtime value in energy reporting

### DIFF
--- a/spinn_front_end_common/utilities/report_functions/energy_report.py
+++ b/spinn_front_end_common/utilities/report_functions/energy_report.py
@@ -73,7 +73,7 @@ class EnergyReport(object):
         summary_report = os.path.join(report_dir, self._SUMMARY_FILENAME)
 
         # figure runtime in milliseconds with time scale factor
-        runtime_total_ms = time_scale_factor()
+        runtime_total_ms = runtime * time_scale_factor()
 
         # create detailed report
         with open(detailed_report, "w") as f:


### PR DESCRIPTION
Not quite sure how this went wrong, but this should fix it.