### PR TITLE
turn of validation of files used by JavaCaller

### DIFF
--- a/spinn_front_end_common/interface/java_caller.py
+++ b/spinn_front_end_common/interface/java_caller.py
@@ -170,7 +170,8 @@ class JavaCaller(object):
         :return: the name of the file containing the JSON
         """
         if self._machine_json_path is None:
-            self._machine_json_path = write_json_machine(progress_bar=False)
+            self._machine_json_path = write_json_machine(
+                progress_bar=False, validate=False)
         return self._machine_json_path
 
     def set_placements(self, used_placements):

--- a/spinn_front_end_common/utilities/report_functions/write_json_machine.py
+++ b/spinn_front_end_common/utilities/report_functions/write_json_machine.py
@@ -22,7 +22,7 @@ from spinn_front_end_common.data import FecDataView
 MACHINE_FILENAME = "machine.json"
 
 
-def write_json_machine(json_folder=None, progress_bar=True):
+def write_json_machine(json_folder=None, progress_bar=True, validate=True):
     """ Runs the code to write the machine in Java readable JSON.
 
     .. warning::
@@ -30,6 +30,7 @@ def write_json_machine(json_folder=None, progress_bar=True):
 
     :param str json_folder: the folder to which the JSON are being written
     :param bool progress_bar: Flag if Progress Bar should be shown
+    :param bool validate: Flag to disable the validation.
     :return: the name of the generated file
     :rtype: str
     """
@@ -48,8 +49,9 @@ def write_json_machine(json_folder=None, progress_bar=True):
         if progress:
             progress.update()
 
-        # validate the schema
-        file_format_schemas.validate(json_obj, MACHINE_FILENAME)
+        if validate:
+            # validate the schema
+            file_format_schemas.validate(json_obj, MACHINE_FILENAME)
 
         # update and complete progress bar
         if progress:


### PR DESCRIPTION
Due to https://github.com/python-jsonschema/jsonschema/issues/1059 jsonschema validation sometime fails.

This pr removes validation from normal run.
This will also provide a very minor speedup by removing an unlikely to be failed safety test

But keeps it when writing the json files as reports.
For example in debug mode which is tested by
spynnaker_integration_tests/test_debug_mode