### PR TITLE
Fix routing

### DIFF
--- a/spinn_front_end_common/utility_models/lpg_splitter.py
+++ b/spinn_front_end_common/utility_models/lpg_splitter.py
@@ -117,3 +117,4 @@ class LPGSplitter(AbstractSplitterCommon):
     @overrides(AbstractSplitterCommon.reset_called)
     def reset_called(self):
         self.__m_vertices_by_ethernet = dict()
+        self.__targeted_lpgs = set()


### PR DESCRIPTION
Changes LPG splitting so that an application vertex will only target one LPG machine vertex in total.  This is needed to ensure that the routing of the vertices works.

Relies on SpiNNakerManchester/PACMAN#470