### PR TITLE
ds renaming

### DIFF
--- a/spinn_front_end_common/data/fec_data_view.py
+++ b/spinn_front_end_common/data/fec_data_view.py
@@ -54,7 +54,7 @@ class _FecDataModel(object):
         "_data_in_multicast_routing_tables",
         "_database_file_path",
         "_database_socket_addresses",
-        "_dsg_targets",
+        "_ds_database",
         "_executable_targets",
         "_executable_types",
         "_first_machine_time_step",
@@ -133,7 +133,7 @@ class _FecDataModel(object):
         self._data_in_multicast_key_to_chip_map = None
         self._data_in_multicast_routing_tables = None
         self._database_file_path = None
-        self._dsg_targets = None
+        self._ds_database = None
         self._next_ds_reference = 0
         self._executable_targets = None
         self._fixed_routes = None
@@ -970,17 +970,17 @@ class FecDataView(PacmanDataView, SpiNNManDataView):
         return cls.__fec_data._executable_targets
 
     @classmethod
-    def get_dsg_targets(cls):
+    def get_ds_database(cls):
         """
-        Data Spec targets database.
+        Data Spec database.
 
-        :rtype: DsSqlliteDatabase
+        :rtype: ~spinn_front_end_common.interface.ds.DsSqlliteDatabase
         :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
-            If the dsg_targets is currently unavailable
+            If the ds_database is currently unavailable
         """
-        if cls.__fec_data._dsg_targets is None:
-            raise cls._exception("dsg_targets")
-        return cls.__fec_data._dsg_targets
+        if cls.__fec_data._ds_database is None:
+            raise cls._exception("_ds_database")
+        return cls.__fec_data._ds_database
 
     @classmethod
     def has_monitors(cls):

--- a/spinn_front_end_common/data/fec_data_writer.py
+++ b/spinn_front_end_common/data/fec_data_writer.py
@@ -478,15 +478,16 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
             raise TypeError("executable_targets must be a ExecutableTargets")
         self.__fec_data._executable_targets = executable_targets
 
-    def set_dsg_targets(self, dsg_targets):
+    def set_ds_database(self, ds_database):
         """
         Sets the Data Spec targets database.
 
-        :param ~spinnman.model.ExecutableTargets dsg_targets:
+        :type ds_database:
+            ~spinn_front_end_common.interface.ds.DsSqlliteDatabase
         """
-        if not isinstance(dsg_targets, DsSqlliteDatabase):
-            raise TypeError("dsg_targets must be a DsSqlliteDatabase")
-        self.__fec_data._dsg_targets = dsg_targets
+        if not isinstance(ds_database, DsSqlliteDatabase):
+            raise TypeError("ds_database must be a DsSqlliteDatabase")
+        self.__fec_data._ds_database = ds_database
 
     def __gatherer_map_error(self):
         return TypeError(

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -77,7 +77,7 @@ from spinn_front_end_common.interface.interface_functions import (
     chip_provenance_updater, chip_runtime_updater, compute_energy_used,
     create_notification_protocol, database_interface,
     reload_dsg_regions, energy_provenance_reporter,
-    execute_application_data_specs, execute_system_data_specs,
+    load_application_data_specs, load_system_data_specs,
     graph_binary_gatherer, graph_data_specification_writer,
     graph_provenance_gatherer,
     host_based_bit_field_router_compressor, hbp_allocator,
@@ -1354,10 +1354,10 @@ class AbstractSpinnakerBase(ConfigHandler):
         """
         Runs, times, and logs the GraphDataSpecificationWriter.
 
-        Sets the dsg_targets data
+        Creates and fills the data spec database
         """
         with FecTimer("Graph data specification writer", TimerWork.OTHER):
-            self._data_writer.set_dsg_targets(
+            self._data_writer.set_ds_database(
                 graph_data_specification_writer())
 
     def _do_data_generation(self):
@@ -1707,15 +1707,15 @@ class AbstractSpinnakerBase(ConfigHandler):
                 return
             load_fixed_routes()
 
-    def _execute_system_data_specification(self):
+    def _execute_load_system_data_specification(self):
         """
-        Runs, times and logs the execute_system_data_specs if required.
+        Runs, times and logs the load_system_data_specs if required.
         """
         with FecTimer(
-                "Execute system data specification", TimerWork.OTHER) as timer:
+                "Load system data specification", TimerWork.OTHER) as timer:
             if timer.skip_if_virtual_board():
                 return None
-            execute_system_data_specs()
+            load_system_data_specs()
 
     def _execute_load_system_executable_images(self):
         """
@@ -1727,18 +1727,19 @@ class AbstractSpinnakerBase(ConfigHandler):
                 return
             load_sys_images()
 
-    def _execute_application_data_specification(self):
+    def _execute_load_application_data_specification(self):
         """
-        Runs, times and logs :py:meth:`execute_application_data_specs`
+        Runs, times and logs :py:meth:`load_application_data_specs`
         if required.
 
         :return: map of placement and DSG data, and loaded data flag.
         :rtype: dict(tuple(int,int,int),DataWritten) or DsWriteInfo
         """
-        with FecTimer("Host data specification", TimerWork.LOADING) as timer:
+        with FecTimer("Load Application data specification",
+                      TimerWork.LOADING) as timer:
             if timer.skip_if_virtual_board():
                 return
-            return execute_application_data_specs()
+            return load_application_data_specs()
 
     def _execute_tags_from_machine_report(self):
         """
@@ -1864,10 +1865,10 @@ class AbstractSpinnakerBase(ConfigHandler):
         self._execute_control_sync(False)
         if self._data_writer.get_requires_mapping():
             self._execute_load_fixed_routes()
-        self._execute_system_data_specification()
+        self._execute_load_system_data_specification()
         self._execute_load_system_executable_images()
         self._execute_load_tags()
-        self._execute_application_data_specification()
+        self._execute_load_application_data_specification()
 
         self._do_extra_load_algorithms()
         compressed = self._do_delayed_compression(compressor, compressed)

--- a/spinn_front_end_common/interface/interface_functions/__init__.py
+++ b/spinn_front_end_common/interface/interface_functions/__init__.py
@@ -32,8 +32,8 @@ from .graph_provenance_gatherer import graph_provenance_gatherer
 from .hbp_allocator import hbp_allocator
 from .host_bit_field_router_compressor import (
     host_based_bit_field_router_compressor)
-from .host_execute_data_specification import (
-    execute_application_data_specs, execute_system_data_specs)
+from .load_data_specification import (
+    load_application_data_specs, load_system_data_specs)
 from .insert_chip_power_monitors_to_graphs import (
     insert_chip_power_monitors_to_graphs)
 from .insert_extra_monitor_vertices_to_graphs import (
@@ -65,8 +65,8 @@ __all__ = [
     "chip_runtime_updater", "create_notification_protocol",
     "compute_energy_used", "database_interface",
     "reload_dsg_regions",
-    "energy_provenance_reporter", "execute_application_data_specs",
-    "execute_system_data_specs", "FindApplicationChipsUsed",
+    "energy_provenance_reporter", "load_application_data_specs",
+    "load_system_data_specs", "FindApplicationChipsUsed",
     "graph_binary_gatherer", "graph_data_specification_writer",
     "graph_provenance_gatherer",
     "hbp_allocator", "host_based_bit_field_router_compressor",

--- a/spinn_front_end_common/interface/interface_functions/dsg_region_reloader.py
+++ b/spinn_front_end_common/interface/interface_functions/dsg_region_reloader.py
@@ -55,7 +55,7 @@ def regenerate_data_spec(placement):
 
     # build the file writer for the spec
     reloader = DataSpecificationReloader(
-        placement.x, placement.y, placement.p, FecDataView.get_dsg_targets(),
+        placement.x, placement.y, placement.p, FecDataView.get_ds_database(),
         report_writer)
 
     # Execute the regeneration

--- a/spinn_front_end_common/interface/interface_functions/load_data_specification.py
+++ b/spinn_front_end_common/interface/interface_functions/load_data_specification.py
@@ -30,19 +30,19 @@ from spinn_front_end_common.utilities.emergency_recovery import (
 logger = FormatAdapter(logging.getLogger(__name__))
 
 
-def execute_system_data_specs():
+def load_system_data_specs():
     """
-    Execute the data specs for all system targets.
+    Load the data specs for all system targets.
     """
-    specifier = _HostExecuteDataSpecification()
+    specifier = _LoadDataSpecification()
     return specifier.load_data_specs(True, False)
 
 
-def execute_application_data_specs():
+def load_application_data_specs():
     """
-    Execute the data specs for all non-system targets.
+    Load the data specs for all non-system targets.
     """
-    specifier = _HostExecuteDataSpecification()
+    specifier = _LoadDataSpecification()
     uses_advanced_monitors = get_config_bool(
         "Machine", "enable_advanced_monitor_support")
     # Allow config to override
@@ -57,9 +57,9 @@ def execute_application_data_specs():
         raise
 
 
-class _HostExecuteDataSpecification(object):
+class _LoadDataSpecification(object):
     """
-    Executes the host based data specification.
+    Loads the data specification.
     """
 
     __slots__ = []
@@ -94,7 +94,7 @@ class _HostExecuteDataSpecification(object):
             java_caller.set_placements(FecDataView.iterate_placemements())
         progress.update()
 
-        java_caller.execute_app_data_specification(use_monitors)
+        java_caller.load_app_data_specification(use_monitors)
         progress.end()
 
     def load_data_specs(self, is_system, uses_advanced_monitors):
@@ -123,7 +123,7 @@ class _HostExecuteDataSpecification(object):
         progress = ProgressBar(
             1, "Executing data specifications and loading data for system "
             "vertices using Java")
-        FecDataView.get_java_caller().execute_system_data_specification()
+        FecDataView.get_java_caller().load_system_data_specification()
         progress.end()
 
     def __python_load(self, is_system, uses_advanced_monitors):
@@ -134,13 +134,13 @@ class _HostExecuteDataSpecification(object):
             self.__set_router_timeouts()
 
         # create a progress bar for end users
-        dsg_targets = FecDataView.get_dsg_targets()
+        ds_database = FecDataView.get_ds_database()
 
         # allocate and set user 0 before loading data
 
         transceiver = FecDataView.get_transceiver()
         writer = transceiver.write_memory
-        core_infos = dsg_targets.get_core_infos(is_system)
+        core_infos = ds_database.get_core_infos(is_system)
         if is_system:
             type_str = "system"
         else:
@@ -152,14 +152,14 @@ class _HostExecuteDataSpecification(object):
 
         for x, y, p, _, _ in progress.over(
                 core_infos, finish_at_end=False):
-            self.__python_maloc_core(dsg_targets, x, y, p)
+            self.__python_maloc_core(ds_database, x, y, p)
 
         for x, y, p, eth_x, eth_y in progress.over(core_infos):
             if uses_advanced_monitors:
                 gatherer = FecDataView.get_gatherer_by_xy(eth_x, eth_y)
                 writer = gatherer.send_data_into_spinnaker
-            written = self.__python_load_core(dsg_targets, x, y, p, writer)
-            to_write = dsg_targets.get_memory_to_write(x, y, p)
+            written = self.__python_load_core(ds_database, x, y, p, writer)
+            to_write = ds_database.get_memory_to_write(x, y, p)
             if (written != to_write):
                 raise DataSpecException(
                     f"For {x=}{y=}{p=} {written=} != {to_write=}")
@@ -167,32 +167,32 @@ class _HostExecuteDataSpecification(object):
         if uses_advanced_monitors:
             self.__reset_router_timeouts()
 
-    def __python_maloc_core(self, dsg_targets, x, y, p):
-        region_sizes = dsg_targets.get_region_sizes(x, y, p)
+    def __python_maloc_core(self, ds_database, x, y, p):
+        region_sizes = ds_database.get_region_sizes(x, y, p)
         total_size = sum(region_sizes.values())
         malloc_size = total_size + APP_PTR_TABLE_BYTE_SIZE
         start_address = self.__malloc_region_storage(x, y, p, malloc_size)
-        dsg_targets.set_start_address(x, y, p, start_address)
+        ds_database.set_start_address(x, y, p, start_address)
 
         next_pointer = start_address + APP_PTR_TABLE_BYTE_SIZE
         for region_num, size in region_sizes.items():
-            dsg_targets.set_region_pointer(x, y, p, region_num, next_pointer)
+            ds_database.set_region_pointer(x, y, p, region_num, next_pointer)
             next_pointer += size
 
         # safety code
-        total_size = dsg_targets.get_total_regions_size(x, y, p)
+        total_size = ds_database.get_total_regions_size(x, y, p)
         expected_pointer = start_address + APP_PTR_TABLE_BYTE_SIZE + total_size
         if (next_pointer != expected_pointer):
             raise DataSpecException(
                 f"For {x=} {y=} {p=} {next_pointer=} != {expected_pointer=}")
 
-    def __python_load_core(self, dsg_targets, x, y, p, writer):
+    def __python_load_core(self, ds_database, x, y, p, writer):
         written = 0
         pointer_table = numpy.zeros(
             MAX_MEM_REGIONS, dtype=TABLE_TYPE)
         try:
             for region_num, pointer, content in \
-                    dsg_targets.get_region_pointers_and_content(x, y, p):
+                    ds_database.get_region_pointers_and_content(x, y, p):
                 pointer_table[region_num]["pointer"] = pointer
 
                 if content is None:
@@ -215,7 +215,7 @@ class _HostExecuteDataSpecification(object):
                     f"{x=} {y=} {p=} {region_num=} has a unsatisfied pointer")
             raise
 
-        base_address = dsg_targets.get_start_address(x, y, p)
+        base_address = ds_database.get_start_address(x, y, p)
         header = numpy.array([APPDATA_MAGIC_NUM, DSE_VERSION], dtype="<u4")
 
         to_write = numpy.concatenate(

--- a/spinn_front_end_common/interface/java_caller.py
+++ b/spinn_front_end_common/interface/java_caller.py
@@ -367,26 +367,7 @@ class JavaCaller(object):
                 "Java call exited with value " + str(result) + " see "
                 + str(log_file) + " for logged info")
 
-    def execute_data_specification(self):
-        """
-        Writes all the data specifications, uploading the result to the
-        machine.
-
-        :raises PacmanExternalAlgorithmFailedToCompleteException:
-            On failure of the Java code.
-        """
-        result = self._run_java(
-            'dse', self._machine_json(),
-            DsSqlliteDatabase.default_database_file(),
-            FecDataView.get_run_dir_path())
-        if result != 0:
-            log_file = os.path.join(
-                FecDataView.get_run_dir_path(), "jspin.log")
-            raise PacmanExternalAlgorithmFailedToCompleteException(
-                "Java call exited with value " + str(result) + " see "
-                + str(log_file) + " for logged info")
-
-    def execute_system_data_specification(self):
+    def load_system_data_specification(self):
         """
         Writes all the data specifications for system cores,
         uploading the result to the machine.
@@ -405,7 +386,7 @@ class JavaCaller(object):
                 "Java call exited with value " + str(result) + " see "
                 + str(log_file) + " for logged info")
 
-    def execute_app_data_specification(self, use_monitors):
+    def load_app_data_specification(self, use_monitors):
         """
         Writes all the data specifications for application cores,
         uploading the result to the machine.

--- a/spinn_front_end_common/utilities/report_functions/memory_map_on_host_chip_report.py
+++ b/spinn_front_end_common/utilities/report_functions/memory_map_on_host_chip_report.py
@@ -37,10 +37,10 @@ def memory_map_on_host_chip_report():
         os.makedirs(directory_name)
 
     transceiver = FecDataView.get_transceiver()
-    dsg_targets = FecDataView.get_dsg_targets()
+    ds_database = FecDataView.get_ds_database()
     progress = ProgressBar(
-        dsg_targets.get_n_ds_cores(), "Writing memory map reports")
-    for (x, y, p) in progress.over(dsg_targets.get_ds_cores()):
+        ds_database.get_n_ds_cores(), "Writing memory map reports")
+    for (x, y, p) in progress.over(ds_database.get_ds_cores()):
         file_name = os.path.join(
             directory_name, f"memory_map_from_processor_{x}_{y}_{p}.txt")
         try:

--- a/spinn_front_end_common/utilities/report_functions/memory_map_on_host_report.py
+++ b/spinn_front_end_common/utilities/report_functions/memory_map_on_host_report.py
@@ -30,7 +30,7 @@ def memory_map_on_host_report():
         with open(file_name, "w", encoding="utf-8") as f:
             f.write("On host data specification executor\n")
             for xyp, start_address, memory_used, memory_written in \
-                    FecDataView.get_dsg_targets().get_info_for_cores():
+                    FecDataView.get_ds_database().get_info_for_cores():
                 f.write(
                     f"{xyp}: ('start_address': {start_address}, "
                     f"hex:{hex(start_address)}), "

--- a/unittests/data/test_simulator_data.py
+++ b/unittests/data/test_simulator_data.py
@@ -573,15 +573,15 @@ class TestSimulatorData(unittest.TestCase):
         with self.assertRaises(TypeError):
             writer.set_executable_targets([])
 
-    def test_dsg_target(self):
+    def test_ds_database(self):
         writer = FecDataWriter.mock()
         with self.assertRaises(DataNotYetAvialable):
-            FecDataView.get_dsg_targets()
+            FecDataView.get_ds_database()
         targets = DsSqlliteDatabase()
-        writer.set_dsg_targets(targets)
-        self.assertEqual(targets, FecDataView.get_dsg_targets())
+        writer.set_ds_database(targets)
+        self.assertEqual(targets, FecDataView.get_ds_database())
         with self.assertRaises(TypeError):
-            writer.set_dsg_targets(dict())
+            writer.set_ds_database(dict())
 
     def test_gatherer_map(self):
         writer = FecDataWriter.mock()

--- a/unittests/interface/interface_functions/test_load_data_specification.py
+++ b/unittests/interface/interface_functions/test_load_data_specification.py
@@ -26,7 +26,7 @@ from spinn_front_end_common.data.fec_data_writer import FecDataWriter
 from spinn_front_end_common.interface.ds import (
     DataSpecificationGenerator)
 from spinn_front_end_common.interface.interface_functions import (
-    execute_application_data_specs)
+    load_application_data_specs)
 from spinn_front_end_common.interface.config_setup import unittest_setup
 from spinn_front_end_common.interface.ds import DsSqlliteDatabase
 from spinn_front_end_common.utilities.constants import (
@@ -92,7 +92,7 @@ class _TestVertexWithBinary(SimpleMachineVertex, AbstractHasAssociatedBinary):
         return self._binary_start_type
 
 
-class TestHostExecuteDataSpecification(unittest.TestCase):
+class TestLoadDataSpecification(unittest.TestCase):
 
     def setUp(cls):
         unittest_setup()
@@ -118,9 +118,9 @@ class TestHostExecuteDataSpecification(unittest.TestCase):
         spec.write_value(3)
         spec.end_specification()
 
-        writer.set_dsg_targets(db)
+        writer.set_ds_database(db)
 
-        execute_application_data_specs()
+        load_application_data_specs()
 
         # Test regions - although 3 are created, only 2 should be uploaded
         # (0 and 2), and only the data written should be uploaded
@@ -189,9 +189,9 @@ class TestHostExecuteDataSpecification(unittest.TestCase):
         spec.reference_memory_region(0, 1)
         spec.end_specification()
 
-        writer.set_dsg_targets(db)
+        writer.set_ds_database(db)
 
-        execute_application_data_specs()
+        load_application_data_specs()
 
         # User 0 for each spec (3) + header and table for each spec (3)
         # + 1 actual region (as rest are references)
@@ -254,7 +254,7 @@ class TestHostExecuteDataSpecification(unittest.TestCase):
         spec.write_value(0)
         spec.end_specification()
 
-        writer.set_dsg_targets(db)
+        writer.set_ds_database(db)
 
         # This safety query should yield nothing
         bad = list(db.get_unlinked_references())
@@ -263,7 +263,7 @@ class TestHostExecuteDataSpecification(unittest.TestCase):
 
         # DataSpecException because one of the regions can't be found
         with self.assertRaises(DataSpecException):
-            execute_application_data_specs()
+            load_application_data_specs()
 
     def test_multispec_with_double_reference(self):
         writer = FecDataWriter.mock()
@@ -301,7 +301,7 @@ class TestHostExecuteDataSpecification(unittest.TestCase):
         spec.reference_memory_region(0, 1)
         spec.end_specification()
 
-        writer.set_dsg_targets(db)
+        writer.set_ds_database(db)
 
         # This safety query should yield nothing
         bad = list(db.get_unlinked_references())
@@ -310,7 +310,7 @@ class TestHostExecuteDataSpecification(unittest.TestCase):
 
         # DataSpecException because the reference is on a different chip
         with self.assertRaises(DataSpecException):
-            execute_application_data_specs()
+            load_application_data_specs()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Does the Python side of more remaining after the DS removal.

Excutor references changed to loader

dsgtargets changed to ds_database

Must be done at the same tome as:
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1358

tested by:
https://github.com/SpiNNakerManchester/IntegrationTests/pull/214