### PR TITLE
Remove the cloning of the graph

### DIFF
--- a/spinn_front_end_common/data/fec_data_writer.py
+++ b/spinn_front_end_common/data/fec_data_writer.py
@@ -548,3 +548,9 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
         If the close causes an Exception it is logged and ignored
         """
         self.__fec_data._clear_notification_protocol()
+
+    @classmethod
+    @overrides(FecDataView.add_vertex)
+    def add_vertex(cls, vertex):
+        # Avoid the safety check in FecDataView
+        PacmanDataWriter.add_vertex(vertex)

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -503,7 +503,7 @@ class AbstractSpinnakerBase(ConfigHandler):
                     self._hard_reset()
             FecTimer.setup(self)
 
-            self._data_writer.clone_graphs()
+            #self._data_writer.clone_graphs()
             self._add_dependent_verts_and_edges_for_application_graph()
             self._add_commands_to_command_sender()
 
@@ -612,6 +612,9 @@ class AbstractSpinnakerBase(ConfigHandler):
         command_sender = None
         graph = self._data_writer.get_runtime_graph()
         vertices = graph.vertices
+        for vertex in vertices:
+            if isinstance(vertex, CommandSender):
+                command_sender = vertex
         for vertex in vertices:
             if isinstance(vertex, AbstractSendMeMulticastCommandsVertex):
                 # if there's no command sender yet, build one

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -119,7 +119,7 @@ from spinn_front_end_common.utilities.report_functions import (
 from spinn_front_end_common.utilities.iobuf_extractor import IOBufExtractor
 from spinn_front_end_common.utilities.utility_objs import ExecutableType
 from spinn_front_end_common.utility_models import (
-    CommandSender, DataSpeedUpPacketGatherMachineVertex, LivePacketGather)
+    CommandSender, DataSpeedUpPacketGatherMachineVertex)
 from spinn_front_end_common.utilities.report_functions.reports import (
     generate_comparison_router_report, partitioner_report,
     placer_reports_with_application_graph,

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -503,7 +503,6 @@ class AbstractSpinnakerBase(ConfigHandler):
                     self._hard_reset()
             FecTimer.setup(self)
 
-            #self._data_writer.clone_graphs()
             self._add_dependent_verts_and_edges_for_application_graph()
             self._add_commands_to_command_sender()
 

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -251,31 +251,6 @@ class AbstractSpinnakerBase(ConfigHandler):
     def _machine_clear(self):
         pass
 
-    def add_live_packet_gatherer_parameters(
-            self, live_packet_gatherer_params, vertex_to_record_from,
-            partition_ids):
-        """ Adds parameters for a new LPG if needed, or adds to the tracker \
-            for parameters. Note that LPGs can be inserted to track behaviour \
-            either at the application graph level or at the machine graph \
-            level, but not both at the same time.
-
-        :param LivePacketGatherParameters live_packet_gatherer_params:
-            params to look for a LPG
-        :param ~pacman.model.graphs.AbstractVertex vertex_to_record_from:
-            the vertex that needs to send to a given LPG
-        :param list(str) partition_ids:
-            the IDs of the partitions to connect from the vertex
-        """
-        lpg_vertex = self._lpg_vertices.get(live_packet_gatherer_params)
-        if lpg_vertex is None:
-            lpg_vertex = LivePacketGather(
-                live_packet_gatherer_params, live_packet_gatherer_params.label)
-            self._lpg_vertices[live_packet_gatherer_params] = lpg_vertex
-            self._data_writer.add_vertex(lpg_vertex)
-        for part_id in partition_ids:
-            self._data_writer.add_edge(
-                ApplicationEdge(vertex_to_record_from, lpg_vertex), part_id)
-
     def check_machine_specifics(self):
         """ Checks machine specifics for the different modes of execution.
 

--- a/spinn_front_end_common/interface/interface_functions/buffer_extractor.py
+++ b/spinn_front_end_common/interface/interface_functions/buffer_extractor.py
@@ -50,7 +50,7 @@ def _count_regions():
     # Count the regions to be read
     n_regions_to_read = 0
     recording_placements = list()
-    for app_vertex in FecDataView.get_runtime_graph().vertices:
+    for app_vertex in FecDataView.iterate_vertices:
         for vertex in app_vertex.machine_vertices:
             if isinstance(vertex, AbstractReceiveBuffersToHost):
                 n_regions_to_read += len(vertex.get_recorded_region_ids())

--- a/spinn_front_end_common/interface/interface_functions/buffer_extractor.py
+++ b/spinn_front_end_common/interface/interface_functions/buffer_extractor.py
@@ -50,7 +50,7 @@ def _count_regions():
     # Count the regions to be read
     n_regions_to_read = 0
     recording_placements = list()
-    for app_vertex in FecDataView.iterate_vertices:
+    for app_vertex in FecDataView.iterate_vertices():
         for vertex in app_vertex.machine_vertices:
             if isinstance(vertex, AbstractReceiveBuffersToHost):
                 n_regions_to_read += len(vertex.get_recorded_region_ids())

--- a/spinn_front_end_common/interface/interface_functions/database_interface.py
+++ b/spinn_front_end_common/interface/interface_functions/database_interface.py
@@ -70,14 +70,12 @@ def _write_to_db(
         w.add_tags()
         p.update()
         lpg_source_machine_vertices = w.add_lpg_mapping()
-        app_graph = FecDataView.get_runtime_graph()
 
         if get_config_bool(
                 "Database", "create_routing_info_to_neuron_id_mapping"):
             machine_vertices = [
                 (vertex, vertex.injection_partition_id)
-                for app_vertex in app_graph.vertices
-                for vertex in app_vertex.machine_vertices
+                for vertex in FecDataView.iterate_machine_vertices()
                 if isinstance(vertex, AbstractSupportsDatabaseInjection)
                 and vertex.is_in_injection_mode]
             machine_vertices.extend(lpg_source_machine_vertices)

--- a/spinn_front_end_common/interface/interface_functions/graph_provenance_gatherer.py
+++ b/spinn_front_end_common/interface/interface_functions/graph_provenance_gatherer.py
@@ -23,19 +23,18 @@ def graph_provenance_gatherer():
     """ Gets provenance information from the graph.
 
      """
-    application_graph = FecDataView.get_runtime_graph()
     progress = ProgressBar(
-        application_graph.n_vertices +
-        application_graph.n_outgoing_edge_partitions,
+        FecDataView.get_n_vertices() +
+        FecDataView.get_n_partitions(),
         "Getting provenance data from application graph")
-    for vertex in progress.over(application_graph.vertices, False):
+    for vertex in progress.over(FecDataView.iterate_vertices(), False):
         if isinstance(vertex, AbstractProvidesLocalProvenanceData):
             vertex.get_local_provenance_data()
             for m_vertex in vertex.machine_vertices:
                 if isinstance(m_vertex, AbstractProvidesLocalProvenanceData):
                     m_vertex.get_local_provenance_data()
     for partition in progress.over(
-            application_graph.outgoing_edge_partitions):
+            FecDataView.iterate_partitions()):
         for edge in partition.edges:
             if isinstance(edge, AbstractProvidesLocalProvenanceData):
                 edge.get_local_provenance_data()

--- a/spinn_front_end_common/interface/interface_functions/host_bit_field_router_compressor.py
+++ b/spinn_front_end_common/interface/interface_functions/host_bit_field_router_compressor.py
@@ -52,7 +52,6 @@ def host_based_bit_field_router_compressor():
     :rtype: ~pacman.model.routing_tables.MulticastRoutingTables
     """
     routing_tables = FecDataView.get_uncompressed().routing_tables
-    app_graph = FecDataView.get_runtime_graph()
     # create progress bar
     progress = ProgressBar(
         len(routing_tables) * 2,
@@ -71,7 +70,7 @@ def host_based_bit_field_router_compressor():
     key_atom_map = generate_key_to_atom_map()
 
     most_costly_cores = defaultdict(lambda: defaultdict(int))
-    for partition in app_graph.outgoing_edge_partitions:
+    for partition in FecDataView.iterate_partitions():
         for edge in partition.edges:
             splitter = edge.post_vertex.splitter
             for vertex, _ in splitter.get_source_specific_in_coming_vertices(
@@ -107,10 +106,9 @@ def generate_key_to_atom_map():
     :rtype: dict(int,int)
     """
     # build key to n atoms map
-    app_graph = FecDataView.get_runtime_graph()
     routing_infos = FecDataView.get_routing_infos()
     key_to_n_atoms_map = dict()
-    for partition in app_graph.outgoing_edge_partitions:
+    for partition in FecDataView.iterate_partitions():
         for vertex in partition.pre_vertex.splitter.get_out_going_vertices(
                 partition.identifier):
             key = routing_infos.get_first_key_from_pre_vertex(

--- a/spinn_front_end_common/interface/interface_functions/host_execute_data_specification.py
+++ b/spinn_front_end_common/interface/interface_functions/host_execute_data_specification.py
@@ -336,10 +336,9 @@ class _HostExecuteDataSpecification(object):
                 base_address = self.__malloc_region_storage(
                     core, region_size)
                 base_address, size_allocated, bytes_written = context.execute(
-                        core, reader,
-                        self.__select_writer(x, y)
-                        if use_monitors else transceiver.write_memory,
-                        base_address, region_size)
+                    core, reader, self.__select_writer(x, y)
+                    if use_monitors else transceiver.write_memory,
+                    base_address, region_size)
                 dsg_targets.set_write_info(
                     x, y, p, base_address, size_allocated, bytes_written)
 

--- a/spinn_front_end_common/interface/interface_functions/local_tdma_builder.py
+++ b/spinn_front_end_common/interface/interface_functions/local_tdma_builder.py
@@ -97,8 +97,8 @@ def local_tdma_builder():
     # calculate for each app vertex if the time needed fits
     app_verts = list()
     max_fraction_of_sending = 0
-    vertices = FecDataView.get_vertices_by_type(TDMAAwareApplicationVertex)
-    for app_vertex in vertices:
+    for app_vertex in FecDataView.get_vertices_by_type(
+            TDMAAwareApplicationVertex):
         app_verts.append(app_vertex)
 
         # get timings
@@ -131,7 +131,8 @@ def local_tdma_builder():
             .format(time_scale_factor_needed))
 
     # get initial offset for each app vertex.
-    for app_vertex in vertices:
+    for app_vertex in  FecDataView.get_vertices_by_type(
+            TDMAAwareApplicationVertex):
         initial_offset = __generate_initial_offset(
             app_vertex, app_verts, clocks_initial,
             clocks_waiting)

--- a/spinn_front_end_common/interface/interface_functions/local_tdma_builder.py
+++ b/spinn_front_end_common/interface/interface_functions/local_tdma_builder.py
@@ -131,7 +131,7 @@ def local_tdma_builder():
             .format(time_scale_factor_needed))
 
     # get initial offset for each app vertex.
-    for app_vertex in  FecDataView.get_vertices_by_type(
+    for app_vertex in FecDataView.get_vertices_by_type(
             TDMAAwareApplicationVertex):
         initial_offset = __generate_initial_offset(
             app_vertex, app_verts, clocks_initial,

--- a/spinn_front_end_common/interface/interface_functions/machine_bit_field_router_compressor.py
+++ b/spinn_front_end_common/interface/interface_functions/machine_bit_field_router_compressor.py
@@ -133,7 +133,6 @@ class _MachineBitFieldRouterCompressor(object):
         """
         view = FecDataView()
         app_id = FecDataView.get_app_id()
-        app_graph = FecDataView.get_runtime_graph()
         routing_tables = FecDataView.get_uncompressed()
         transceiver = FecDataView.get_transceiver()
         if len(routing_tables.routing_tables) == 0:
@@ -150,7 +149,7 @@ class _MachineBitFieldRouterCompressor(object):
             text += " capped at {} retries".format(retry_count)
         progress_bar = ProgressBar(
             total_number_of_things_to_do=(
-                len(app_graph.vertices) +
+                FecDataView.get_n_vertices() +
                 (len(routing_tables.routing_tables) *
                  self.TIMES_CYCLED_ROUTING_TABLES)),
             string_describing_what_being_progressed=text)
@@ -199,7 +198,7 @@ class _MachineBitFieldRouterCompressor(object):
         # start the host side compressions if needed
         if len(on_host_chips) != 0:
             most_costly_cores = defaultdict(lambda: defaultdict(int))
-            for partition in app_graph.outgoing_edge_partitions:
+            for partition in FecDataView.iterate_partitions():
                 for edge in partition.edges:
                     sttr = edge.pre_vertex.splitter
                     for vertex in sttr.get_source_specific_in_coming_vertices(
@@ -704,10 +703,9 @@ class _MachineBitFieldRouterCompressor(object):
         # data holders
         region_addresses = defaultdict(list)
         sdram_block_addresses_and_sizes = defaultdict(list)
-        app_graph = FecDataView.get_runtime_graph()
 
         for app_vertex in progress_bar.over(
-                app_graph.vertices, finish_at_end=False):
+                FecDataView.iterate_vertices(), finish_at_end=False):
             for m_vertex in app_vertex.machine_vertices:
                 if isinstance(
                         m_vertex, AbstractSupportsBitFieldRoutingCompression):

--- a/spinn_front_end_common/interface/interface_functions/sdram_outgoing_partition_allocator.py
+++ b/spinn_front_end_common/interface/interface_functions/sdram_outgoing_partition_allocator.py
@@ -30,16 +30,15 @@ def sdram_outgoing_partition_allocator():
         transceiver = None
         virtual_usage = defaultdict(int)
 
-    app_graph = FecDataView.get_runtime_graph()
     progress_bar = ProgressBar(
-        total_number_of_things_to_do=len(app_graph.vertices),
+        total_number_of_things_to_do=FecDataView.get_n_vertices(),
         string_describing_what_being_progressed=(
             "Allocating SDRAM for SDRAM outgoing egde partitions"))
 
     # Keep track of SDRAM tags used
     next_tag = defaultdict(lambda: SDRAM_EDGE_BASE_TAG)
 
-    for vertex in app_graph.vertices:
+    for vertex in FecDataView.iterate_vertices():
         sdram_partitions = vertex.splitter.get_internal_sdram_partitions()
         for sdram_partition in sdram_partitions:
 

--- a/spinn_front_end_common/interface/interface_functions/split_lpg_vertices.py
+++ b/spinn_front_end_common/interface/interface_functions/split_lpg_vertices.py
@@ -26,6 +26,5 @@ def split_lpg_vertices(system_placements):
     :param Placements system_placements:
         exiting placements to be added to
     """
-    for vertex in FecDataView.get_runtime_graph().vertices:
-        if isinstance(vertex, LivePacketGather):
-            vertex.splitter.create_vertices(system_placements)
+    for vertex in FecDataView.get_vertices_by_type(LivePacketGather):
+        vertex.splitter.create_vertices(system_placements)

--- a/spinn_front_end_common/interface/splitter_selectors/splitter_selector.py
+++ b/spinn_front_end_common/interface/splitter_selectors/splitter_selector.py
@@ -32,7 +32,7 @@ def splitter_selector():
 
     :rtype: None
     """
-    for app_vertex in PacmanDataView.get_runtime_graph().vertices:
+    for app_vertex in PacmanDataView.iterate_vertices():
         if app_vertex.splitter is None:
             vertex_selector(app_vertex)
 

--- a/spinn_front_end_common/utilities/database/database_writer.py
+++ b/spinn_front_end_common/utilities/database/database_writer.py
@@ -73,7 +73,8 @@ class DatabaseWriter(SQLiteDB):
         """
         if FecDataView.get_vertices_by_type(LivePacketGather):
             return True
-        for vertex in FecDataView.get_vertices_by_type(AbstractSupportsDatabaseInjection):
+        for vertex in FecDataView.get_vertices_by_type(
+                AbstractSupportsDatabaseInjection):
             if vertex.is_in_injection_mode:
                 return True
         return False

--- a/spinn_front_end_common/utilities/report_functions/bit_field_compressor_report.py
+++ b/spinn_front_end_common/utilities/report_functions/bit_field_compressor_report.py
@@ -129,8 +129,7 @@ def _compute_to_merge_per_chip():
     total_to_merge = 0
     to_merge_per_chip = defaultdict(int)
 
-    app_graph = FecDataView.get_runtime_graph()
-    for partition in app_graph.outgoing_edge_partitions:
+    for partition in FecDataView.iterate_partitions():
         for edge in partition.edges:
             splitter = edge.post_vertex.splitter
             for vertex in splitter.get_source_specific_in_coming_vertices(

--- a/spinn_front_end_common/utilities/report_functions/network_specification.py
+++ b/spinn_front_end_common/utilities/report_functions/network_specification.py
@@ -30,23 +30,21 @@ def network_specification():
     :rtype: None
     """
     filename = os.path.join(FecDataView.get_run_dir_path(), _FILENAME)
-    graph = FecDataView.get_runtime_graph()
     try:
         with open(filename, "w", encoding="utf-8") as f:
             f.write("*** Vertices:\n")
-            for vertex in graph.vertices:
-                _write_report(f, vertex, graph)
+            for vertex in FecDataView.iterate_vertices():
+                _write_report(f, vertex)
     except IOError:
         logger.exception("Generate_placement_reports: Can't open file {}"
                          " for writing.", filename)
 
 
-def _write_report(f, vertex, graph):
+def _write_report(f, vertex):
     """
     :param ~io.FileIO f:
     :param vertex:
-    :type vertex: ApplicationVertex or MachineVertex
-    :param ApplicationGraph graph:
+    :type vertex: ApplicationVertex
     """
     if isinstance(vertex, ApplicationVertex):
         f.write("Vertex {}, size: {}, model: {}, max_atoms{}\n".format(
@@ -62,8 +60,9 @@ def _write_report(f, vertex, graph):
             str(constraint)))
 
     f.write("    Outgoing Edge Partitions:\n")
-    for partition in graph.get_outgoing_edge_partitions_starting_at_vertex(
-            vertex):
+    for partition in \
+            FecDataView.get_outgoing_edge_partitions_starting_at_vertex(
+                vertex):
         f.write("    Partition {}:\n".format(
             partition.identifier))
         for edge in partition.edges:

--- a/spinn_front_end_common/utilities/report_functions/reports.py
+++ b/spinn_front_end_common/utilities/report_functions/reports.py
@@ -231,10 +231,9 @@ def partitioner_report():
     file_name = os.path.join(
         FecDataView.get_run_dir_path(), _PARTITIONING_FILENAME)
     time_date_string = time.strftime("%c")
-    graph = FecDataView.get_runtime_graph()
     try:
         with open(file_name, "w", encoding="utf-8") as f:
-            progress = ProgressBar(graph.n_vertices,
+            progress = ProgressBar(FecDataView.get_n_vertices(),
                                    "Generating partitioner report")
 
             f.write("        Partitioning Information by Vertex\n")
@@ -242,7 +241,7 @@ def partitioner_report():
             f.write(f"Generated: {time_date_string} for target machine "
                     f"'{FecDataView.get_ipaddress()}'\n\n")
 
-            for vertex in progress.over(graph.vertices):
+            for vertex in progress.over(FecDataView.iterate_vertices()):
                 _write_one_vertex_partition(f, vertex)
     except IOError:
         logger.exception("Generate_placement_reports: Can't open file {} for"
@@ -284,10 +283,9 @@ def placement_report_with_application_graph_by_vertex():
     file_name = os.path.join(
         FecDataView.get_run_dir_path(), _PLACEMENT_VTX_GRAPH_FILENAME)
     time_date_string = time.strftime("%c")
-    graph = FecDataView.get_runtime_graph()
     try:
         with open(file_name, "w", encoding="utf-8") as f:
-            progress = ProgressBar(graph.n_vertices,
+            progress = ProgressBar(FecDataView.get_n_vertices(),
                                    "Generating placement report")
 
             f.write("        Placement Information by Vertex\n")
@@ -295,7 +293,7 @@ def placement_report_with_application_graph_by_vertex():
             f.write(f"Generated: {time_date_string} "
                     f"for target machine '{FecDataView.get_ipaddress()}'\n\n")
 
-            for vertex in progress.over(graph.vertices):
+            for vertex in progress.over(FecDataView.iterate_vertices()):
                 _write_one_vertex_application_placement(f, vertex)
     except IOError:
         logger.exception("Generate_placement_reports: Can't open file {} for"
@@ -528,13 +526,12 @@ def routing_info_report(extra_allocations):
 
     """
     file_name = os.path.join(FecDataView.get_run_dir_path(), _VIRTKEY_FILENAME)
-    app_graph = FecDataView.get_runtime_graph()
     routing_infos = FecDataView.get_routing_infos()
     try:
         with open(file_name, "w", encoding="utf-8") as f:
             vertex_partitions = set(
                 (p.pre_vertex, p.identifier)
-                for p in app_graph.outgoing_edge_partitions)
+                for p in FecDataView.iterate_partitions())
             vertex_partitions.update(extra_allocations)
             progress = ProgressBar(len(vertex_partitions),
                                    "Generating Routing info report")

--- a/unittests/data/test_simulator_data.py
+++ b/unittests/data/test_simulator_data.py
@@ -730,5 +730,7 @@ class TestSimulatorData(unittest.TestCase):
         cs = CommandSender("test", [])
         writer.add_vertex(app1)
         with self.assertRaises(NotImplementedError):
-            writer.add_vertex((cs))
+            FecDataView.add_vertex((cs))
         self.assertEqual(1, FecDataView.get_n_vertices())
+        writer.add_vertex(cs)
+        self.assertEqual(2, FecDataView.get_n_vertices())


### PR DESCRIPTION
Support for https://github.com/SpiNNakerManchester/PACMAN/pull/449

Does not claim to be the best longer term solution for _add_commands_to_command_sender or _add_dependent_verts_and_edges_for_application_graph
Rather is just enough to avoid the need of the cloned graph, especially when run is called more than once.

removes unused ASB.add_live_packet_gatherer_parameters (functionality had been moved to the View in https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/929