### PR TITLE
no longer publish Python docs to github.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,33 +51,33 @@ jobs:
       - name: Checkout SpiNNaker Dependencies
         uses: ./support/actions/install-spinn-deps
         with:
-          # Need spinnaker_tools so we can run the makefiles
+          # Need spinnaker_tools and SpiNNUtils so we can run the makefiles
+          # sphinx needs SpiNNMachine SpiNNMan PACMAN DataSpecification spalloc
           repositories: >
-            SpiNNUtils SpiNNMachine SpiNNMan PACMAN DataSpecification spalloc
-            spinnaker_tools
+            SpiNNUtils spinnaker_tools
           install: true
 
       - name: Read tags
         run: make doxysetup
         working-directory: c_common
 
-      - name: Install Python code
-        uses: ./support/actions/run-install
+      # - name: Install Python code
+      #  uses: ./support/actions/run-install
 
-      - name: Build Python documentation
-        uses: ./support/actions/sphinx
-        with:
-          directory: doc/source
+      # - name: Build Python documentation
+      #  uses: ./support/actions/sphinx
+      #  with:
+      #    directory: doc/source
       - name: Build C documentation
         uses: mattnotmitt/doxygen-action@v1.9.5
         with:
           working-directory: c_common
 
+      # sphinx needs cp -vaT $PY_DOC_DIR $DEPLOY_DIR/python
       - name: Merge documentation trees
         run: |
           cp -vaT $ROOT_DOC_DIR $DEPLOY_DIR
           cp -vaT $C_DOC_DIR $DEPLOY_DIR/c
-          cp -vaT $PY_DOC_DIR $DEPLOY_DIR/python
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,10 +38,6 @@ jobs:
       - name: Set dynamic environment variables
         run: |
           echo "SPINN_DIRS=$PWD/spinnaker_tools" >> $GITHUB_ENV
-      - name: Install pip, etc
-        uses: ./support/actions/python-tools
-        with:
-          coverage: false
 
       - name: Checkout SpiNNaker Dependencies
         uses: ./support/actions/install-spinn-deps

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,6 @@ on:
 env:
   ROOT_DOC_DIR: doc/global
   C_DOC_DIR: c_common/doc/html
-  PY_DOC_DIR: doc/source/_build/html
   DEPLOY_DIR: deploy
 
 jobs:
@@ -29,10 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
       - name: Checkout
         uses: actions/checkout@v3
       - name: Checkout SupportScripts
@@ -51,29 +46,19 @@ jobs:
       - name: Checkout SpiNNaker Dependencies
         uses: ./support/actions/install-spinn-deps
         with:
-          # Need spinnaker_tools and SpiNNUtils so we can run the makefiles
-          # sphinx needs SpiNNMachine SpiNNMan PACMAN DataSpecification spalloc
           repositories: >
-            SpiNNUtils spinnaker_tools
+            spinnaker_tools
           install: true
 
       - name: Read tags
         run: make doxysetup
         working-directory: c_common
 
-      # - name: Install Python code
-      #  uses: ./support/actions/run-install
-
-      # - name: Build Python documentation
-      #  uses: ./support/actions/sphinx
-      #  with:
-      #    directory: doc/source
       - name: Build C documentation
         uses: mattnotmitt/doxygen-action@v1.9.5
         with:
           working-directory: c_common
 
-      # sphinx needs cp -vaT $PY_DOC_DIR $DEPLOY_DIR/python
       - name: Merge documentation trees
         run: |
           cp -vaT $ROOT_DOC_DIR $DEPLOY_DIR

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ deactivated.
 
 Documentation
 =============
-[SpiNNFrontEndCommon Python documentation](http://spinnakermanchester.github.io/SpiNNFrontEndCommon/python/)
+[SpiNNFrontEndCommon python documentation](https://spinnfrontendcommon.readthedocs.io)
 <br>
 [SpiNNFrontEndCommon C documentation](http://spinnakermanchester.github.io/SpiNNFrontEndCommon/c/)
 

--- a/c_common/Doxyfile
+++ b/c_common/Doxyfile
@@ -26,7 +26,7 @@
 #---------------------------------------------------------------------------
 
 PROJECT_NAME           = SpiNNFrontEndCommon
-PROJECT_NUMBER         = 5.1.1
+PROJECT_NUMBER         = 6.0.1
 PROJECT_BRIEF          = "Common support code for user-facing front end systems."
 PROJECT_LOGO           =
 

--- a/doc/global/index.html
+++ b/doc/global/index.html
@@ -22,10 +22,21 @@ limitations under the License.
 <h1>SpiNNFrontEndCommon Source-Derived Documentation</h1>
 <ul>
 <li>
-  <a href="c/index.html">SpiNNFrontEndCommon <strong>C</strong> Documentation</a>
+  <a href="c/index.html">Current SpiNNFrontEndCommon <strong>C</strong> Documentation</a>
 </li>
 <li>
-  <a href="python/index.html">SpiNNFrontEndCommon <strong>Python</strong> Documentation</a>
+Sorry Previous or Combined C Documentation is not available.
+<li>
+<br>
+</li>
+<li>
+  <a href="https://spinnfrontendcommon.readthedocs.io/en/latest/">Current SpiNNFrontEndCommon <strong>Python</strong> Documentation</a>
+</li>
+<li>
+  <a href="https://spinnakermanchester.readthedocs.io/en/latest/">Current Combined <strong>Python</strong> Documentation</a>
+</li>
+<li>
+  Previous <strong> Python</strong> Documentation <a href="https://readthedocs.org/projects/spinnfrontendcommon/versions/">SpiNNFrontEndCommon</a>  <a href="https://readthedocs.org/projects/spinnakermanchester/versions/"> Combined</a></a>
 </li>
 </ul>
 </body>

--- a/doc/global/python/index.html
+++ b/doc/global/python/index.html
@@ -1,0 +1,24 @@
+<html>
+<!--
+Copyright (c) 2023 The University of Manchester
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url='https://spinnfrontendcommon.readthedocs.io/'" />
+  </head>
+  <body>
+    <p>The Python documentation is available on <a href="http://spinnfrontendcommon.readthedocs.io/">readthedocs</a></p>
+  </body>
+</html>


### PR DESCRIPTION
Only publish python docs on reathedocs.

This is for several reasons
1. It is the standard place to publish python docs
2. RDT supports multiple versions/tags
3. The docs from one repository link to another and having github.io docs link to RDT was ugly.

This PR.
1. Comments out the creation of python docs in the publish action.
2. Updates the readme to point to RTD see https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/tree/doc_links
4. Update the index to go to https://spinnakermanchester.github.io/SpiNNFrontEndCommon/ to point to RDC

This was tested by a second branch which triggered the publish action but that should not be merged.