### PR TITLE
use one transaction for multiple calls

### DIFF
--- a/spinn_front_end_common/interface/provenance/provenance_writer.py
+++ b/spinn_front_end_common/interface/provenance/provenance_writer.py
@@ -56,7 +56,7 @@ class ProvenanceWriter(BaseDatabase):
         :param str description: Type of value
         :param float the_value: data
         """
-        with self.transaction() as cur:
+        with self.cursor() as cur:
             cur.execute(
                 """
                 INSERT INTO power_provenance(
@@ -77,7 +77,7 @@ class ProvenanceWriter(BaseDatabase):
         :param str description: type of value
         :param float the_value: data
         """
-        with self.transaction() as cur:
+        with self.cursor() as cur:
             cur.execute(
                 """
                 INSERT INTO gatherer_provenance(
@@ -94,7 +94,7 @@ class ProvenanceWriter(BaseDatabase):
         :param str description: type of value
         :param int the_value: data
         """
-        with self.transaction() as cur:
+        with self.cursor() as cur:
             cur.execute(
                 """
                 INSERT INTO monitor_provenance(
@@ -113,7 +113,7 @@ class ProvenanceWriter(BaseDatabase):
         :param float the_value: data
         :param bool expected: Flag to say this data was expected
         """
-        with self.transaction() as cur:
+        with self.cursor() as cur:
             cur.execute(
                 """
                 INSERT INTO router_provenance(
@@ -131,7 +131,7 @@ class ProvenanceWriter(BaseDatabase):
         :param str description: type of value
         :param int the_value: data
         """
-        with self.transaction() as cur:
+        with self.cursor() as cur:
             core_id = self._get_core_id(cur, x, y, p)
             cur.execute(
                 """
@@ -149,7 +149,7 @@ class ProvenanceWriter(BaseDatabase):
 
         :param str message:
         """
-        with self.transaction() as cur:
+        with self.cursor() as cur:
             cur.execute(
                 """
                 INSERT INTO reports(message)
@@ -204,6 +204,16 @@ class ProvenanceWriter(BaseDatabase):
                 VALUES (?, ?, ?)
                 """, ((x, y, ipaddress)
                       for ((x, y), ipaddress) in connections.items()))
+
+    def _context_entered(self):
+        self.start_transaction()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is None:
+            self.commit()
+        else:
+            self.rollback()
+        return super().__exit__(exc_type, exc_val, exc_tb)
 
     def _test_log_locked(self, text):
         """

--- a/spinn_front_end_common/utilities/sqlite_db.py
+++ b/spinn_front_end_common/utilities/sqlite_db.py
@@ -21,7 +21,6 @@ import pathlib
 import sqlite3
 import struct
 from spinn_utilities.abstract_context_manager import AbstractContextManager
-from spinn_utilities.logger_utils import warn_once
 logger = logging.getLogger(__name__)
 
 
@@ -140,7 +139,7 @@ class SQLiteDB(AbstractContextManager):
         try:
             if self.__db is not None:
                 if self.__db.in_transaction:
-                     raise NotImplementedError(
+                    raise NotImplementedError(
                         "This call is illegal with an open transaction")
                 self.__db.close()
                 self.__db = None

--- a/spinn_front_end_common/utilities/sqlite_db.py
+++ b/spinn_front_end_common/utilities/sqlite_db.py
@@ -170,30 +170,6 @@ class SQLiteDB(AbstractContextManager):
         else:
             raise TypeError("can only set pragmas to bool, int or str")
 
-    @property
-    def connection(self):
-        """
-        The underlying SQLite database connection.
-
-        .. warning::
-            If you're using this a lot, consider contacting the SpiNNaker
-            Software Team with details of your use case so we can extend the
-            relevant core class to support you. *Normally* it is better to use
-            :py:meth:`transaction` to obtain a cursor with appropriate
-            transactional guards.
-
-        :rtype: ~sqlite3.Connection
-        :raises AttributeError: if the database connection has been closed
-        """
-        warn_once(
-            logger,
-            "Low-level connection used instead of transaction() context. "
-            "Please contact SpiNNaker Software Team with your use-case for "
-            "assistance.")
-        if not self.__db:
-            raise AttributeError("database has been closed")
-        return self.__db
-
     def start_transaction(self):
         """
         This starts a transaction which then allows the cursor to be obtained.


### PR DESCRIPTION
This is a cherry pick and simplification of idea of using a db transaction longer from https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1062

As ProvenanceWriter is designed to be used as a ContextManager (using with)
context_entered starts a transaction
exit commits or rolls back

This depended on the SQLiteDB.connection property to expose the database in a way we did not really intend.
Instead
SQLiteDB 
- no longer has a connection property
- now has start_transaction, commit, rollback and cursor methods
- check to make sure cursor only happens with an open transaction and close only without an open transaction
- has a more light weight inner class _CursorWrapper which does not enter and exit the database

Unit test where added to show that
- commit and rollback are safe even when not expected.
- cursor and the ProvenanceWriter methods that depend on it will fail outside of a with. (id no open transaction)




