### PR TITLE
get_placement_on_processor

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1949,6 +1949,7 @@ class AbstractSpinnakerBase(ConfigHandler):
             if timer.skip_if_virtual_board():
                 return []
             # Also used in recover from error where is is not all placements
+
             placements_provenance_gatherer(
                 self._data_writer.get_n_placements(),
                 self._data_writer.iterate_placemements())
@@ -2269,10 +2270,13 @@ class AbstractSpinnakerBase(ConfigHandler):
                 finished_cores = transceiver.get_cores_in_state(
                     non_rte_core_subsets, CPUState.FINISHED)
                 finished_placements = Placements()
-                placements = self._data_writer.get_placements()
                 for (x, y, p) in finished_cores:
-                    finished_placements.add_placement(
-                        placements.get_placement_on_processor(x, y, p))
+                    try:
+                        placement = self._data_writer.\
+                            get_placement_on_processor(x, y, p)
+                        finished_placements.add_placement(placement)
+                    except Exception:   # pylint: disable=broad-except
+                        pass  # already recovering from error
                 placements_provenance_gatherer(
                     finished_placements.n_placements,
                     finished_placements.placements)

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -220,8 +220,8 @@ class BufferManager(object):
         """
         if not self._finished:
             with self._thread_lock_buffer_in:
-                vertex = FecDataView.get_vertex_on_processor(
-                    packet.x, packet.y, packet.p)
+                vertex = FecDataView.get_placement_on_processor(
+                    packet.x, packet.y, packet.p).vertex
                 if vertex in self._sender_vertices:
                     self._send_messages(
                         packet.space_available, vertex,


### PR DESCRIPTION
The view.get_placement_on_processor was missing and needed by ASB.__recover_from _error

As view.get_vertex_on_processor differed only by where the .vertex was placed I choose to remove the get_vertex_on_processor from both Placements and View and instead replaced its only use with
view.get_placement_on_processor().vertex

Depends on: https://github.com/SpiNNakerManchester/PACMAN/pull/471