### PR TITLE
Global provenance

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -98,7 +98,7 @@ from spinn_front_end_common.interface.interface_functions.\
     host_no_bitfield_router_compression import (
         ordered_covering_compression, pair_compression)
 from spinn_front_end_common.interface.provenance import (
-    FecTimer, ProvenanceWriter, TimerCategory, TimerWork)
+    FecTimer, GlobalProvenance, TimerCategory, TimerWork)
 from spinn_front_end_common.interface.splitter_selectors import (
     splitter_selector)
 from spinn_front_end_common.interface.java_caller import JavaCaller
@@ -721,7 +721,7 @@ class AbstractSpinnakerBase(ConfigHandler):
     def _create_version_provenance(self):
         """ Add the version information to the provenance data at the start.
         """
-        with ProvenanceWriter() as db:
+        with GlobalProvenance() as db:
             db.insert_version("spinn_utilities_version", spinn_utils_version)
             db.insert_version("spinn_machine_version", spinn_machine_version)
             db.insert_version("spalloc_version", spalloc_version)

--- a/spinn_front_end_common/interface/interface_functions/compute_energy_used.py
+++ b/spinn_front_end_common/interface/interface_functions/compute_energy_used.py
@@ -71,14 +71,14 @@ def compute_energy_used(machine_allocation_controller=None):
             FecDataView.get_current_run_timesteps() *
             FecDataView.get_time_scale_factor())
     machine = FecDataView.get_machine()
-    db = ProvenanceReader()
-    dsg_time = db.get_category_timer_sum(TimerCategory.DATA_GENERATION)
-    execute_time = db.get_category_timer_sum(TimerCategory.RUN_LOOP)
-    # NOTE: this extraction time is part of the execution time; it does not
-    #       refer to the time taken in e.g. pop.get_data() or projection.get()
-    extraction_time = db.get_timer_sum_by_work(TimerWork.EXTRACT_DATA)
-    load_time = db.get_category_timer_sum(TimerCategory.LOADING)
-    mapping_time = db.get_category_timer_sum(TimerCategory.MAPPING)
+    with ProvenanceReader() as db:
+        dsg_time = db.get_category_timer_sum(TimerCategory.DATA_GENERATION)
+        execute_time = db.get_category_timer_sum(TimerCategory.RUN_LOOP)
+        # NOTE: this extraction time is part of the execution time; it does not
+        # refer to the time taken in e.g. pop.get_data() or projection.get()
+        extraction_time = db.get_timer_sum_by_work(TimerWork.EXTRACT_DATA)
+        load_time = db.get_category_timer_sum(TimerCategory.LOADING)
+        mapping_time = db.get_category_timer_sum(TimerCategory.MAPPING)
     # TODO get_machine not include here
     power_used = PowerUsed()
 
@@ -187,13 +187,14 @@ def _router_packet_energy(power_used):
     :param PowerUsed power_used:
     """
     energy_cost = 0.0
-    for name, cost in _COST_PER_TYPE.items():
-        data = ProvenanceReader().get_router_by_chip(name)
-        for (x, y, value) in data:
-            this_cost = value * cost
-            energy_cost += this_cost
-            if this_cost:
-                power_used.add_router_active_energy(x, y, this_cost)
+    with ProvenanceReader() as db:
+        for name, cost in _COST_PER_TYPE.items():
+            data = db.get_router_by_chip(name)
+            for (x, y, value) in data:
+                this_cost = value * cost
+                energy_cost += this_cost
+                if this_cost:
+                    power_used.add_router_active_energy(x, y, this_cost)
 
     power_used.packet_joules = energy_cost
 
@@ -359,8 +360,8 @@ def _calculate_loading_energy(machine, load_time_ms, n_monitors, n_frames):
     # pylint: disable=too-many-arguments
 
     # find time in milliseconds
-    reader = ProvenanceReader()
-    total_time_ms = reader.get_timer_sum_by_category(TimerCategory.LOADING)
+    with ProvenanceReader() as db:
+        total_time_ms = db.get_timer_sum_by_category(TimerCategory.LOADING)
 
     # handle monitor core active cost
 
@@ -405,8 +406,8 @@ def _calculate_data_extraction_energy(machine, n_monitors, n_frames):
     # find time
     # TODO is this what was desired
     total_time_ms = 0
-    buffer_time_ms = ProvenanceReader().get_timer_sum_by_work(
-        TimerWork.EXTRACT_DATA)
+    with ProvenanceReader() as db:
+        buffer_time_ms = db.get_timer_sum_by_work(TimerWork.EXTRACT_DATA)
 
     energy_cost = 0
     # NOTE: Buffer time could be None if nothing was set to record

--- a/spinn_front_end_common/interface/interface_functions/compute_energy_used.py
+++ b/spinn_front_end_common/interface/interface_functions/compute_energy_used.py
@@ -17,7 +17,7 @@ import itertools
 from spinn_utilities.config_holder import (get_config_int, get_config_str)
 from spinn_front_end_common.data import FecDataView
 from spinn_front_end_common.interface.provenance import (
-    ProvenanceReader, TimerCategory, TimerWork)
+    GlobalProvenance, ProvenanceReader, TimerCategory, TimerWork)
 from spinn_front_end_common.utilities.utility_objs import PowerUsed
 from spinn_front_end_common.utility_models import (
     ChipPowerMonitorMachineVertex)
@@ -71,7 +71,7 @@ def compute_energy_used(machine_allocation_controller=None):
             FecDataView.get_current_run_timesteps() *
             FecDataView.get_time_scale_factor())
     machine = FecDataView.get_machine()
-    with ProvenanceReader() as db:
+    with GlobalProvenance() as db:
         dsg_time = db.get_category_timer_sum(TimerCategory.DATA_GENERATION)
         execute_time = db.get_category_timer_sum(TimerCategory.RUN_LOOP)
         # NOTE: this extraction time is part of the execution time; it does not
@@ -360,7 +360,7 @@ def _calculate_loading_energy(machine, load_time_ms, n_monitors, n_frames):
     # pylint: disable=too-many-arguments
 
     # find time in milliseconds
-    with ProvenanceReader() as db:
+    with GlobalProvenance() as db:
         total_time_ms = db.get_timer_sum_by_category(TimerCategory.LOADING)
 
     # handle monitor core active cost
@@ -406,7 +406,7 @@ def _calculate_data_extraction_energy(machine, n_monitors, n_frames):
     # find time
     # TODO is this what was desired
     total_time_ms = 0
-    with ProvenanceReader() as db:
+    with GlobalProvenance() as db:
         buffer_time_ms = db.get_timer_sum_by_work(TimerWork.EXTRACT_DATA)
 
     energy_cost = 0

--- a/spinn_front_end_common/interface/interface_functions/spalloc_allocator.py
+++ b/spinn_front_end_common/interface/interface_functions/spalloc_allocator.py
@@ -166,7 +166,8 @@ def _launch_checked_job(n_boards, spalloc_kw_args):
         connections = job.connections
         info = str(connections).replace("{", "[").replace("}", "]")
         logger.info("boards: " + info)
-        ProvenanceWriter().insert_board_provenance(connections)
+        with ProvenanceWriter() as db:
+            db.insert_board_provenance(connections)
         if hostname in avoid_boards:
             avoid_jobs.append(job)
             logger.warning(

--- a/spinn_front_end_common/interface/provenance/__init__.py
+++ b/spinn_front_end_common/interface/provenance/__init__.py
@@ -18,6 +18,7 @@ from .abstract_provides_local_provenance_data import (
 from .abstract_provides_provenance_data_from_machine import (
     AbstractProvidesProvenanceDataFromMachine)
 from .fec_timer import FecTimer
+from .global_provenance import GlobalProvenance
 from .log_store_db import LogStoreDB
 from .provenance_reader import ProvenanceReader
 from .provides_provenance_data_from_machine_impl import (
@@ -27,6 +28,7 @@ from .timer_category import TimerCategory
 from .timer_work import TimerWork
 
 __all__ = ["AbstractProvidesLocalProvenanceData", "FecTimer",
+           "GlobalProvenance",
            "AbstractProvidesProvenanceDataFromMachine", "LogStoreDB",
            "ProvenanceReader", "ProvenanceWriter",
            "ProvidesProvenanceDataFromMachineImpl",

--- a/spinn_front_end_common/interface/provenance/fec_timer.py
+++ b/spinn_front_end_common/interface/provenance/fec_timer.py
@@ -20,8 +20,7 @@ from datetime import timedelta
 from spinn_utilities.config_holder import (get_config_bool)
 from spinn_utilities.log import FormatAdapter
 from spinn_front_end_common.data import FecDataView
-from spinn_front_end_common.interface.provenance.provenance_writer import (
-    ProvenanceWriter)
+from .global_provenance import GlobalProvenance
 
 logger = FormatAdapter(logging.getLogger(__name__))
 
@@ -108,7 +107,7 @@ class FecTimer(object):
     def skip(self, reason):
         message = f"{self._algorithm} skipped as {reason}"
         timedelta = self._stop_timer()
-        with ProvenanceWriter() as db:
+        with GlobalProvenance() as db:
             db.insert_timing(self._category_id, self._algorithm, self._work,
                              timedelta, reason)
         self._report(message)
@@ -157,7 +156,7 @@ class FecTimer(object):
     def error(self, reason):
         timedelta = self._stop_timer()
         message = f"{self._algorithm} failed after {timedelta} as {reason}"
-        with ProvenanceWriter() as db:
+        with GlobalProvenance() as db:
             db.insert_timing(self._category_id, self._algorithm,
                              self._work, timedelta, reason)
         self._report(message)
@@ -190,7 +189,7 @@ class FecTimer(object):
                           f"after {timedelta}"
                 skip = f"Exception {ex}"
 
-        with ProvenanceWriter() as db:
+        with GlobalProvenance() as db:
             db.insert_timing(self._category_id, self._algorithm, self._work,
                              timedelta, skip)
         self._report(message)
@@ -205,7 +204,7 @@ class FecTimer(object):
         """
         time_now = _now()
         if cls._category_id:
-            with ProvenanceWriter() as db:
+            with GlobalProvenance() as db:
                 diff = _convert_to_timedelta(time_now - cls._category_time)
                 db.insert_category_timing(cls._category_id, diff)
         return time_now
@@ -218,7 +217,7 @@ class FecTimer(object):
         :param TimerCategory category: Category to switch to
         """
         time_now = cls.__stop_category()
-        with ProvenanceWriter() as db:
+        with GlobalProvenance() as db:
             cls._category_id = db.insert_category(category, cls._machine_on)
         cls._category = category
         cls._category_time = time_now

--- a/spinn_front_end_common/interface/provenance/global.sql
+++ b/spinn_front_end_common/interface/provenance/global.sql
@@ -34,7 +34,7 @@ CREATE TABLE IF NOT EXISTS timer_provenance(
     skip_reason STRING);
 
 CREATE VIEW IF NOT EXISTS full_timer_view AS
-    SELECT timer_id, category, algorithm, work, machine_on, timer_provenance.time_taken, n_run, n_loop
+    SELECT timer_id, category, algorithm, work, machine_on, timer_provenance.time_taken, n_run, n_loop, skip_reason
     FROM timer_provenance ,category_timer_provenance
 	WHERE timer_provenance.category_id = category_timer_provenance.category_id
     ORDER BY timer_id;

--- a/spinn_front_end_common/interface/provenance/global.sql
+++ b/spinn_front_end_common/interface/provenance/global.sql
@@ -1,0 +1,86 @@
+-- Copyright (c) 2018-2022 The University of Manchester
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-- https://www.sqlite.org/pragma.html#pragma_synchronous
+PRAGMA main.synchronous = OFF;
+
+-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+-- A table holding the values for versions
+CREATE TABLE IF NOT EXISTS version_provenance(
+    version_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    description STRING NOT NULL,
+    the_value STRING NOT NULL);
+
+-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+-- A table holding the values for algorithm timings
+CREATE TABLE IF NOT EXISTS timer_provenance(
+    timer_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    category_id INTEGER NOT NULL,
+    algorithm STRING NOT NULL,
+    work STRING NOT NULL,
+    time_taken INTEGER NOT NULL,
+    skip_reason STRING);
+
+CREATE VIEW IF NOT EXISTS full_timer_view AS
+    SELECT timer_id, category, algorithm, work, machine_on, timer_provenance.time_taken, n_run, n_loop
+    FROM timer_provenance ,category_timer_provenance
+	WHERE timer_provenance.category_id = category_timer_provenance.category_id
+    ORDER BY timer_id;
+
+CREATE VIEW IF NOT EXISTS timer_view AS
+    SELECT category, algorithm, work, machine_on, time_taken, n_run, n_loop
+    FROM full_timer_view
+    WHERE skip_reason is NULL
+    ORDER BY timer_id;
+
+-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+-- A table holding the values for category timings
+CREATE TABLE IF NOT EXISTS category_timer_provenance(
+    category_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    category STRING NOT NULL,
+    time_taken INTEGER,
+    machine_on BOOL NOT NULL,
+    n_run INTEGER NOT NULL,
+    n_loop INTEGER);
+
+---------------------------------------------------------------------
+-- A table to store log.info
+CREATE TABLE IF NOT EXISTS p_log_provenance(
+    log_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp TIMESTAMP NOT NULL,
+    level INTEGER NOT NULL,
+    message STRING NOT NULL);
+
+CREATE TABLE IF NOT EXISTS log_level_names(
+    level INTEGER PRIMARY KEY NOT NULL,
+    name STRING NOT NULL);
+
+INSERT OR IGNORE INTO log_level_names
+    (level, name)
+VALUES
+    (50, "CRITICAL"),
+    (40, "ERROR"),
+    (30, "WARNING"),
+    (20, "INFO"),
+    (10, "DEBUG");
+
+CREATE VIEW IF NOT EXISTS p_log_view AS
+    SELECT
+        timestamp,
+		name,
+        message
+    FROM p_log_provenance left join log_level_names
+    ON p_log_provenance.level = log_level_names.level
+    ORDER BY p_log_provenance.log_id;

--- a/spinn_front_end_common/interface/provenance/global_provenance.py
+++ b/spinn_front_end_common/interface/provenance/global_provenance.py
@@ -188,9 +188,10 @@ class GlobalProvenance(SQLiteDB):
             # lock the database
             cur.execute(
                 """
-                INSERT INTO reports(message)
-                VALUES(?)
-                """, [text])
+                INSERT INTO version_provenance(
+                    description, the_value)
+                VALUES("foo", "bar")
+                """)
             cur.lastrowid
             # try logging and storing while locked.
             logger.warning(text)

--- a/spinn_front_end_common/interface/provenance/global_provenance.py
+++ b/spinn_front_end_common/interface/provenance/global_provenance.py
@@ -17,11 +17,10 @@ from datetime import datetime
 import logging
 import os
 import re
-from spinn_utilities.config_holder import get_config_int
 from spinn_utilities.log import FormatAdapter
 from spinn_front_end_common.data import FecDataView
 from spinn_front_end_common.utilities.constants import (
-    MICRO_TO_MILLISECOND_CONVERSION, PROVENANCE_DB)
+    MICRO_TO_MILLISECOND_CONVERSION)
 from spinn_front_end_common.utilities.sqlite_db import SQLiteDB
 
 logger = FormatAdapter(logging.getLogger(__name__))
@@ -59,7 +58,7 @@ class GlobalProvenance(SQLiteDB):
             for example before run is called
         """
         return os.path.join(
-                FecDataView.get_provenance_dir_path(),
+            FecDataView.get_provenance_dir_path(),
             "global_provenance.sqlite3")
 
     def __init__(self, database_file=None, memory=False):

--- a/spinn_front_end_common/interface/provenance/global_provenance.py
+++ b/spinn_front_end_common/interface/provenance/global_provenance.py
@@ -25,7 +25,7 @@ from spinn_front_end_common.utilities.sqlite_db import SQLiteDB
 
 logger = FormatAdapter(logging.getLogger(__name__))
 
-_DDL_FILE = os.path.join(os.path.dirname(__file__), "db.sql")
+_DDL_FILE = os.path.join(os.path.dirname(__file__), "global.sql")
 _RE = re.compile(r"(\d+)([_,:])(\d+)(?:\2(\d+))?")
 
 

--- a/spinn_front_end_common/interface/provenance/global_provenance.py
+++ b/spinn_front_end_common/interface/provenance/global_provenance.py
@@ -1,0 +1,416 @@
+# Copyright (c) 2017-2022 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from datetime import datetime
+import logging
+import os
+import re
+from spinn_utilities.config_holder import get_config_int
+from spinn_utilities.log import FormatAdapter
+from spinn_front_end_common.data import FecDataView
+from spinn_front_end_common.utilities.constants import (
+    MICRO_TO_MILLISECOND_CONVERSION, PROVENANCE_DB)
+from spinn_front_end_common.utilities.sqlite_db import SQLiteDB
+
+logger = FormatAdapter(logging.getLogger(__name__))
+
+_DDL_FILE = os.path.join(os.path.dirname(__file__), "db.sql")
+_RE = re.compile(r"(\d+)([_,:])(\d+)(?:\2(\d+))?")
+
+
+class GlobalProvenance(SQLiteDB):
+    """ Specific implementation of the Database for SQLite 3.
+
+    .. note::
+        *Not thread safe on the same database file.*
+        Threads can access different DBs just fine.
+
+    .. note::
+        This totally relies on the way SQLite's type affinities function.
+        You can't port to a different database engine without a lot of work.
+    """
+
+    __slots__ = [
+        "_database_file"
+    ]
+
+    @classmethod
+    def get_global_provenace_path(cls):
+        """ Get the path of the current provenance database of the last run
+
+        .. warning::
+            Calling this method between start/reset and run may result in a
+            path to a database not yet created.
+
+        :raises ValueError:
+            if the system is in a state where path can't be retrieved,
+            for example before run is called
+        """
+        return os.path.join(
+                FecDataView.get_provenance_dir_path(),
+            "global_provenance.sqlite3")
+
+    def __init__(self, database_file=None, memory=False):
+        """
+        :param database_file:
+            The name of a file that contains (or will contain) an SQLite
+            database holding the data.
+            If omitted, either the default file path or an unshared in-memory
+            database will be used (suitable only for testing).
+        :type database_file: str or None
+        :param bool memory:
+            Flag to say unshared in-memory can be used.
+            Otherwise a None file will mean the default should be used
+
+        """
+        if database_file is None and not memory:
+            database_file = self.get_global_provenace_path()
+        self._database_file = database_file
+        SQLiteDB.__init__(self, database_file, ddl_file=_DDL_FILE,
+                          row_factory=None, text_factory=None)
+
+    def insert_version(self, description, the_value):
+        """
+        Inserts data into the version_provenance table
+
+        :param str description: The package for which the version applies
+        :param str the_value: The version to be recorded
+        """
+        with self.transaction() as cur:
+            cur.execute(
+                """
+                INSERT INTO version_provenance(
+                    description, the_value)
+                VALUES(?, ?)
+                """, [description, the_value])
+
+    def insert_category(self, category, machine_on):
+        """
+        Inserts category into the category_timer_provenance  returning id
+
+        :param TimerCategory category: Name of Category starting
+        :param bool machine_on: If the machine was done during all
+            or some of the time
+        """
+        with self.transaction() as cur:
+            cur.execute(
+                """
+                INSERT INTO category_timer_provenance(
+                    category, machine_on, n_run, n_loop)
+                VALUES(?, ?, ?, ?)
+                """,
+                [category.category_name, machine_on,
+                 FecDataView.get_run_number(),
+                 FecDataView.get_run_step()])
+            return cur.lastrowid
+
+    def insert_category_timing(self, category_id, timedelta):
+        """
+        Inserts run time into the category
+
+        :param int category_id: id of the Category finished
+        :param ~datetime.timedelta timedelta: Time to be recorded
+       """
+        time_taken = (
+                (timedelta.seconds * MICRO_TO_MILLISECOND_CONVERSION) +
+                (timedelta.microseconds / MICRO_TO_MILLISECOND_CONVERSION))
+
+        with self.transaction() as cur:
+            cur.execute(
+                """
+                UPDATE category_timer_provenance
+                SET
+                    time_taken = ?
+                WHERE category_id = ?
+                """, (time_taken, category_id))
+
+    def insert_timing(
+            self, category, algorithm, work, timedelta, skip_reason):
+        """
+        Inserts algorithms run times into the timer_provenance table
+
+        :param int category: Category Id of the Algorithm
+        :param str algorithm: Algorithm name
+        :param TimerWork work: Type of work being done
+        :param ~datetime.timedelta timedelta: Time to be recorded
+        :param skip_reason: The reason the algorthm was skipped or None if
+            it was not skipped
+        :tpye skip_reason: str or None
+        """
+        time_taken = (
+                (timedelta.seconds * MICRO_TO_MILLISECOND_CONVERSION) +
+                (timedelta.microseconds / MICRO_TO_MILLISECOND_CONVERSION))
+        with self.transaction() as cur:
+            cur.execute(
+                """
+                INSERT INTO timer_provenance(
+                    category_id, algorithm, work, time_taken, skip_reason)
+                VALUES(?, ?, ?, ?, ?)
+                """,
+                [category, algorithm, work.work_name, time_taken, skip_reason])
+
+    def store_log(self, level, message, timestamp=None):
+        """
+        Stores log messages into the database
+
+        :param int level:
+        :param str message:
+        """
+        if timestamp is None:
+            timestamp = datetime.now()
+        with self.transaction() as cur:
+            cur.execute(
+                """
+                INSERT INTO p_log_provenance(
+                    timestamp, level, message)
+                VALUES(?, ?, ?)
+                """,
+                [timestamp, level, message])
+
+    def _test_log_locked(self, text):
+        """
+        THIS IS A TESTING METHOD.
+
+        This will lock the database and then try to do a log
+        """
+        with self.transaction() as cur:
+            # lock the database
+            cur.execute(
+                """
+                INSERT INTO reports(message)
+                VALUES(?)
+                """, [text])
+            cur.lastrowid
+            # try logging and storing while locked.
+            logger.warning(text)
+
+    def run_query(self, query, params=()):
+        """
+        Opens a connection to the database, runs a query, extracts the results
+        and closes the connection
+
+        The return type depends on the use_sqlite_rows param.
+        By default this method returns tuples (lookup by index) but the
+        advanced tuple type can be used instead, which supports lookup by name
+        used in the query (use ``AS name`` in the query to set).
+
+        This method will not allow queries that change the database unless the
+        read_only flag is set to False.
+
+        .. note::
+            This method is mainly provided as a support method for the later
+            methods that return specific data. For new IntergationTests
+            please add a specific method rather than call this directly.
+
+        :param str query: The SQL query to be run. May include ``?`` wildcards
+        :param ~collections.abc.Iterable(str or int) params:
+            The values to replace the ``?`` wildcards with.
+            The number and types must match what the query expects
+        :param bool read_only: see :py:meth:`get_database_handle`
+        :param bool use_sqlite_rows: see :py:meth:`get_database_handle`
+        :return: A list possibly empty of tuples/rows
+            (one for each row in the database)
+            where the number and type of the values corresponds to the where
+            statement
+        :rtype: list(tuple or ~sqlite3.Row)
+        """
+        results = []
+        with self.transaction() as cur:
+            for row in cur.execute(query, params):
+                results.append(row)
+        return results
+
+    def get_timer_provenance(self, algorithm):
+        """
+        Gets the timer provenance item(s) from the last run
+
+        :param str algorithm:
+            The value to LIKE search for in the algorithm column.
+            Can be the full name, or have ``%``  and ``_`` wildcards.
+        :return:
+            A possibly multiline string with for each row which matches the
+            like a line ``algorithm: value``
+        :rtype: str
+        """
+        query = """
+            SELECT algorithm, time_taken
+            FROM timer_provenance
+            WHERE algorithm LIKE ?
+            """
+        return "\n".join(
+            f"{row[0]}: {row[1]}"
+            for row in self.run_query(query, [algorithm]))
+
+    def get_run_times(self):
+        """
+        Gets the algorithm running times from the last run. If an algorithm is
+        invoked multiple times in the run, its times are summed.
+
+        :return:
+            A possibly multiline string with for each row which matches the
+            like a line ``description_name: time``. The times are in seconds.
+        :rtype: str
+        """
+        # We know the database actually stores microseconds for durations
+        query = """
+            SELECT description, SUM(time_taken) / 1000000.0
+            FROM timer_provenance
+            GROUP BY description
+            ORDER BY the_value
+            """
+        return "\n".join(
+            f"{row[0].replace('_', ' ')}: {row[1]} s"
+            for row in self.run_query(query))
+
+    def get_run_time_of_BufferExtractor(self):
+        """
+        Gets the BufferExtractor provenance item(s) from the last run
+
+        :return:
+            A possibly multiline string with for each row which matches the
+            like %BufferExtractor description_name: value
+        :rtype: str
+        """
+        return self.get_timer_provenance("%BufferExtractor")
+
+    def get_category_timer_sum(self, category):
+        """
+        Get the total runtime for one category of algorithms
+
+        :param  TimerCategory category:
+        :return: total off all runtimes with this category
+        :rtype: int
+        """
+        query = """
+             SELECT sum(time_taken)
+             FROM category_timer_provenance
+             WHERE category = ?
+             """
+        data = self.run_query(query, [category.category_name])
+        try:
+            info = data[0][0]
+            if info is None:
+                return 0
+            return info
+        except IndexError:
+            return 0
+
+    def get_category_timer_sums(self, category):
+        """
+        Get the runtime for one category of algorithms
+        split machine on, machine off
+
+        :param TimerCategory category:
+        :return: total on and off time of instances with this category
+        :rtype: int
+        """
+        on = 0
+        off = 0
+        query = """
+             SELECT sum(time_taken), machine_on
+             FROM category_timer_provenance
+             WHERE category = ?
+             GROUP BY machine_on
+             """
+        try:
+            for data in self.run_query(query, [category.category_name]):
+                if data[1]:
+                    on = data[0]
+                else:
+                    off = data[0]
+        except IndexError:
+            pass
+        return on, off
+
+    def get_timer_sum_by_category(self, category):
+        """
+        Get the total runtime for one category of algorithms
+
+        :param TimerCategory category:
+        :return: total off all runtimes with this category
+        :rtype: int
+        """
+        query = """
+             SELECT sum(time_taken)
+             FROM full_timer_view
+             WHERE category = ?
+             """
+        data = self.run_query(query, [category.category_name])
+        try:
+            info = data[0][0]
+            if info is None:
+                return 0
+            return info
+        except IndexError:
+            return 0
+
+    def get_timer_sum_by_work(self, work):
+        """
+        Get the total runtime for one work type of algorithms
+
+        :param TimerWork work:
+        :return: total off all runtimes with this category
+        :rtype: int
+        """
+        query = """
+             SELECT sum(time_taken)
+             FROM full_timer_view
+             WHERE work = ?
+             """
+        data = self.run_query(query, [work.work_name])
+        try:
+            info = data[0][0]
+            if info is None:
+                return 0
+            return info
+        except IndexError:
+            return 0
+
+    def get_timer_sum_by_algorithm(self, algorithm):
+        """
+        Get the total runtime for one algorithm
+
+        :param str algorithm:
+        :return: total off all runtimes with this algorithm
+        :rtype: int
+        """
+        query = """
+             SELECT sum(time_taken)
+             FROM timer_provenance
+             WHERE algorithm = ?
+             """
+        data = self.run_query(query, [algorithm])
+        try:
+            info = data[0][0]
+            if info is None:
+                return 0
+            return info
+        except IndexError:
+            return 0
+
+    def retreive_log_messages(self, min_level=0):
+        """
+        Retrieves all log messages at or above the min_level
+
+        :param int min_level:
+        :rtype: list(tuple(int, str))
+        """
+        query = """
+            SELECT message
+            FROM p_log_provenance
+            WHERE level >= ?
+            """
+        messages = self.run_query(query, [min_level])
+        return list(map(lambda x: x[0], messages))

--- a/spinn_front_end_common/interface/provenance/global_provenance.py
+++ b/spinn_front_end_common/interface/provenance/global_provenance.py
@@ -58,7 +58,7 @@ class GlobalProvenance(SQLiteDB):
             for example before run is called
         """
         return os.path.join(
-            FecDataView.get_provenance_dir_path(),
+            FecDataView.get_timestamp_dir_path(),
             "global_provenance.sqlite3")
 
     def __init__(self, database_file=None, memory=False):

--- a/spinn_front_end_common/interface/provenance/local.sql
+++ b/spinn_front_end_common/interface/provenance/local.sql
@@ -17,13 +17,6 @@
 PRAGMA main.synchronous = OFF;
 
 -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
--- A table holding the values for versions
-CREATE TABLE IF NOT EXISTS version_provenance(
-    version_id INTEGER PRIMARY KEY AUTOINCREMENT,
-    description STRING NOT NULL,
-    the_value STRING NOT NULL);
-
--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -- A table holding the values for power provenance
 -- Except for engery used by cores or routers
 CREATE TABLE IF NOT EXISTS power_provenance(
@@ -31,45 +24,6 @@ CREATE TABLE IF NOT EXISTS power_provenance(
     description STRING NOT NULL,
     the_value FLOAT NOT NULL);
 
--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
--- A table holding the values for algorithm timings
-CREATE TABLE IF NOT EXISTS timer_provenance(
-    timer_id INTEGER PRIMARY KEY AUTOINCREMENT,
-    category_id INTEGER NOT NULL,
-    algorithm STRING NOT NULL,
-    work STRING NOT NULL,
-    time_taken INTEGER NOT NULL,
-    skip_reason STRING);
-
-CREATE VIEW IF NOT EXISTS full_timer_view AS
-    SELECT timer_id, category, algorithm, work, machine_on, timer_provenance.time_taken, n_run, n_loop
-    FROM timer_provenance ,category_timer_provenance
-	WHERE timer_provenance.category_id = category_timer_provenance.category_id
-    ORDER BY timer_id;
-
-CREATE VIEW IF NOT EXISTS timer_view AS
-    SELECT category, algorithm, work, machine_on, time_taken, n_run, n_loop
-    FROM full_timer_view
-    WHERE skip_reason is NULL
-    ORDER BY timer_id;
-
--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
--- A table holding the values for category timings
-CREATE TABLE IF NOT EXISTS category_timer_provenance(
-    category_id INTEGER PRIMARY KEY AUTOINCREMENT,
-    category STRING NOT NULL,
-    time_taken INTEGER,
-    machine_on BOOL NOT NULL,
-    n_run INTEGER NOT NULL,
-    n_loop INTEGER);
-
--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
--- A table holding the values for uncategorised general provenance
-CREATE TABLE IF NOT EXISTS other_provenance(
-    other_id INTEGER PRIMARY KEY AUTOINCREMENT,
-    category STRING NOT NULL,
-    description STRING NOT NULL,
-    the_value STRING NOT NULL);
 
 -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -- A table holding the values for data speed up packet gathers
@@ -224,33 +178,3 @@ CREATE TABLE IF NOT EXISTS boards_provenance(
     ip_addres STRING NOT NULL,
     ethernet_x INTEGER NOT NULL,
     ethernet_y INTEGER NOT NULL);
-
----------------------------------------------------------------------
--- A table to store log.info
-CREATE TABLE IF NOT EXISTS p_log_provenance(
-    log_id INTEGER PRIMARY KEY AUTOINCREMENT,
-    timestamp TIMESTAMP NOT NULL,
-    level INTEGER NOT NULL,
-    message STRING NOT NULL);
-
-CREATE TABLE IF NOT EXISTS log_level_names(
-    level INTEGER PRIMARY KEY NOT NULL,
-    name STRING NOT NULL);
-
-INSERT OR IGNORE INTO log_level_names
-    (level, name)
-VALUES
-    (50, "CRITICAL"),
-    (40, "ERROR"),
-    (30, "WARNING"),
-    (20, "INFO"),
-    (10, "DEBUG");
-
-CREATE VIEW IF NOT EXISTS p_log_view AS
-    SELECT
-        timestamp,
-		name,
-        message
-    FROM p_log_provenance left join log_level_names
-    ON p_log_provenance.level = log_level_names.level
-    ORDER BY p_log_provenance.log_id;

--- a/spinn_front_end_common/interface/provenance/log_store_db.py
+++ b/spinn_front_end_common/interface/provenance/log_store_db.py
@@ -16,7 +16,7 @@
 import sqlite3
 from spinn_utilities.log_store import LogStore
 from spinn_utilities.overrides import overrides
-from .provenance_writer import ProvenanceWriter
+from .global_provenance import GlobalProvenance
 from .provenance_reader import ProvenanceReader
 
 
@@ -25,7 +25,7 @@ class LogStoreDB(LogStore):
     @overrides(LogStore.store_log)
     def store_log(self, level, message, timestamp=None):
         try:
-            with ProvenanceWriter() as db:
+            with GlobalProvenance() as db:
                 db.store_log(level, message, timestamp)
         except sqlite3.OperationalError as ex:
             if "database is locked" in ex.args:
@@ -37,9 +37,9 @@ class LogStoreDB(LogStore):
 
     @overrides(LogStore.retreive_log_messages)
     def retreive_log_messages(self, min_level=0):
-        with ProvenanceReader() as db:
+        with GlobalProvenance() as db:
             return db.retreive_log_messages(min_level)
 
     @overrides(LogStore.get_location)
     def get_location(self):
-        return ProvenanceReader.get_last_run_database_path()
+        return GlobalProvenance.get_global_provenace_path()

--- a/spinn_front_end_common/interface/provenance/log_store_db.py
+++ b/spinn_front_end_common/interface/provenance/log_store_db.py
@@ -17,7 +17,6 @@ import sqlite3
 from spinn_utilities.log_store import LogStore
 from spinn_utilities.overrides import overrides
 from .global_provenance import GlobalProvenance
-from .provenance_reader import ProvenanceReader
 
 
 class LogStoreDB(LogStore):

--- a/spinn_front_end_common/interface/provenance/log_store_db.py
+++ b/spinn_front_end_common/interface/provenance/log_store_db.py
@@ -37,7 +37,8 @@ class LogStoreDB(LogStore):
 
     @overrides(LogStore.retreive_log_messages)
     def retreive_log_messages(self, min_level=0):
-        return ProvenanceReader().retreive_log_messages(min_level)
+        with ProvenanceReader() as db:
+            return db.retreive_log_messages(min_level)
 
     @overrides(LogStore.get_location)
     def get_location(self):

--- a/spinn_front_end_common/interface/provenance/provenance_reader.py
+++ b/spinn_front_end_common/interface/provenance/provenance_reader.py
@@ -154,9 +154,8 @@ class ProvenanceReader(SQLiteDB):
             ORDER BY description
             """
         return "\n".join(
-            f"{ row['description'] }: { row['value'] }"
-            for row in self.run_query(query, [int(x), int(y)],
-                                      use_sqlite_rows=True))
+            f"{ row[0] }: { row[1] }"
+            for row in self.run_query(query, [int(x), int(y)]))
 
     def get_cores_with_provenace(self):
         """

--- a/spinn_front_end_common/interface/provenance/provenance_reader.py
+++ b/spinn_front_end_common/interface/provenance/provenance_reader.py
@@ -16,6 +16,8 @@
 import os
 from spinn_front_end_common.data import FecDataView
 from spinn_front_end_common.utilities.constants import PROVENANCE_DB
+from spinn_front_end_common.utilities.exceptions import (
+    NoProvenanceDatabaseException)
 from spinn_front_end_common.utilities.sqlite_db import SQLiteDB
 
 
@@ -70,7 +72,8 @@ class ProvenanceReader(SQLiteDB):
         else:
             self._provenance_data_path = self.get_last_run_database_path()
         if not os.path.exists(self._provenance_data_path):
-            raise Exception(f"no such DB: {self._provenance_data_path}")
+            raise NoProvenanceDatabaseException(
+                f"no such DB: {self._provenance_data_path}")
         SQLiteDB.__init__(self, self._provenance_data_path, read_only=True,
                           row_factory=None, text_factory=None)
 

--- a/spinn_front_end_common/interface/provenance/provenance_reader.py
+++ b/spinn_front_end_common/interface/provenance/provenance_reader.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import sqlite3
 from spinn_front_end_common.data import FecDataView
 from spinn_front_end_common.utilities.constants import PROVENANCE_DB
 from spinn_front_end_common.utilities.sqlite_db import SQLiteDB
@@ -108,7 +107,7 @@ class ProvenanceReader(SQLiteDB):
         results = []
         with self.transaction() as cur:
             for row in cur.execute(query, params):
-                    results.append(row)
+                results.append(row)
         return results
 
     def cores_with_late_spikes(self):
@@ -413,23 +412,23 @@ class ProvenanceReader(SQLiteDB):
         # This uses the example file in the same directory as this script
         with ProvenanceReader(os.path.join(
             os.path.dirname(__file__), "provenance.sqlite3")) as pr:
-            print("DIRECT QUERY:")
-            query = """
-                SELECT x, y, the_value
-                FROM router_provenance
-                WHERE description = 'Local_P2P_Packets'
-                """
-            results = pr.run_query(query)
-            for row in results:
-                print(row)
-            print("\nCORES WITH LATE SPIKES:")
-            print(pr.cores_with_late_spikes())
-            print("\nRUN TIME OF BUFFER EXTRACTOR:")
-            print(pr.get_run_time_of_BufferExtractor())
-            print("\nROUETER (0,0) PROVENANCE:")
-            print(pr.get_provenance_for_router(0, 0))
-            print("\nCORES WITH PROVENACE")
-            print(pr.get_cores_with_provenace())
+                print("DIRECT QUERY:")
+                query = """
+                    SELECT x, y, the_value
+                    FROM router_provenance
+                    WHERE description = 'Local_P2P_Packets'
+                    """
+                results = pr.run_query(query)
+                for row in results:
+                    print(row)
+                print("\nCORES WITH LATE SPIKES:")
+                print(pr.cores_with_late_spikes())
+                print("\nRUN TIME OF BUFFER EXTRACTOR:")
+                print(pr.get_run_time_of_BufferExtractor())
+                print("\nROUETER (0,0) PROVENANCE:")
+                print(pr.get_provenance_for_router(0, 0))
+                print("\nCORES WITH PROVENACE")
+                print(pr.get_cores_with_provenace())
 
 
 if __name__ == '__main__':

--- a/spinn_front_end_common/interface/provenance/provenance_reader.py
+++ b/spinn_front_end_common/interface/provenance/provenance_reader.py
@@ -231,22 +231,22 @@ class ProvenanceReader(SQLiteDB):
         """
         # This uses the example file in the same directory as this script
         with ProvenanceReader(os.path.join(
-            os.path.dirname(__file__), "provenance.sqlite3")) as pr:
-                print("DIRECT QUERY:")
-                query = """
-                    SELECT x, y, the_value
-                    FROM router_provenance
-                    WHERE description = 'Local_P2P_Packets'
-                    """
-                results = pr.run_query(query)
-                for row in results:
-                    print(row)
-                print("\nCORES WITH LATE SPIKES:")
-                print(pr.cores_with_late_spikes())
-                print("\nROUETER (0,0) PROVENANCE:")
-                print(pr.get_provenance_for_router(0, 0))
-                print("\nCORES WITH PROVENACE")
-                print(pr.get_cores_with_provenace())
+                os.path.dirname(__file__), "provenance.sqlite3")) as pr:
+            print("DIRECT QUERY:")
+            query = """
+                SELECT x, y, the_value
+                FROM router_provenance
+                WHERE description = 'Local_P2P_Packets'
+                """
+            results = pr.run_query(query)
+            for row in results:
+                print(row)
+            print("\nCORES WITH LATE SPIKES:")
+            print(pr.cores_with_late_spikes())
+            print("\nROUETER (0,0) PROVENANCE:")
+            print(pr.get_provenance_for_router(0, 0))
+            print("\nCORES WITH PROVENACE")
+            print(pr.get_cores_with_provenace())
 
 
 if __name__ == '__main__':

--- a/spinn_front_end_common/interface/provenance/provenance_writer.py
+++ b/spinn_front_end_common/interface/provenance/provenance_writer.py
@@ -13,15 +13,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
 import logging
 import os
 import re
 from spinn_utilities.config_holder import get_config_int
 from spinn_utilities.log import FormatAdapter
 from spinn_front_end_common.data import FecDataView
-from spinn_front_end_common.utilities.constants import (
-    MICRO_TO_MILLISECOND_CONVERSION, PROVENANCE_DB)
+from spinn_front_end_common.utilities.constants import (PROVENANCE_DB)
 from spinn_front_end_common.utilities.sqlite_db import SQLiteDB
 
 logger = FormatAdapter(logging.getLogger(__name__))

--- a/spinn_front_end_common/interface/provenance/provenance_writer.py
+++ b/spinn_front_end_common/interface/provenance/provenance_writer.py
@@ -24,7 +24,7 @@ from spinn_front_end_common.utilities.sqlite_db import SQLiteDB
 
 logger = FormatAdapter(logging.getLogger(__name__))
 
-_DDL_FILE = os.path.join(os.path.dirname(__file__), "db.sql")
+_DDL_FILE = os.path.join(os.path.dirname(__file__), "local.sql")
 _RE = re.compile(r"(\d+)([_,:])(\d+)(?:\2(\d+))?")
 
 

--- a/spinn_front_end_common/interface/provenance/provenance_writer.py
+++ b/spinn_front_end_common/interface/provenance/provenance_writer.py
@@ -65,21 +65,6 @@ class ProvenanceWriter(SQLiteDB):
         self._database_file = database_file
         SQLiteDB.__init__(self, database_file, ddl_file=_DDL_FILE)
 
-    def insert_version(self, description, the_value):
-        """
-        Inserts data into the version_provenance table
-
-        :param str description: The package for which the version applies
-        :param str the_value: The version to be recorded
-        """
-        with self.transaction() as cur:
-            cur.execute(
-                """
-                INSERT INTO version_provenance(
-                    description, the_value)
-                VALUES(?, ?)
-                """, [description, the_value])
-
     def insert_power(self, description, the_value):
         """
         Inserts a general power value into the power_provenane table
@@ -94,71 +79,6 @@ class ProvenanceWriter(SQLiteDB):
                     description, the_value)
                 VALUES(?, ?)
                 """, [description, the_value])
-
-    def insert_category(self, category, machine_on):
-        """
-        Inserts category into the category_timer_provenance  returning id
-
-        :param TimerCategory category: Name of Category starting
-        :param bool machine_on: If the machine was done during all
-            or some of the time
-        """
-        with self.transaction() as cur:
-            cur.execute(
-                """
-                INSERT INTO category_timer_provenance(
-                    category, machine_on, n_run, n_loop)
-                VALUES(?, ?, ?, ?)
-                """,
-                [category.category_name, machine_on,
-                 FecDataView.get_run_number(),
-                 FecDataView.get_run_step()])
-            return cur.lastrowid
-
-    def insert_category_timing(self, category_id, timedelta):
-        """
-        Inserts run time into the category
-
-        :param int category_id: id of the Category finished
-        :param ~datetime.timedelta timedelta: Time to be recorded
-       """
-        time_taken = (
-                (timedelta.seconds * MICRO_TO_MILLISECOND_CONVERSION) +
-                (timedelta.microseconds / MICRO_TO_MILLISECOND_CONVERSION))
-
-        with self.transaction() as cur:
-            cur.execute(
-                """
-                UPDATE category_timer_provenance
-                SET
-                    time_taken = ?
-                WHERE category_id = ?
-                """, (time_taken, category_id))
-
-    def insert_timing(
-            self, category, algorithm, work, timedelta, skip_reason):
-        """
-        Inserts algorithms run times into the timer_provenance table
-
-        :param int category: Category Id of the Algorithm
-        :param str algorithm: Algorithm name
-        :param TimerWork work: Type of work being done
-        :param ~datetime.timedelta timedelta: Time to be recorded
-        :param skip_reason: The reason the algorthm was skipped or None if
-            it was not skipped
-        :tpye skip_reason: str or None
-        """
-        time_taken = (
-                (timedelta.seconds * MICRO_TO_MILLISECOND_CONVERSION) +
-                (timedelta.microseconds / MICRO_TO_MILLISECOND_CONVERSION))
-        with self.transaction() as cur:
-            cur.execute(
-                """
-                INSERT INTO timer_provenance(
-                    category_id, algorithm, work, time_taken, skip_reason)
-                VALUES(?, ?, ?, ?, ?)
-                """,
-                [category, algorithm, work.work_name, time_taken, skip_reason])
 
     def insert_other(self, category, description, the_value):
         """
@@ -337,24 +257,6 @@ class ProvenanceWriter(SQLiteDB):
                 VALUES (?, ?, ?)
                 """, ((x, y, ipaddress)
                       for ((x, y), ipaddress) in connections.items()))
-
-    def store_log(self, level, message, timestamp=None):
-        """
-        Stores log messages into the database
-
-        :param int level:
-        :param str message:
-        """
-        if timestamp is None:
-            timestamp = datetime.now()
-        with self.transaction() as cur:
-            cur.execute(
-                """
-                INSERT INTO p_log_provenance(
-                    timestamp, level, message)
-                VALUES(?, ?, ?)
-                """,
-                [timestamp, level, message])
 
     def _test_log_locked(self, text):
         """

--- a/spinn_front_end_common/interface/provenance/provenance_writer.py
+++ b/spinn_front_end_common/interface/provenance/provenance_writer.py
@@ -78,25 +78,6 @@ class ProvenanceWriter(SQLiteDB):
                 VALUES(?, ?)
                 """, [description, the_value])
 
-    def insert_other(self, category, description, the_value):
-        """
-        Insert unforeseen provenance into the other_provenace_table
-
-        This allows to add provenance that does not readily fit into any of
-        the other categerogies
-
-        :param str category: grouping from this provenance
-        :param str description: Specific provenance being saved
-        :param ste the_value: Data
-        """
-        with self.transaction() as cur:
-            cur.execute(
-                """
-                INSERT INTO other_provenance(
-                    category, description, the_value)
-                VALUES(?, ?, ?)
-                """, [category, description, the_value])
-
     def insert_gatherer(self, x, y, address, bytes_read, run, description,
                         the_value):
         """

--- a/spinn_front_end_common/utilities/exceptions.py
+++ b/spinn_front_end_common/utilities/exceptions.py
@@ -61,6 +61,7 @@ class CantFindSDRAMToUseException(SpinnFrontEndException):
     """ Raised when malloc and sdram stealing cannot occur.
     """
 
+
 class NoProvenanceDatabaseException(SpinnFrontEndException):
     """
     Raised when the Provenance database has not yet been created.

--- a/spinn_front_end_common/utilities/exceptions.py
+++ b/spinn_front_end_common/utilities/exceptions.py
@@ -60,3 +60,8 @@ class BufferedRegionNotPresent(SpinnFrontEndException):
 class CantFindSDRAMToUseException(SpinnFrontEndException):
     """ Raised when malloc and sdram stealing cannot occur.
     """
+
+class NoProvenanceDatabaseException(SpinnFrontEndException):
+    """
+    Raised when the Provenance database has not yet been created.
+    """

--- a/spinn_front_end_common/utilities/report_functions/bit_field_compressor_report.py
+++ b/spinn_front_end_common/utilities/report_functions/bit_field_compressor_report.py
@@ -84,24 +84,25 @@ def _merged_component(to_merge_per_chip, writer):
     to_merge_chips = set(to_merge_per_chip.keys())
 
     found = False
-    for (x, y, merged) in ProvenanceReader().get_router_by_chip(
-            MERGED_NAME):
-        if (x, y) not in to_merge_per_chip:
-            continue
-        to_merge = to_merge_per_chip[x, y]
-        to_merge_chips.discard((x, y))
-        found = True
-        writer.write(
-            "Chip {}:{} has {} bitfields out of {} merged into it."
-            " Which is {:.2%}\n".format(
-                x, y, merged, to_merge, merged / to_merge))
-        total_bit_fields_merged += int(merged)
-        if merged > top_bit_field:
-            top_bit_field = merged
-        if merged < min_bit_field:
-            min_bit_field = merged
-        average_per_chip_merged += merged
-        n_chips += 1
+    with ProvenanceReader() as db:
+        for (x, y, merged) in db.get_router_by_chip(
+                MERGED_NAME):
+            if (x, y) not in to_merge_per_chip:
+                continue
+            to_merge = to_merge_per_chip[x, y]
+            to_merge_chips.discard((x, y))
+            found = True
+            writer.write(
+                "Chip {}:{} has {} bitfields out of {} merged into it."
+                " Which is {:.2%}\n".format(
+                    x, y, merged, to_merge, merged / to_merge))
+            total_bit_fields_merged += int(merged)
+            if merged > top_bit_field:
+                top_bit_field = merged
+            if merged < min_bit_field:
+                min_bit_field = merged
+            average_per_chip_merged += merged
+            n_chips += 1
 
     if found:
         average_per_chip_merged = (

--- a/spinn_front_end_common/utilities/report_functions/bit_field_compressor_report.py
+++ b/spinn_front_end_common/utilities/report_functions/bit_field_compressor_report.py
@@ -20,10 +20,12 @@ from collections import defaultdict
 from spinn_utilities.log import FormatAdapter
 from spinn_front_end_common.abstract_models import AbstractHasAssociatedBinary
 from spinn_front_end_common.data import FecDataView
-from spinn_front_end_common.interface.provenance import ProvenanceWriter
+from spinn_front_end_common.interface.provenance import \
+    (ProvenanceReader, ProvenanceWriter)
 from .bit_field_summary import BitFieldSummary
+from spinn_front_end_common.utilities.exceptions import (
+    NoProvenanceDatabaseException)
 from spinn_front_end_common.utilities.utility_objs import ExecutableType
-from spinn_front_end_common.interface.provenance import ProvenanceReader
 
 logger = FormatAdapter(logging.getLogger(__name__))
 _FILE_NAME = "bit_field_compressed_summary.rpt"
@@ -56,11 +58,15 @@ def bitfield_compressor_report():
     file_name = os.path.join(FecDataView.get_run_dir_path(), _FILE_NAME)
     try:
         with open(file_name, "w", encoding="utf-8") as f:
-            return _write_report(f)
+            _write_report(f)
     except IOError:
         logger.exception("Generate_placement_reports: Can't open file"
                          " {} for writing.", _FILE_NAME)
-        return None
+        return
+    except NoProvenanceDatabaseException:
+        logger.exception(
+            "No proveance found to write bitfield_compressor_report")
+        return
 
 
 def _merged_component(to_merge_per_chip, writer):

--- a/spinn_front_end_common/utilities/report_functions/energy_report.py
+++ b/spinn_front_end_common/utilities/report_functions/energy_report.py
@@ -20,7 +20,7 @@ from spinn_utilities.config_holder import (get_config_int, get_config_str)
 from spinn_utilities.log import FormatAdapter
 from spinn_front_end_common.data import FecDataView
 from spinn_front_end_common.interface.provenance import (
-    FecTimer, ProvenanceReader, TimerCategory)
+    FecTimer, GlobalProvenance, TimerCategory)
 from spinn_front_end_common.utility_models import ChipPowerMonitorMachineVertex
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from spinn_front_end_common.interface.interface_functions.compute_energy_used\
@@ -309,7 +309,7 @@ class EnergyReport(object):
         """
 
         # find time in milliseconds
-        with ProvenanceReader() as db:
+        with GlobalProvenance() as db:
             total_time_ms = db.get_timer_sum_by_category(TimerCategory.LOADING)
 
         # handle active routers etc
@@ -336,7 +336,7 @@ class EnergyReport(object):
         """
 
         # find time
-        with ProvenanceReader() as db:
+        with GlobalProvenance() as db:
             total_time_ms = db.get_timer_sum_by_algorithm(
                 FecTimer.APPLICATION_RUNNER)
 

--- a/spinn_front_end_common/utilities/report_functions/energy_report.py
+++ b/spinn_front_end_common/utilities/report_functions/energy_report.py
@@ -309,8 +309,8 @@ class EnergyReport(object):
         """
 
         # find time in milliseconds
-        reader = ProvenanceReader()
-        total_time_ms = reader.get_timer_sum_by_category(TimerCategory.LOADING)
+        with ProvenanceReader() as db:
+            total_time_ms = db.get_timer_sum_by_category(TimerCategory.LOADING)
 
         # handle active routers etc
         active_router_cost = (
@@ -336,9 +336,9 @@ class EnergyReport(object):
         """
 
         # find time
-        reader = ProvenanceReader()
-        total_time_ms = reader.get_timer_sum_by_algorithm(
-            FecTimer.APPLICATION_RUNNER)
+        with ProvenanceReader() as db:
+            total_time_ms = db.get_timer_sum_by_algorithm(
+                FecTimer.APPLICATION_RUNNER)
 
         # handle active routers etc
         energy_cost_of_active_router = (

--- a/unittests/interface/provenance/test_provenance_database.py
+++ b/unittests/interface/provenance/test_provenance_database.py
@@ -22,7 +22,8 @@ import unittest
 from spinn_utilities.config_holder import set_config
 from spinn_front_end_common.interface.config_setup import unittest_setup
 from spinn_front_end_common.interface.provenance import (
-    LogStoreDB, GlobalProvenance, ProvenanceWriter, ProvenanceReader, TimerCategory, TimerWork)
+    LogStoreDB, GlobalProvenance, ProvenanceWriter, ProvenanceReader,
+    TimerCategory, TimerWork)
 
 logger = FormatAdapter(logging.getLogger(__name__))
 

--- a/unittests/interface/provenance/test_provenance_database.py
+++ b/unittests/interface/provenance/test_provenance_database.py
@@ -112,10 +112,6 @@ class TestProvenanceDatabase(unittest.TestCase):
             data = db.get_category_timer_sum(TimerCategory.MAPPING)
         self.assertEqual(12 + 123, data)
 
-    def test_other(self):
-        with ProvenanceWriter() as db:
-            db.insert_other("foo", "bar", 12)
-
     def test_gatherer(self):
         with ProvenanceWriter() as db:
             db.insert_gatherer(

--- a/unittests/utilities/test_fec_timer.py
+++ b/unittests/utilities/test_fec_timer.py
@@ -17,7 +17,7 @@ import tempfile
 import unittest
 from testfixtures import LogCapture
 from spinn_front_end_common.interface.provenance import (
-    FecTimer, ProvenanceReader, TimerCategory, TimerWork)
+    FecTimer, GlobalProvenance, TimerCategory, TimerWork)
 from spinn_front_end_common.interface.config_setup import unittest_setup
 
 
@@ -74,7 +74,7 @@ class TestFecTimer(unittest.TestCase):
         FecTimer.end_category(TimerCategory.GET_MACHINE)
         FecTimer.end_category(TimerCategory.MAPPING)
         FecTimer.end_category(TimerCategory.RUN_OTHER)
-        with ProvenanceReader() as db:
+        with GlobalProvenance() as db:
             on, off = db.get_category_timer_sums(TimerCategory.RUN_OTHER)
             total = db.get_category_timer_sum(TimerCategory.RUN_OTHER)
             self.assertGreater(on, 0)
@@ -105,7 +105,7 @@ class TestFecTimer(unittest.TestCase):
         FecTimer.start_category(TimerCategory.WAITING)
         FecTimer.start_category(TimerCategory.SHUTTING_DOWN)
         FecTimer.start_category(TimerCategory.SHUTTING_DOWN)
-        with ProvenanceReader() as db:
+        with GlobalProvenance() as db:
             total = db.get_category_timer_sum(
                 TimerCategory.SHUTTING_DOWN)
             self.assertEqual(total, 0)
@@ -135,7 +135,7 @@ class TestFecTimer(unittest.TestCase):
     def test_stop_category_timing_clean(self):
         FecTimer.start_category(TimerCategory.WAITING)
         FecTimer.start_category(TimerCategory.RUN_OTHER)
-        with ProvenanceReader() as db:
+        with GlobalProvenance() as db:
             before = db.get_category_timer_sum(TimerCategory.WAITING)
             FecTimer.start_category(TimerCategory.MAPPING)
             FecTimer.end_category(TimerCategory.MAPPING)
@@ -149,7 +149,7 @@ class TestFecTimer(unittest.TestCase):
     def test_stop_category_timing_messy(self):
         FecTimer.start_category(TimerCategory.WAITING)
         FecTimer.start_category(TimerCategory.RUN_OTHER)
-        with ProvenanceReader() as db:
+        with GlobalProvenance() as db:
             before = db.get_category_timer_sum(TimerCategory.WAITING)
             FecTimer.start_category(TimerCategory.MAPPING)
             FecTimer.start_category(TimerCategory.SHUTTING_DOWN)
@@ -160,8 +160,7 @@ class TestFecTimer(unittest.TestCase):
             total = db.get_category_timer_sum(TimerCategory.WAITING)
             # As we never ended RUN_OTHER we never got back to WAITING
             self.assertEqual(total, before)
-            other = ProvenanceReader().get_category_timer_sum(
-                TimerCategory.RUN_OTHER)
+            other = db.get_category_timer_sum(TimerCategory.RUN_OTHER)
             self.assertGreater(other, 0)
 
     def test_stop_last_category_blocked(self):


### PR DESCRIPTION
This PR splits of the GlobalProvenance into a separate Class and separate sqlite3 file

This includes version timer and log provenance all of which apply over multiple resets.

The sqlite3 file is therefor next to and not in the run_ directories

-

in preparation of the merging of Provenance and Buffer databases the ProvenanceWriter and ProvenanceReader are now follow the with pattern

Must be done at the same time as:
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1238
https://github.com/SpiNNakerManchester/SpiNNakerGraphFrontEnd/pull/226

Tested by:
https://github.com/SpiNNakerManchester/IntegrationTests/pull/160

Replaces:
https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/990