### PR TITLE
Reduce overhead data spec colours

### DIFF
--- a/c_common/models/live_packet_gather/src/live_packet_gather.c
+++ b/c_common/models/live_packet_gather/src/live_packet_gather.c
@@ -225,9 +225,9 @@ static inline uint32_t translated_key(uint32_t key) {
     key_translation_entry entry = config->translation_table[index];
 
     // Pre-shift the key as requested
-    uint32_t shifted_key = key;
+    uint32_t shifted_key = key & ~entry.mask;
     if (config->received_key_right_shift) {
-        shifted_key = (key & ~entry.mask) >> config->received_key_right_shift;
+        shifted_key = shifted_key >> config->received_key_right_shift;
     }
     return shifted_key + entry.lo_atom;
 }

--- a/c_common/models/live_packet_gather/src/live_packet_gather.c
+++ b/c_common/models/live_packet_gather/src/live_packet_gather.c
@@ -214,19 +214,22 @@ static inline bool find_translation_entry(uint32_t key, uint32_t *index) {
 static inline uint32_t translated_key(uint32_t key) {
     uint32_t index = 0;
 
-    // Pre-shift the key as requested
-    uint32_t shifted_key = key;
-    if (config->received_key_right_shift) {
-        shifted_key = key >> config->received_key_right_shift;
-    }
-
     // If there isn't an entry, don't translate
-    if (!find_translation_entry(shifted_key, &index)) {
-        return shifted_key;
+    if (!find_translation_entry(key, &index)) {
+        if (config->received_key_right_shift) {
+            return key >> config->received_key_right_shift;
+        }
+        return key;
     }
 
     key_translation_entry entry = config->translation_table[index];
-    return (shifted_key & ~entry.mask) + entry.lo_atom;
+
+    // Pre-shift the key as requested
+    uint32_t shifted_key = key;
+    if (config->received_key_right_shift) {
+        shifted_key = (key & ~entry.mask) >> config->received_key_right_shift;
+    }
+    return shifted_key + entry.lo_atom;
 }
 
 //! \brief Because _WHY OH WHY_ would you use aligned memory? At least with this

--- a/spinn_front_end_common/interface/interface_functions/host_bit_field_router_compressor.py
+++ b/spinn_front_end_common/interface/interface_functions/host_bit_field_router_compressor.py
@@ -113,8 +113,7 @@ def generate_key_to_atom_map():
                 partition.identifier):
             key = routing_infos.get_first_key_from_pre_vertex(
                 vertex, partition.identifier)
-            key_to_n_atoms_map[key] = (
-                vertex.get_n_keys_for_partition(partition))
+            key_to_n_atoms_map[key] = vertex.vertex_slice.n_atoms
     return key_to_n_atoms_map
 
 

--- a/spinn_front_end_common/utilities/database/database_writer.py
+++ b/spinn_front_end_common/utilities/database/database_writer.py
@@ -21,6 +21,7 @@ from spinn_front_end_common.utilities.sqlite_db import SQLiteDB
 from spinn_front_end_common.abstract_models import (
     AbstractSupportsDatabaseInjection, HasCustomAtomKeyMap)
 from spinn_front_end_common.utility_models import LivePacketGather
+from pacman.utilities.utility_calls import get_field_based_keys
 
 logger = FormatAdapter(logging.getLogger(__name__))
 DB_NAME = "input_output_database.sqlite3"
@@ -234,7 +235,7 @@ class DatabaseWriter(SQLiteDB):
                     # at which point there is nothing to do here anyway
                     if r_info is not None:
                         vertex_slice = m_vertex.vertex_slice
-                        keys = r_info.get_keys(vertex_slice.n_atoms)
+                        keys = get_field_based_keys(r_info.key, vertex_slice)
                         start = vertex_slice.lo_atom
                         atom_keys = [(i, k) for i, k in enumerate(keys, start)]
                 m_vertex_id = self.__vertex_to_id[m_vertex]

--- a/spinn_front_end_common/utilities/utility_objs/live_packet_gather_parameters.py
+++ b/spinn_front_end_common/utilities/utility_objs/live_packet_gather_parameters.py
@@ -33,7 +33,7 @@ class LivePacketGatherParameters(object):
         "_key_prefix", "_prefix_type", "_message_type", "_right_shift",
         "_payload_as_time_stamps", "_use_payload_prefix", "_payload_prefix",
         "_payload_right_shift", "_n_packets_per_time_step", "_label",
-        "_translate_keys"
+        "_translate_keys", "_received_key_right_shift"
     ]
 
     def __init__(
@@ -43,7 +43,7 @@ class LivePacketGatherParameters(object):
             payload_as_time_stamps=True, use_payload_prefix=True,
             payload_prefix=None, payload_right_shift=0,
             number_of_packets_sent_per_time_step=0, label=None,
-            translate_keys=False):
+            translate_keys=False, received_key_right_shift=0):
         """
         :raises ConfigurationException:
             If the parameters passed are known to be an invalid combination.
@@ -84,6 +84,7 @@ class LivePacketGatherParameters(object):
         self._n_packets_per_time_step = number_of_packets_sent_per_time_step
         self._label = label
         self._translate_keys = translate_keys
+        self._received_key_right_shift = received_key_right_shift
 
     @property
     def port(self):
@@ -149,6 +150,10 @@ class LivePacketGatherParameters(object):
     def translate_keys(self):
         return self._translate_keys
 
+    @property
+    def received_key_right_shift(self):
+        return self._received_key_right_shift
+
     def get_iptag_resource(self):
         """ Get a description of the IPtag that the LPG for these parameters \
             will require.
@@ -178,7 +183,9 @@ class LivePacketGatherParameters(object):
                 self._n_packets_per_time_step ==
                 other.number_of_packets_sent_per_time_step and
                 self._label == other.label and
-                self._translate_keys == other.translate_keys)
+                self._translate_keys == other.translate_keys and
+                self._received_key_right_shift ==
+                other.received_key_right_shift)
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -190,5 +197,5 @@ class LivePacketGatherParameters(object):
             self._right_shift, self._payload_as_time_stamps,
             self._use_payload_prefix, self._payload_prefix,
             self._payload_right_shift, self._n_packets_per_time_step,
-            self._label, self._translate_keys)
+            self._label, self._translate_keys, self._received_key_right_shift)
         return hash(data)

--- a/spinn_front_end_common/utilities/utility_objs/live_packet_gather_parameters.py
+++ b/spinn_front_end_common/utilities/utility_objs/live_packet_gather_parameters.py
@@ -33,7 +33,7 @@ class LivePacketGatherParameters(object):
         "_key_prefix", "_prefix_type", "_message_type", "_right_shift",
         "_payload_as_time_stamps", "_use_payload_prefix", "_payload_prefix",
         "_payload_right_shift", "_n_packets_per_time_step", "_label",
-        "_translate_keys", "_received_key_right_shift"
+        "_received_key_mask", "_translate_keys", "_translated_key_right_shift"
     ]
 
     def __init__(
@@ -43,7 +43,8 @@ class LivePacketGatherParameters(object):
             payload_as_time_stamps=True, use_payload_prefix=True,
             payload_prefix=None, payload_right_shift=0,
             number_of_packets_sent_per_time_step=0, label=None,
-            translate_keys=False, received_key_right_shift=0):
+            received_key_mask=0xFFFFFFFF,
+            translate_keys=False, translated_key_right_shift=0):
         """
         :raises ConfigurationException:
             If the parameters passed are known to be an invalid combination.
@@ -83,8 +84,9 @@ class LivePacketGatherParameters(object):
         self._payload_right_shift = payload_right_shift
         self._n_packets_per_time_step = number_of_packets_sent_per_time_step
         self._label = label
+        self._received_key_mask = received_key_mask
         self._translate_keys = translate_keys
-        self._received_key_right_shift = received_key_right_shift
+        self._translated_key_right_shift = translated_key_right_shift
 
     @property
     def port(self):
@@ -147,12 +149,16 @@ class LivePacketGatherParameters(object):
         return self._label
 
     @property
+    def received_key_mask(self):
+        return self._received_key_mask
+
+    @property
     def translate_keys(self):
         return self._translate_keys
 
     @property
-    def received_key_right_shift(self):
-        return self._received_key_right_shift
+    def translated_key_right_shift(self):
+        return self._translated_key_right_shift
 
     def get_iptag_resource(self):
         """ Get a description of the IPtag that the LPG for these parameters \
@@ -183,9 +189,10 @@ class LivePacketGatherParameters(object):
                 self._n_packets_per_time_step ==
                 other.number_of_packets_sent_per_time_step and
                 self._label == other.label and
+                self._received_key_mask == other.received_key_mask and
                 self._translate_keys == other.translate_keys and
-                self._received_key_right_shift ==
-                other.received_key_right_shift)
+                self._translated_key_right_shift ==
+                other.translated_key_right_shift)
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -197,5 +204,6 @@ class LivePacketGatherParameters(object):
             self._right_shift, self._payload_as_time_stamps,
             self._use_payload_prefix, self._payload_prefix,
             self._payload_right_shift, self._n_packets_per_time_step,
-            self._label, self._translate_keys, self._received_key_right_shift)
+            self._label, self._received_key_mask, self._translate_keys,
+            self._translated_key_right_shift)
         return hash(data)

--- a/spinn_front_end_common/utility_models/live_packet_gather_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/live_packet_gather_machine_vertex.py
@@ -50,7 +50,7 @@ class LivePacketGatherMachineVertex(
     TRAFFIC_IDENTIFIER = "LPG_EVENT_STREAM"
 
     _N_ADDITIONAL_PROVENANCE_ITEMS = 4
-    _CONFIG_SIZE = 13 * BYTES_PER_WORD
+    _CONFIG_SIZE = 14 * BYTES_PER_WORD
     _PROVENANCE_REGION_SIZE = 2 * BYTES_PER_WORD
     KEY_ENTRY_SIZE = 3 * BYTES_PER_WORD
 
@@ -212,6 +212,9 @@ class LivePacketGatherMachineVertex(
 
         # number of packets to send per time stamp
         spec.write_value(self._lpg_params.number_of_packets_sent_per_time_step)
+
+        # Received key right shift
+        spec.write_value(self._lpg_params.received_key_right_shift)
 
         # Key Translation
         if not self._lpg_params.translate_keys:

--- a/spinn_front_end_common/utility_models/live_packet_gather_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/live_packet_gather_machine_vertex.py
@@ -50,7 +50,7 @@ class LivePacketGatherMachineVertex(
     TRAFFIC_IDENTIFIER = "LPG_EVENT_STREAM"
 
     _N_ADDITIONAL_PROVENANCE_ITEMS = 4
-    _CONFIG_SIZE = 14 * BYTES_PER_WORD
+    _CONFIG_SIZE = 15 * BYTES_PER_WORD
     _PROVENANCE_REGION_SIZE = 2 * BYTES_PER_WORD
     KEY_ENTRY_SIZE = 3 * BYTES_PER_WORD
 
@@ -213,8 +213,11 @@ class LivePacketGatherMachineVertex(
         # number of packets to send per time stamp
         spec.write_value(self._lpg_params.number_of_packets_sent_per_time_step)
 
-        # Received key right shift
-        spec.write_value(self._lpg_params.received_key_right_shift)
+        # Received key mask
+        spec.write_value(self._lpg_params.received_key_mask)
+
+        # Translated key right shift
+        spec.write_value(self._lpg_params.translated_key_right_shift)
 
         # Key Translation
         if not self._lpg_params.translate_keys:

--- a/spinn_front_end_common/utility_models/reverse_ip_tag_multi_cast_source.py
+++ b/spinn_front_end_common/utility_models/reverse_ip_tag_multi_cast_source.py
@@ -154,7 +154,7 @@ class ReverseIpTagMultiCastSource(
     @overrides(LegacyPartitionerAPI.get_sdram_used_by_atoms)
     def get_sdram_used_by_atoms(self, vertex_slice):
         return ReverseIPTagMulticastSourceMachineVertex.get_sdram_usage(
-            self.__filtered_send_buffer_times(vertex_slice),
+            self._filtered_send_buffer_times(vertex_slice),
             self._is_recording, self._receive_rate, vertex_slice.n_atoms)
 
     @property
@@ -184,7 +184,7 @@ class ReverseIpTagMultiCastSource(
     @overrides(LegacyPartitionerAPI.create_machine_vertex)
     def create_machine_vertex(
             self, vertex_slice, sdram, label=None):
-        send_buffer_times = self.__filtered_send_buffer_times(vertex_slice)
+        send_buffer_times = self._filtered_send_buffer_times(vertex_slice)
         machine_vertex = ReverseIPTagMulticastSourceMachineVertex(
             vertex_slice=vertex_slice,
             label=label, app_vertex=self,
@@ -204,7 +204,7 @@ class ReverseIpTagMultiCastSource(
             assert (sdram == machine_vertex.sdram_required)
         return machine_vertex
 
-    def __filtered_send_buffer_times(self, vertex_slice):
+    def _filtered_send_buffer_times(self, vertex_slice):
         ids = vertex_slice.get_raster_ids(self.atoms_shape)
         send_buffer_times = self._send_buffer_times
         n_buffer_times = 0

--- a/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
@@ -455,10 +455,10 @@ class ReverseIPTagMulticastSourceMachineVertex(
                 len(self._send_buffer_times)):
             if hasattr(self._send_buffer_times[0], "__len__"):
                 # Works with a list-of-lists
-                self.app_vertex.fill_send_buffer_2d(key_to_send)
+                self._fill_send_buffer_2d(key_to_send)
             else:
                 # Work with a single list
-                self.app_vertex.fill_send_buffer_1d(key_to_send)
+                self._fill_send_buffer_1d(key_to_send)
 
     def _fill_send_buffer_2d(self, key_base):
         """ Add the keys with different times for each atom.

--- a/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
@@ -744,6 +744,9 @@ class ReverseIPTagMulticastSourceMachineVertex(
 
     @overrides(SendsBuffersFromHostPreBufferedImpl.rewind)
     def rewind(self, region):
+        # reset theses so fill send buffer will run when send_buffers called
+        self._first_machine_time_step = None
+        self._run_until_timesteps = None
         # Avoid update_buffer as not needed and called during reset
         self._send_buffers[region].rewind()
 


### PR DESCRIPTION
Adds a few things to correct the colour that has been added elsewhere if requested:
 - Live packet gatherer can either mask out the colour or shift keys if translating keys
 - ReverseIPTagMulticastSource has been updated to allow the overriding of keys generated
