### PR TITLE
Defaults from cfg

### DIFF
--- a/fec_integration_tests/file_convertor_tests/test_write_json_machine.py
+++ b/fec_integration_tests/file_convertor_tests/test_write_json_machine.py
@@ -38,7 +38,7 @@ class TestWriteJson(unittest.TestCase):
     mainPort = 22244
 
     def setUp(self):
-        unittest_setup()
+        unittest_setup(board_type=1)
         class_file = sys.modules[self.__module__].__file__
         path = os.path.dirname(os.path.abspath(class_file))
         os.chdir(path)

--- a/fec_integration_tests/interface/interface_functions/test_database_interface.py
+++ b/fec_integration_tests/interface/interface_functions/test_database_interface.py
@@ -103,7 +103,7 @@ def _place_vertices(app_vertex, placements, chips):
 
 
 def test_database_interface():
-    unittest_setup()
+    unittest_setup(board_type=1)
     set_config("Database", "create_database", "True")
     set_config("Database", "create_routing_info_to_neuron_id_mapping", "True")
 

--- a/fec_integration_tests/interface/interface_functions/test_front_end_common_insert_lpgs.py
+++ b/fec_integration_tests/interface/interface_functions/test_front_end_common_insert_lpgs.py
@@ -37,7 +37,7 @@ class TestInsertLPGs(unittest.TestCase):
 
     """
     def setUp(self):
-        unittest_setup()
+        unittest_setup(board_type=1)
 
     def test_that_3_lpgs_are_generated_on_3_board_app_graph(self):
         writer = FecDataWriter.mock()

--- a/spinn_front_end_common/interface/config_handler.py
+++ b/spinn_front_end_common/interface/config_handler.py
@@ -22,6 +22,7 @@ from spinn_utilities.config_holder import (
     config_options, load_config, get_config_bool, get_config_int,
     get_config_str, get_config_str_list, set_config)
 from spinn_machine import Machine
+from spinn_machine.config_setup import setup_spin1
 from spinn_front_end_common.interface.provenance import LogStoreDB
 from spinn_front_end_common.data.fec_data_writer import FecDataWriter
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
@@ -70,6 +71,7 @@ class ConfigHandler(object):
         logger.set_log_store(LogStoreDB())
 
         # set up machine targeted data
+        self._setup_board_type()
         self._debug_configs()
         self._previous_handler()
 
@@ -77,6 +79,14 @@ class ConfigHandler(object):
         max_machine_core = get_config_int("Machine", "max_machine_core")
         if max_machine_core is not None:
             Machine.set_max_cores_per_chip(max_machine_core)
+
+    def _setup_board_type(self):
+        """
+        Stub to detect between spin1 and spin2 and update tej cofnigs
+
+        """
+        # TODO read config and determine if spin1 or spin2
+        setup_spin1()
 
     def _debug_configs(self):
         """

--- a/spinn_front_end_common/interface/config_setup.py
+++ b/spinn_front_end_common/interface/config_setup.py
@@ -22,7 +22,7 @@ from spinn_front_end_common.data.fec_data_writer import FecDataWriter
 BASE_CONFIG_FILE = "spinnaker.cfg"
 
 
-def unittest_setup():
+def unittest_setup(*, board_type=None):
     """
     Does all the steps that may be required before a unit test.
 
@@ -33,16 +33,28 @@ def unittest_setup():
 
     .. note::
         This file should only be called from `spinn_front_end_common/tests`
+
+    :param board_type: Value to say how to confuire the system.
+        This includes defining what a VirtualMachine would be
+        Can be 1 for Spin1 boards, 2 for Spin2 boards or
+        None if the test do not depend on knowing the board type.
+    :type board_type: None or int
     """
     clear_cfg_files(True)
-    add_spinnaker_cfg()
     FecDataWriter.mock()
+    add_spinnaker_cfg(board_type)
 
 
-def add_spinnaker_cfg():
+def add_spinnaker_cfg(board_type):
     """
     Add the local configuration and all dependent configuration files.
+
+    :param board_type: Value to say how to confuire the system.
+        This includes defining what a VirtualMachine would be
+        Can be 1 for Spin1 boards, 2 for Spin2 boards or
+        None if the test do not depend on knowing the board type.
+    :type board_type: None or int
     """
-    add_pacman_cfg()  # This add its dependencies too
-    add_spinnman_cfg()  # double adds of dependencies ignored
     add_default_cfg(os.path.join(os.path.dirname(__file__), BASE_CONFIG_FILE))
+    add_pacman_cfg(board_type)  # This add its dependencies too
+    add_spinnman_cfg(board_type)  # double adds of dependencies ignored

--- a/unittests/data/manual_check.py
+++ b/unittests/data/manual_check.py
@@ -25,7 +25,7 @@ from spinn_utilities.config_holder import clear_cfg_files
 
 # reset the configs without mocking the global data
 clear_cfg_files(True)
-add_spinnaker_cfg()
+add_spinnaker_cfg(board_type=None)
 
 view = FecDataView()
 try:

--- a/unittests/data/test_simulator_data.py
+++ b/unittests/data/test_simulator_data.py
@@ -45,7 +45,7 @@ from spinn_front_end_common.utility_models import (
 class TestSimulatorData(unittest.TestCase):
 
     def setUp(cls):
-        unittest_setup()
+        unittest_setup(board_type=1)
 
     def test_setup(self):
         # What happens before setup depends on the previous test

--- a/unittests/interface/buffer_management/test_buffered_database.py
+++ b/unittests/interface/buffer_management/test_buffered_database.py
@@ -25,7 +25,7 @@ from spinn_front_end_common.interface.config_setup import unittest_setup
 class TestBufferedDatabase(unittest.TestCase):
 
     def setUp(self):
-        unittest_setup()
+        unittest_setup(board_type=1)
 
     def test_use_database(self):
         f = BufferDatabase.default_database_file()

--- a/unittests/interface/ds/test_ds.py
+++ b/unittests/interface/ds/test_ds.py
@@ -50,7 +50,7 @@ class _TestVertexWithBinary(SimpleMachineVertex, AbstractHasAssociatedBinary):
 class TestDataSpecification(unittest.TestCase):
 
     def setUp(self):
-        unittest_setup()
+        unittest_setup(board_type=1)
 
     def test_init(self):
         db = DsSqlliteDatabase()

--- a/unittests/interface/interface_functions/test_load_data_specification.py
+++ b/unittests/interface/interface_functions/test_load_data_specification.py
@@ -87,7 +87,7 @@ class _TestVertexWithBinary(SimpleMachineVertex, AbstractHasAssociatedBinary):
 class TestLoadDataSpecification(unittest.TestCase):
 
     def setUp(cls):
-        unittest_setup()
+        unittest_setup(board_type=1)
         set_config("Machine", "enable_advanced_monitor_support", "False")
 
     def test_call(self):


### PR DESCRIPTION
Part of https://github.com/SpiNNakerManchester/SpiNNMachine/pull/215

Config_holder has a stub that of now just sets spin1

To be determined how to distinguish in a cfg which board type to be expected.
 