### PR TITLE
Update .pylintrc

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -243,13 +243,6 @@ max-line-length=100
 # Maximum number of lines in a module
 max-module-lines=1000
 
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
-
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.
 single-line-class-stmt=no


### PR DESCRIPTION
Remove clause from pylintrc that was failing the build. Pylint's just changed to make it warn about a feature long-gone, which was triggering the build failure. https://github.com/PyCQA/pylint/issues/6813