### PR TITLE
Physical board chip report

### DIFF
--- a/spinn_front_end_common/utilities/report_functions/board_chip_report.py
+++ b/spinn_front_end_common/utilities/report_functions/board_chip_report.py
@@ -55,4 +55,4 @@ def _write_report(writer, machine, progress_bar):
 
         writer.write(
             "board with IP address : {} : has chips [{}]\n".format(
-                e_chip.ip_address, xyps.join(", ")))
+                e_chip.ip_address, ", ".join(xyps)))

--- a/spinn_front_end_common/utilities/report_functions/board_chip_report.py
+++ b/spinn_front_end_common/utilities/report_functions/board_chip_report.py
@@ -49,8 +49,10 @@ def _write_report(writer, machine, progress_bar):
     :param ~spinn_machine.Machine machine:
     :param ~spinn_utilities.progress_bar.ProgressBar progress_bar:
     """
-    for chip in progress_bar.over(machine.ethernet_connected_chips):
-        xys = machine.get_existing_xys_on_board(chip)
+    for e_chip in progress_bar.over(machine.ethernet_connected_chips):
+        xyps = [f"{chip.x}, {chip.y}, P: {chip.get_physical_core_id(0)}"
+                for chip in machine.get_chips_by_ethernet(e_chip.x, e_chip.y)]
+
         writer.write(
             "board with IP address : {} : has chips {}\n".format(
-                chip.ip_address, list(xys)))
+                e_chip.ip_address, xyps))

--- a/spinn_front_end_common/utilities/report_functions/board_chip_report.py
+++ b/spinn_front_end_common/utilities/report_functions/board_chip_report.py
@@ -54,5 +54,5 @@ def _write_report(writer, machine, progress_bar):
                 for chip in machine.get_chips_by_ethernet(e_chip.x, e_chip.y)]
 
         writer.write(
-            "board with IP address : {} : has chips {}\n".format(
-                e_chip.ip_address, xyps))
+            "board with IP address : {} : has chips [{}]\n".format(
+                e_chip.ip_address, xyps.join(", ")))

--- a/spinn_front_end_common/utilities/report_functions/board_chip_report.py
+++ b/spinn_front_end_common/utilities/report_functions/board_chip_report.py
@@ -50,7 +50,7 @@ def _write_report(writer, machine, progress_bar):
     :param ~spinn_utilities.progress_bar.ProgressBar progress_bar:
     """
     for e_chip in progress_bar.over(machine.ethernet_connected_chips):
-        xyps = [f"{chip.x}, {chip.y}, P: {chip.get_physical_core_id(0)}"
+        xyps = [f"({chip.x}, {chip.y}, P: {chip.get_physical_core_id(0)})"
                 for chip in machine.get_chips_by_ethernet(e_chip.x, e_chip.y)]
 
         writer.write(


### PR DESCRIPTION
This adds the physical core of the monitor to the board-chip report, which can help in blacklisting when a monitor crashes during an operation.