### PR TITLE
ExecutableType moved to SpiNNMan

### DIFF
--- a/fec_integration_tests/interface/interface_functions/test_front_end_common_load_executable_images.py
+++ b/fec_integration_tests/interface/interface_functions/test_front_end_common_load_executable_images.py
@@ -17,10 +17,9 @@ from collections import defaultdict
 from spinn_utilities.overrides import overrides
 from spinnman.transceiver import Transceiver
 from spinnman.model import ExecutableTargets
+from spinnman.model.enums import ExecutableType
 from spinn_front_end_common.data.fec_data_writer import FecDataWriter
 from spinn_front_end_common.interface.config_setup import unittest_setup
-from spinn_front_end_common.utilities.utility_objs import (
-    ExecutableType)
 from spinn_front_end_common.interface.interface_functions import (
     load_app_images)
 

--- a/spinn_front_end_common/abstract_models/abstract_has_associated_binary.py
+++ b/spinn_front_end_common/abstract_models/abstract_has_associated_binary.py
@@ -38,5 +38,5 @@ class AbstractHasAssociatedBinary(object, metaclass=AbstractBase):
         """
         Get the start type of the binary to be run.
 
-        :rtype: ~spinn_front_end_common.utilities.utility_objs.ExecutableType
+        :rtype: ~spinn_machine.model.enum.ExecutableType
         """

--- a/spinn_front_end_common/abstract_models/abstract_has_associated_binary.py
+++ b/spinn_front_end_common/abstract_models/abstract_has_associated_binary.py
@@ -38,5 +38,5 @@ class AbstractHasAssociatedBinary(object, metaclass=AbstractBase):
         """
         Get the start type of the binary to be run.
 
-        :rtype: ~spinn_machine.model.enum.ExecutableType
+        :rtype: ~spinnman.model.enum.ExecutableType
         """

--- a/spinn_front_end_common/data/fec_data_view.py
+++ b/spinn_front_end_common/data/fec_data_view.py
@@ -868,7 +868,7 @@ class FecDataView(PacmanDataView, SpiNNManDataView):
         Gets the _executable_types if they have been created.
 
         :rtype: dict(
-            ~spinn_front_end_common.utilities.utility_objs.ExecutableType,
+            ~spinn_machine.model.enum.ExecutableType,
             ~spinn_machine.CoreSubsets)
         :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
             If the executable_types is currently unavailable

--- a/spinn_front_end_common/data/fec_data_view.py
+++ b/spinn_front_end_common/data/fec_data_view.py
@@ -868,7 +868,7 @@ class FecDataView(PacmanDataView, SpiNNManDataView):
         Gets the _executable_types if they have been created.
 
         :rtype: dict(
-            ~spinn_machine.model.enum.ExecutableType,
+            ~spinnman.model.enum.ExecutableType,
             ~spinn_machine.CoreSubsets)
         :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
             If the executable_types is currently unavailable

--- a/spinn_front_end_common/data/fec_data_writer.py
+++ b/spinn_front_end_common/data/fec_data_writer.py
@@ -442,7 +442,7 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
         """
         :param executable_types:
         :type executable_types: dict(
-            ~spinn_machine.model.enum.ExecutableType,
+            ~spinnman.model.enum.ExecutableType,
             ~spinn_machine.CoreSubsets or None)
         """
         if not isinstance(executable_types, dict):

--- a/spinn_front_end_common/data/fec_data_writer.py
+++ b/spinn_front_end_common/data/fec_data_writer.py
@@ -442,7 +442,7 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
         """
         :param executable_types:
         :type executable_types: dict(
-            ~spinn_front_end_common.utilities.utility_objs.ExecutableType,
+            ~spinn_machine.model.enum.ExecutableType,
             ~spinn_machine.CoreSubsets or None)
         """
         if not isinstance(executable_types, dict):

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -35,7 +35,7 @@ from spinn_machine import CoreSubsets, Machine
 from spinnman import __version__ as spinnman_version
 from spinnman.exceptions import SpiNNManCoresNotInStateException
 from spinnman.model.cpu_infos import CPUInfos
-from spinnman.model.enums.cpu_state import CPUState
+from spinnman.model.enums import CPUState, ExecutableType
 
 from data_specification import __version__ as data_spec_version
 
@@ -116,7 +116,6 @@ from spinn_front_end_common.utilities.report_functions import (
     write_json_machine, write_json_placements,
     write_json_routing_tables, drift_report)
 from spinn_front_end_common.utilities.iobuf_extractor import IOBufExtractor
-from spinn_front_end_common.utilities.utility_objs import ExecutableType
 from spinn_front_end_common.utility_models import (
     DataSpeedUpPacketGatherMachineVertex)
 from spinn_front_end_common.utilities.report_functions.reports import (

--- a/spinn_front_end_common/interface/interface_functions/application_finisher.py
+++ b/spinn_front_end_common/interface/interface_functions/application_finisher.py
@@ -17,13 +17,12 @@ import time
 from spinn_utilities.progress_bar import ProgressBar
 from spinnman.messages.sdp import SDPFlag, SDPHeader, SDPMessage
 from spinnman.messages.scp.enums import Signal
-from spinnman.model.enums import CPUState
+from spinnman.model.enums import CPUState, ExecutableType
 from spinn_front_end_common.data import FecDataView
 from spinn_front_end_common.utilities.constants import (
     SDP_PORTS, SDP_RUNNING_MESSAGE_CODES)
 from spinn_front_end_common.utilities.exceptions import (
     ExecutableFailedToStopException)
-from spinn_front_end_common.utilities.utility_objs import ExecutableType
 
 _ONE_WORD = struct.Struct("<I")
 

--- a/spinn_front_end_common/interface/interface_functions/application_runner.py
+++ b/spinn_front_end_common/interface/interface_functions/application_runner.py
@@ -16,9 +16,9 @@ import logging
 import time
 from spinn_utilities.log import FormatAdapter
 from spinnman.messages.scp.enums import Signal
+from spinnman.model.enums import ExecutableType
 from spinn_front_end_common.data import FecDataView
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
-from spinn_front_end_common.utilities.utility_objs import ExecutableType
 from spinn_front_end_common.utilities.constants import (
     MICRO_TO_MILLISECOND_CONVERSION)
 

--- a/spinn_front_end_common/interface/interface_functions/chip_iobuf_clearer.py
+++ b/spinn_front_end_common/interface/interface_functions/chip_iobuf_clearer.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from spinnman.model.enums import ExecutableType
 from spinn_front_end_common.data import FecDataView
 from spinn_front_end_common.utilities.scp import ClearIOBUFProcess
-from spinn_front_end_common.utilities.utility_objs import ExecutableType
 
 
 def chip_io_buf_clearer():

--- a/spinn_front_end_common/interface/interface_functions/chip_runtime_updater.py
+++ b/spinn_front_end_common/interface/interface_functions/chip_runtime_updater.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from spinn_utilities.progress_bar import ProgressBar
-from spinnman.model.enums import CPUState
+from spinnman.model.enums import CPUState, ExecutableType
 from spinn_front_end_common.data import FecDataView
-from spinn_front_end_common.utilities.utility_objs import ExecutableType
 from spinn_front_end_common.utilities.scp import UpdateRuntimeProcess
 
 

--- a/spinn_front_end_common/interface/interface_functions/find_application_chips_used.py
+++ b/spinn_front_end_common/interface/interface_functions/find_application_chips_used.py
@@ -14,7 +14,7 @@
 
 from collections import defaultdict
 import sys
-from spinn_front_end_common.utilities.utility_objs import ExecutableType
+from spinnman.model.enums import ExecutableType
 from spinn_front_end_common.abstract_models import AbstractHasAssociatedBinary
 
 

--- a/spinn_front_end_common/interface/interface_functions/host_execute_data_specification.py
+++ b/spinn_front_end_common/interface/interface_functions/host_execute_data_specification.py
@@ -19,6 +19,7 @@ from spinn_utilities.config_holder import get_config_bool
 from spinn_utilities.progress_bar import ProgressBar
 from spinn_utilities.log import FormatAdapter
 from spinn_machine import CoreSubsets
+from spinnman.model.enums import ExecutableType
 from data_specification import DataSpecificationExecutor, MemoryRegionReal
 from data_specification.constants import (
     MAX_MEM_REGIONS, APP_PTR_TABLE_BYTE_SIZE)
@@ -26,7 +27,6 @@ from data_specification.exceptions import DataSpecificationException
 from spinn_front_end_common.data import FecDataView
 from spinn_front_end_common.utilities.helpful_functions import (
     write_address_to_user0)
-from spinn_front_end_common.utilities.utility_objs import ExecutableType
 from spinn_front_end_common.utilities.emergency_recovery import (
     emergency_recover_states_from_failure)
 from spinn_front_end_common.utilities.constants import CORE_DATA_SDRAM_BASE_TAG

--- a/spinn_front_end_common/interface/interface_functions/host_no_bitfield_router_compression.py
+++ b/spinn_front_end_common/interface/interface_functions/host_no_bitfield_router_compression.py
@@ -19,12 +19,11 @@ from spinn_utilities.log import FormatAdapter
 from spinn_utilities.progress_bar import ProgressBar
 from spinn_machine import CoreSubsets, Router
 from spinnman.model import ExecutableTargets
-from spinnman.model.enums import CPUState
+from spinnman.model.enums import CPUState, ExecutableType
 from spinn_front_end_common.data import FecDataView
 from spinn_front_end_common.utilities.exceptions import SpinnFrontEndException
 from spinn_front_end_common.utilities.system_control_logic import (
     run_system_application)
-from spinn_front_end_common.utilities.utility_objs import ExecutableType
 from spinn_front_end_common.utilities.helpful_functions import (
     get_defaultable_source_id)
 from spinn_front_end_common.utilities.constants import COMPRESSOR_SDRAM_TAG

--- a/spinn_front_end_common/interface/interface_functions/load_executable_images.py
+++ b/spinn_front_end_common/interface/interface_functions/load_executable_images.py
@@ -14,11 +14,10 @@
 from spinn_utilities.progress_bar import ProgressBar
 from spinnman.messages.scp.enums import Signal
 from spinnman.model import ExecutableTargets
-from spinnman.model.enums import CPUState
+from spinnman.model.enums import CPUState, ExecutableType
 from spinn_front_end_common.data import FecDataView
 from spinn_front_end_common.utilities.helpful_functions import (
     flood_fill_binary_to_spinnaker)
-from spinn_front_end_common.utilities.utility_objs import ExecutableType
 from spinnman.exceptions import SpiNNManCoresNotInStateException
 from spinn_front_end_common.utilities.emergency_recovery import (
     emergency_recover_states_from_failure)

--- a/spinn_front_end_common/interface/interface_functions/locate_executable_start_type.py
+++ b/spinn_front_end_common/interface/interface_functions/locate_executable_start_type.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 from spinn_machine import CoreSubsets
+from spinnman.model.enums import ExecutableType
 from spinn_front_end_common.abstract_models import AbstractHasAssociatedBinary
 from spinn_front_end_common.data import FecDataView
-from spinn_front_end_common.utilities.utility_objs import ExecutableType
 
 
 def locate_executable_start_type():

--- a/spinn_front_end_common/interface/interface_functions/machine_bit_field_router_compressor.py
+++ b/spinn_front_end_common/interface/interface_functions/machine_bit_field_router_compressor.py
@@ -24,7 +24,7 @@ from spinnman.exceptions import (
     SpinnmanInvalidParameterException,
     SpinnmanUnexpectedResponseCodeException, SpiNNManCoresNotInStateException)
 from spinnman.model import ExecutableTargets
-from spinnman.model.enums import CPUState
+from spinnman.model.enums import CPUState, ExecutableType
 from pacman.model.routing_tables import MulticastRoutingTables
 from pacman.operations.router_compressors.ordered_covering_router_compressor\
     import (
@@ -43,7 +43,6 @@ from spinn_front_end_common.utilities.helpful_functions import (
     get_defaultable_source_id, n_word_struct)
 from spinn_front_end_common.utilities.system_control_logic import (
     run_system_application)
-from spinn_front_end_common.utilities.utility_objs import ExecutableType
 from spinn_front_end_common.utilities.constants import (
     BIT_FIELD_COMMS_SDRAM_TAG, BIT_FIELD_USABLE_SDRAM_TAG,
     BIT_FIELD_ADDRESSES_SDRAM_TAG, BIT_FIELD_ROUTING_TABLE_SDRAM_TAG)

--- a/spinn_front_end_common/utilities/helpful_functions.py
+++ b/spinn_front_end_common/utilities/helpful_functions.py
@@ -17,12 +17,11 @@ import logging
 import struct
 from spinn_utilities.log import FormatAdapter
 from spinn_machine import CoreSubsets
-from spinnman.model.enums import CPUState
+from spinnman.model.enums import CPUState, ExecutableType
 from data_specification.constants import (
     APP_PTR_TABLE_HEADER_BYTE_SIZE, APP_PTR_TABLE_REGION_BYTE_SIZE)
 from spinn_front_end_common.data import FecDataView
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
-from spinn_front_end_common.utilities.utility_objs import ExecutableType
 
 logger = FormatAdapter(logging.getLogger(__name__))
 _n_word_structs = []

--- a/spinn_front_end_common/utilities/iobuf_extractor.py
+++ b/spinn_front_end_common/utilities/iobuf_extractor.py
@@ -19,10 +19,10 @@ from spinn_utilities.log import FormatAdapter
 from spinn_utilities.make_tools.replacer import Replacer
 from spinn_utilities.progress_bar import ProgressBar
 from spinn_machine.core_subsets import CoreSubsets
+from spinnman.model.enums import ExecutableType
 from spinnman.model.io_buffer import IOBuffer
 from spinn_utilities.config_holder import get_config_str
 from spinn_front_end_common.data import FecDataView
-from spinn_front_end_common.utilities.utility_objs import ExecutableType
 from spinn_front_end_common.utilities.helpful_functions import (
     convert_string_into_chip_and_core_subset)
 

--- a/spinn_front_end_common/utilities/report_functions/bit_field_compressor_report.py
+++ b/spinn_front_end_common/utilities/report_functions/bit_field_compressor_report.py
@@ -17,12 +17,12 @@ import os
 import sys
 from collections import defaultdict
 from spinn_utilities.log import FormatAdapter
+from spinnman.model.enums import ExecutableType
 from spinn_front_end_common.abstract_models import AbstractHasAssociatedBinary
 from spinn_front_end_common.data import FecDataView
 from spinn_front_end_common.interface.provenance import (
     ProvenanceReader, ProvenanceWriter)
 from .bit_field_summary import BitFieldSummary
-from spinn_front_end_common.utilities.utility_objs import ExecutableType
 
 logger = FormatAdapter(logging.getLogger(__name__))
 _FILE_NAME = "bit_field_compressed_summary.rpt"

--- a/spinn_front_end_common/utilities/system_control_logic.py
+++ b/spinn_front_end_common/utilities/system_control_logic.py
@@ -16,8 +16,8 @@ from spinnman.exceptions import (
     SpinnmanException, SpiNNManCoresNotInStateException)
 from spinnman.messages.scp.enums import Signal
 from spinnman.model import ExecutableTargets
+from spinnman.model.enums import ExecutableType
 from spinn_front_end_common.data import FecDataView
-from spinn_front_end_common.utilities.utility_objs import ExecutableType
 from spinn_front_end_common.utilities.iobuf_extractor import IOBufExtractor
 
 

--- a/spinn_front_end_common/utilities/utility_objs/executable_type.py
+++ b/spinn_front_end_common/utilities/utility_objs/executable_type.py
@@ -12,13 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-from spinn_utilities.log import FormatAdapter
 from spinnman.model.enums import ExecutableType as _ExecutableType
-
-logger = FormatAdapter(logging.getLogger(__name__))
-
-logger.warning("Class ExecutableType has been moved to spinnman.model.enums")
 
 
 class ExecutableType(object):

--- a/spinn_front_end_common/utilities/utility_objs/executable_type.py
+++ b/spinn_front_end_common/utilities/utility_objs/executable_type.py
@@ -12,73 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from enum import Enum
-from spinnman.model.enums import CPUState
+import logging
+from spinn_utilities.log import FormatAdapter
+from spinnman.model.enums import ExecutableType as _ExecutableType
+
+logger = FormatAdapter(logging.getLogger(__name__))
+
+logger.warning("Class ExecutableType has been moved to spinnman.model.enums")
 
 
-class ExecutableType(Enum):
+class ExecutableType(object):
     """
-    The different types of executable from the perspective of how they
-    are started and controlled.
+    This class is deprecated. Please use spinnman.model.enums.ExecutableType
     """
+    RUNNING = _ExecutableType.RUNNING
 
-    #: Runs immediately without waiting for barrier and then exits.
-    RUNNING = (
-        0,
-        [CPUState.RUNNING],
-        [CPUState.FINISHED],
-        False,
-        "Runs immediately without waiting for barrier and then exits")
-    #: Calls ``spin1_start(SYNC_WAIT)`` and then eventually ``spin1_exit()``.
-    SYNC = (
-        1,
-        [CPUState.SYNC0],
-        [CPUState.FINISHED],
-        False,
-        "Calls spin1_start(SYNC_WAIT) and then eventually spin1_exit()")
-    #: Calls ``simulation_run()`` and ``simulation_exit()`` /
-    #: ``simulation_handle_pause_resume()``.
-    USES_SIMULATION_INTERFACE = (
-        2,
-        [CPUState.SYNC0, CPUState.SYNC1, CPUState.PAUSED, CPUState.READY],
-        [CPUState.READY],
-        True,
-        "Calls simulation_run() and simulation_exit() / "
-        "simulation_handle_pause_resume()")
-    #: Situation where there user has supplied no application but for some
-    #: reason still wants to run.
-    NO_APPLICATION = (
-        3,
-        [],
-        [],
-        True,
-        "Situation where there user has supplied no application but for "
-        "some reason still wants to run")
-    #: Runs immediately without waiting for barrier and never ends.
-    SYSTEM = (
-        4,
-        [CPUState.RUNNING],
-        [CPUState.RUNNING],
-        True,
-        "Runs immediately without waiting for barrier and never ends")
+    SYNC = _ExecutableType.SYNC
 
-    def __new__(cls, value, start_state, end_state,
-                supports_auto_pause_and_resume, doc=""):
-        # pylint: disable=protected-access, too-many-arguments
-        obj = object.__new__(cls)
-        obj._value_ = value
-        obj.start_state = start_state
-        obj.end_state = end_state
-        obj.supports_auto_pause_and_resume = supports_auto_pause_and_resume
-        obj.__doc__ = doc
-        return obj
+    USES_SIMULATION_INTERFACE = _ExecutableType.USES_SIMULATION_INTERFACE
 
-    def __init__(self, value, start_state, end_state,
-                 supports_auto_pause_and_resume, doc=""):
-        # pylint: disable=too-many-arguments
-        self._value_ = value
-        self.__doc__ = doc
-        self.start_state = start_state
-        self.end_state = end_state
-        self.supports_auto_pause_and_resume = supports_auto_pause_and_resume
-        self.__doc__ = doc
+    NO_APPLICATION = _ExecutableType.NO_APPLICATION
+
+    SYSTEM = _ExecutableType.SYSTEM

--- a/spinn_front_end_common/utility_models/chip_power_monitor_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/chip_power_monitor_machine_vertex.py
@@ -19,6 +19,7 @@ import numpy
 from spinn_utilities.config_holder import get_config_int
 from spinn_utilities.log import FormatAdapter
 from spinn_utilities.overrides import overrides
+from spinnman.model.enums import ExecutableType
 from data_specification.enums import DataType
 from pacman.model.graphs.machine import MachineVertex
 from pacman.model.resources import VariableSDRAM
@@ -32,7 +33,6 @@ from spinn_front_end_common.interface.buffer_management.buffer_models import (
 from spinn_front_end_common.interface.provenance import ProvenanceWriter
 from spinn_front_end_common.utilities.constants import (
     SYSTEM_BYTES_REQUIREMENT, SIMULATION_N_BYTES, BYTES_PER_WORD)
-from spinn_front_end_common.utilities.utility_objs import ExecutableType
 from spinn_front_end_common.utilities.helpful_functions import (
     locate_memory_region_for_placement)
 from spinn_front_end_common.interface.simulation.simulation_utilities import (

--- a/spinn_front_end_common/utility_models/command_sender_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/command_sender_machine_vertex.py
@@ -14,6 +14,7 @@
 
 from enum import IntEnum
 from spinn_utilities.overrides import overrides
+from spinnman.model.enums import ExecutableType
 from pacman.model.graphs.machine import MachineVertex, MachineEdge
 from pacman.model.resources import ConstantSDRAM
 from pacman.model.routing_info import BaseKeyAndMask
@@ -27,8 +28,6 @@ from spinn_front_end_common.interface.simulation.simulation_utilities import (
 from spinn_front_end_common.utilities.constants import (
     SYSTEM_BYTES_REQUIREMENT, SIMULATION_N_BYTES, BYTES_PER_WORD)
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
-from spinn_front_end_common.utilities.utility_objs import (
-    ExecutableType)
 
 
 class CommandSenderMachineVertex(

--- a/spinn_front_end_common/utility_models/data_speed_up_packet_gatherer_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/data_speed_up_packet_gatherer_machine_vertex.py
@@ -35,8 +35,6 @@ from spinn_front_end_common.abstract_models import (
     AbstractHasAssociatedBinary, AbstractGeneratesDataSpecification)
 from spinn_front_end_common.interface.provenance import (
     AbstractProvidesProvenanceDataFromMachine)
-from spinn_front_end_common.utilities.utility_objs import (
-    ExecutableType)
 from spinn_front_end_common.utilities.constants import (
     SDP_PORTS, BYTES_PER_WORD, BYTES_PER_KB)
 from spinn_front_end_common.utilities.utility_calls import (

--- a/spinn_front_end_common/utility_models/data_speed_up_packet_gatherer_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/data_speed_up_packet_gatherer_machine_vertex.py
@@ -22,7 +22,7 @@ from spinn_utilities.overrides import overrides
 from spinn_utilities.log import FormatAdapter
 from spinnman.exceptions import SpinnmanTimeoutException
 from spinnman.messages.sdp import SDPMessage, SDPHeader, SDPFlag
-from spinnman.model.enums.cpu_state import CPUState
+from spinnman.model.enums import CPUState, ExecutableType
 from pacman.model.graphs.machine import MachineVertex
 from pacman.model.resources import ConstantSDRAM, IPtagResource
 from spinn_front_end_common.data import FecDataView

--- a/spinn_front_end_common/utility_models/extra_monitor_support_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/extra_monitor_support_machine_vertex.py
@@ -18,13 +18,13 @@ import struct
 from spinn_utilities.log import FormatAdapter
 from spinn_utilities.overrides import overrides
 from spinn_machine import CoreSubsets, Router
+from spinnman.model.enums import ExecutableType
 from pacman.model.graphs.machine import MachineVertex
 from pacman.model.resources import ConstantSDRAM
 from spinn_utilities.config_holder import get_config_bool
 from spinn_front_end_common.abstract_models import (
     AbstractHasAssociatedBinary, AbstractGeneratesDataSpecification)
 from spinn_front_end_common.data import FecDataView
-from spinn_front_end_common.utilities.utility_objs import ExecutableType
 from spinn_front_end_common.utilities.utility_objs.\
     extra_monitor_scp_processes import (
         ReadStatusProcess, ResetCountersProcess, SetPacketTypesProcess,

--- a/spinn_front_end_common/utility_models/live_packet_gather_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/live_packet_gather_machine_vertex.py
@@ -17,6 +17,7 @@ import struct
 from spinn_utilities.overrides import overrides
 from pacman.model.graphs.machine import MachineVertex
 from pacman.model.resources import ConstantSDRAM
+from spinnman.model.enums import ExecutableType
 from spinn_front_end_common.data import FecDataView
 from spinn_front_end_common.interface.provenance import (
     ProvidesProvenanceDataFromMachineImpl, ProvenanceWriter)
@@ -24,7 +25,6 @@ from spinn_front_end_common.interface.simulation.simulation_utilities import (
     get_simulation_header_array)
 from spinn_front_end_common.abstract_models import (
     AbstractGeneratesDataSpecification, AbstractHasAssociatedBinary)
-from spinn_front_end_common.utilities.utility_objs import ExecutableType
 from spinn_front_end_common.utilities.constants import (
     SYSTEM_BYTES_REQUIREMENT, SIMULATION_N_BYTES, BYTES_PER_WORD)
 from spinn_front_end_common.utilities.exceptions import ConfigurationException

--- a/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
@@ -21,6 +21,7 @@ from spinn_utilities.log import FormatAdapter
 from spinn_utilities.overrides import overrides
 from spinnman.messages.eieio import EIEIOPrefix, EIEIOType
 from spinnman.messages.eieio.data_messages import EIEIODataHeader
+from spinnman.model.enums import ExecutableType
 from pacman.model.resources import ReverseIPtagResource, VariableSDRAM
 from pacman.model.graphs.common import Slice
 from pacman.model.graphs.machine import MachineVertex
@@ -50,7 +51,6 @@ from spinn_front_end_common.interface.provenance import (
 from spinn_front_end_common.interface.buffer_management.recording_utilities \
     import (get_recording_header_array, get_recording_header_size,
             get_recording_data_constant_size)
-from spinn_front_end_common.utilities.utility_objs import ExecutableType
 
 logger = FormatAdapter(logging.getLogger(__name__))
 

--- a/unittests/interface/interface_functions/test_front_end_common_app_finisher.py
+++ b/unittests/interface/interface_functions/test_front_end_common_app_finisher.py
@@ -14,7 +14,7 @@
 
 from spinn_utilities.overrides import overrides
 from spinn_machine import CoreSubsets
-from spinn_front_end_common.utilities.utility_objs import ExecutableType
+from spinnman.model.enums import ExecutableType
 from spinnman.model.enums.cpu_state import CPUState
 from spinn_front_end_common.data.fec_data_writer import FecDataWriter
 from spinn_front_end_common.interface.config_setup import unittest_setup

--- a/unittests/interface/interface_functions/test_front_end_common_graph_binary_gatherer.py
+++ b/unittests/interface/interface_functions/test_front_end_common_graph_binary_gatherer.py
@@ -15,6 +15,7 @@
 import unittest
 from spinn_utilities.executable_finder import ExecutableFinder
 from spinn_utilities.overrides import overrides
+from spinnman.model.enums import ExecutableType
 from pacman.model.graphs.machine import SimpleMachineVertex
 from pacman.model.graphs.application.abstract import (
     AbstractOneAppOneMachineVertex)
@@ -23,7 +24,6 @@ from spinn_front_end_common.data.fec_data_writer import FecDataWriter
 from spinn_front_end_common.interface.config_setup import unittest_setup
 from spinn_front_end_common.interface.interface_functions import (
     graph_binary_gatherer, locate_executable_start_type)
-from spinn_front_end_common.utilities.utility_objs import ExecutableType
 from spinn_front_end_common.abstract_models import AbstractHasAssociatedBinary
 
 

--- a/unittests/interface/interface_functions/test_host_execute_data_specification.py
+++ b/unittests/interface/interface_functions/test_host_execute_data_specification.py
@@ -18,6 +18,7 @@ from spinn_utilities.config_holder import set_config
 from spinn_utilities.overrides import overrides
 from spinnman.transceiver import Transceiver
 from spinnman.model import ExecutableTargets
+from spinnman.model.enums import ExecutableType
 from data_specification.constants import (
     MAX_MEM_REGIONS, APP_PTR_TABLE_BYTE_SIZE)
 from data_specification.data_specification_generator import (
@@ -27,7 +28,6 @@ from spinn_front_end_common.data.fec_data_writer import FecDataWriter
 from spinn_front_end_common.interface.interface_functions import (
     execute_application_data_specs)
 from spinn_front_end_common.interface.config_setup import unittest_setup
-from spinn_front_end_common.utilities.utility_objs import (ExecutableType)
 from spinn_front_end_common.interface.ds import DsSqlliteDatabase
 from spinn_front_end_common.utilities.constants import BYTES_PER_WORD
 


### PR DESCRIPTION
Create a stub to allow the moved ExecutableType  to still be imported from FrontendCommon

See: https://github.com/SpiNNakerManchester/SpiNNMan/pull/323