### PR TITLE
Use UDP for live event listening to allow poking to continue to work

### DIFF
--- a/spinn_front_end_common/interface/interface_functions/spalloc_allocator.py
+++ b/spinn_front_end_common/interface/interface_functions/spalloc_allocator.py
@@ -146,7 +146,7 @@ class SpallocJobController(MachineAllocationController):
 
     @overrides(AbstractMachineAllocationController.open_eieio_listener)
     def open_eieio_listener(self):
-        return self._job.open_listener_connection()
+        return self._job.open_eieio_listener_connection()
 
     @property
     @overrides(AbstractMachineAllocationController.proxying)

--- a/spinn_front_end_common/utilities/connections/live_event_connection.py
+++ b/spinn_front_end_common/utilities/connections/live_event_connection.py
@@ -287,7 +287,7 @@ class LiveEventConnection(DatabaseConnection):
         if self.__sender_connection is None:
             job = db.get_job()
             if job:
-                self.__sender_connection = job.open_listener_connection()
+                self.__sender_connection = job.open_eieio_listener_connection()
             else:
                 self.__sender_connection = EIEIOConnection()
         for label in self.__send_labels:
@@ -306,7 +306,7 @@ class LiveEventConnection(DatabaseConnection):
         if self.__receiver_connection is None:
             job = db.get_job()
             if job:
-                self.__receiver_connection = job.open_listener_connection()
+                self.__receiver_connection = job.open_udp_listener_connection()
             else:
                 self.__receiver_connection = UDPConnection()
         receivers = set()


### PR DESCRIPTION
Fixes bug when using proxy with live I/O. 

Depends on SpiNNakerManchester/SpiNNMan#330