### PR TITLE
more flexibility for when tests interact

### DIFF
--- a/unittests/interface/provenance/test_provenance_database.py
+++ b/unittests/interface/provenance/test_provenance_database.py
@@ -186,12 +186,14 @@ class TestProvenanceDatabase(unittest.TestCase):
         db1.store_log(30, "this is a warning")
         db2.store_log(10, "this is a debug")
         db1.store_log(20, "this is an info")
-        self.assertListEqual(
-            ["this is a warning", "this is a debug", "this is an info"],
-            db2.retreive_log_messages())
-        self.assertListEqual(
-            ["this is a warning", "this is an info"],
-            db1.retreive_log_messages(20))
+        messages = db2.retreive_log_messages()
+        self.assertIn("this is a warning", messages)
+        self.assertIn("this is a debug", messages)
+        self.assertIn("this is an info", messages)
+        messages = db2.retreive_log_messages(20)
+        self.assertIn("this is a warning", messages)
+        self.assertNotIn("this is a debug", messages)
+        self.assertIn("this is an info", messages)
         db2.get_location()
 
     def test_database_locked(self):
@@ -201,10 +203,12 @@ class TestProvenanceDatabase(unittest.TestCase):
         with ProvenanceWriter() as db:
             db._test_log_locked("locked")
             logger.warning("not locked")
-        logger.warning("this wis fine")
+        logger.warning("this is fine")
         # the use of class variables and tests run in parallel dont work.
-        if "JENKINS_URL" not in os.environ:
-            self.assertListEqual(
-                ["this works", "not locked", "this wis fine"],
-                ls.retreive_log_messages(20))
+        # if "JENKINS_URL" not in os.environ:
+        messages = ls.retreive_log_messages(20)
+        self.assertIn("this works", messages)
+        self.assertIn("not locked", messages)
+        self.assertIn("this is fine", messages)
+        self.assertNotIn("locked", messages)
         logger.set_log_store(None)


### PR DESCRIPTION
related to https://github.com/SpiNNakerManchester/SpiNNUtils/pull/195 but can be merged separately.

If all test run together on some systems the tests can interact.
For example on Windows the log appears to go into a different thread and does not happen until the next test is already running.

tested by: