### PR TITLE
Use less transactions

### DIFF
--- a/fec_integration_tests/interface/interface_functions/test_database_interface.py
+++ b/fec_integration_tests/interface/interface_functions/test_database_interface.py
@@ -149,17 +149,19 @@ def test_database_interface():
     db_path = database_interface(1000)
     print(db_path)
 
-    reader = DatabaseReader(db_path)
-    assert reader.get_ip_address(0, 0) == writer.get_chip_at(0, 0).ip_address
-    assert all(db_p == placements.get_placement_of_vertex(m_vertex).location
-               for db_p, m_vertex in zip(
-                   reader.get_placements(app_vertex_1.label),
-                   app_vertex_1.machine_vertices))
-    assert reader.get_configuration_parameter_value("runtime") == 1000
-    assert (
-        reader.get_live_output_details(
-            app_vertex_1.label, lpg_vertex.label) ==
-        (tag.ip_address, tag.port, tag.strip_sdp, tag.board_address, tag.tag,
-         tag.destination_x, tag.destination_y))
-    assert reader.get_atom_id_to_key_mapping(app_vertex_1.label)
-    assert reader.get_key_to_atom_id_mapping(app_vertex_1.label)
+    with DatabaseReader(db_path) as reader:
+        assert (reader.get_ip_address(0, 0) ==
+                writer.get_chip_at(0, 0).ip_address)
+        assert all(db_p ==
+                   placements.get_placement_of_vertex(m_vertex).location
+                   for db_p, m_vertex in zip(
+                       reader.get_placements(app_vertex_1.label),
+                       app_vertex_1.machine_vertices))
+        assert reader.get_configuration_parameter_value("runtime") == 1000
+        assert (
+            reader.get_live_output_details(
+                app_vertex_1.label, lpg_vertex.label) ==
+            (tag.ip_address, tag.port, tag.strip_sdp, tag.board_address,
+             tag.tag, tag.destination_x, tag.destination_y))
+        assert reader.get_atom_id_to_key_mapping(app_vertex_1.label)
+        assert reader.get_key_to_atom_id_mapping(app_vertex_1.label)

--- a/spinn_front_end_common/data/fec_data_view.py
+++ b/spinn_front_end_common/data/fec_data_view.py
@@ -973,6 +973,7 @@ class FecDataView(PacmanDataView, SpiNNManDataView):
     def get_ds_database_path(cls):
         """
         Gets the path for the Data Spec database.
+
         :rtype: str
         :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
             If the ds_database is currently unavailable

--- a/spinn_front_end_common/data/fec_data_view.py
+++ b/spinn_front_end_common/data/fec_data_view.py
@@ -54,6 +54,7 @@ class _FecDataModel(object):
         "_data_in_multicast_routing_tables",
         "_database_file_path",
         "_database_socket_addresses",
+        "_ds_database_path",
         "_executable_targets",
         "_executable_types",
         "_first_machine_time_step",
@@ -132,6 +133,7 @@ class _FecDataModel(object):
         self._data_in_multicast_key_to_chip_map = None
         self._data_in_multicast_routing_tables = None
         self._database_file_path = None
+        self._ds_database_path = None
         self._next_ds_reference = 0
         self._executable_targets = None
         self._fixed_routes = None
@@ -966,6 +968,20 @@ class FecDataView(PacmanDataView, SpiNNManDataView):
         if cls.__fec_data._executable_targets is None:
             raise cls._exception("executable_targets")
         return cls.__fec_data._executable_targets
+
+    @classmethod
+    def get_ds_database_path(cls):
+        """
+        Gets the path for the Data Spec database.
+        :rtype: str
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the ds_database is currently unavailable
+        """
+        if cls.__fec_data._ds_database_path is None:
+            if cls._is_mocked():
+                return os.path.join(cls._temporary_dir_path(), "ds.sqlite3")
+            raise cls._exception("_ds_database+path")
+        return cls.__fec_data._ds_database_path
 
     @classmethod
     def has_monitors(cls):

--- a/spinn_front_end_common/data/fec_data_view.py
+++ b/spinn_front_end_common/data/fec_data_view.py
@@ -54,7 +54,6 @@ class _FecDataModel(object):
         "_data_in_multicast_routing_tables",
         "_database_file_path",
         "_database_socket_addresses",
-        "_ds_database",
         "_executable_targets",
         "_executable_types",
         "_first_machine_time_step",
@@ -133,7 +132,6 @@ class _FecDataModel(object):
         self._data_in_multicast_key_to_chip_map = None
         self._data_in_multicast_routing_tables = None
         self._database_file_path = None
-        self._ds_database = None
         self._next_ds_reference = 0
         self._executable_targets = None
         self._fixed_routes = None
@@ -968,19 +966,6 @@ class FecDataView(PacmanDataView, SpiNNManDataView):
         if cls.__fec_data._executable_targets is None:
             raise cls._exception("executable_targets")
         return cls.__fec_data._executable_targets
-
-    @classmethod
-    def get_ds_database(cls):
-        """
-        Data Spec database.
-
-        :rtype: ~spinn_front_end_common.interface.ds.DsSqlliteDatabase
-        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
-            If the ds_database is currently unavailable
-        """
-        if cls.__fec_data._ds_database is None:
-            raise cls._exception("_ds_database")
-        return cls.__fec_data._ds_database
 
     @classmethod
     def has_monitors(cls):

--- a/spinn_front_end_common/data/fec_data_writer.py
+++ b/spinn_front_end_common/data/fec_data_writer.py
@@ -481,6 +481,7 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
     def set_ds_database_path(self, ds_database_path):
         """
         Sets the Data Spec targets database.
+
         :type ds_database:
             ~spinn_front_end_common.interface.ds.DsSqlliteDatabase
         """

--- a/spinn_front_end_common/data/fec_data_writer.py
+++ b/spinn_front_end_common/data/fec_data_writer.py
@@ -478,6 +478,17 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
             raise TypeError("executable_targets must be a ExecutableTargets")
         self.__fec_data._executable_targets = executable_targets
 
+    def set_ds_database_path(self, ds_database_path):
+        """
+        Sets the Data Spec targets database.
+        :type ds_database:
+            ~spinn_front_end_common.interface.ds.DsSqlliteDatabase
+        """
+        if not os.path.isfile(ds_database_path):
+            raise TypeError("ds_database path must be a filee")
+
+        self.__fec_data._ds_database_path = ds_database_path
+
     def __gatherer_map_error(self):
         return TypeError(
             "gatherer_map must be a dict((int, int), "

--- a/spinn_front_end_common/data/fec_data_writer.py
+++ b/spinn_front_end_common/data/fec_data_writer.py
@@ -479,17 +479,6 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
             raise TypeError("executable_targets must be a ExecutableTargets")
         self.__fec_data._executable_targets = executable_targets
 
-    def set_ds_database(self, ds_database):
-        """
-        Sets the Data Spec targets database.
-
-        :type ds_database:
-            ~spinn_front_end_common.interface.ds.DsSqlliteDatabase
-        """
-        if not isinstance(ds_database, DsSqlliteDatabase):
-            raise TypeError("ds_database must be a DsSqlliteDatabase")
-        self.__fec_data._ds_database = ds_database
-
     def __gatherer_map_error(self):
         return TypeError(
             "gatherer_map must be a dict((int, int), "

--- a/spinn_front_end_common/data/fec_data_writer.py
+++ b/spinn_front_end_common/data/fec_data_writer.py
@@ -29,7 +29,6 @@ from spinnman.model import ExecutableTargets
 from pacman.data.pacman_data_writer import PacmanDataWriter
 from pacman.model.routing_tables import MulticastRoutingTables
 from spinn_front_end_common.interface.buffer_management import BufferManager
-from spinn_front_end_common.interface.ds import DsSqlliteDatabase
 from spinn_front_end_common.interface.java_caller import JavaCaller
 from spinn_front_end_common.utilities.constants import (
     MICRO_TO_MILLISECOND_CONVERSION, MICRO_TO_SECOND_CONVERSION)

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1420,8 +1420,7 @@ class AbstractSpinnakerBase(ConfigHandler):
         Creates and fills the data spec database
         """
         with FecTimer("Graph data specification writer", TimerWork.OTHER):
-            self._data_writer.set_ds_database(
-                graph_data_specification_writer())
+            graph_data_specification_writer()
 
     def _do_data_generation(self):
         """

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1420,7 +1420,8 @@ class AbstractSpinnakerBase(ConfigHandler):
         Creates and fills the data spec database
         """
         with FecTimer("Graph data specification writer", TimerWork.OTHER):
-            graph_data_specification_writer()
+            self._data_writer.set_ds_database_path(
+                graph_data_specification_writer())
 
     def _do_data_generation(self):
         """

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -370,9 +370,8 @@ class BufferManager(object):
             len(recording_placements),
             "Extracting buffers from the last run")
 
-        with BufferDatabase() as db:
-            for placement in progress.over(recording_placements):
-                self._retreive_by_placement(db, placement)
+        for placement in progress.over(recording_placements):
+            self._retreive_by_placement(placement)
 
     def get_data_by_placement(self, placement, recording_region_id):
         """
@@ -397,11 +396,10 @@ class BufferManager(object):
             return db.get_region_data(
                 placement.x, placement.y, placement.p, recording_region_id)
 
-    def _retreive_by_placement(self, db, placement):
+    def _retreive_by_placement(self, placement):
         """
         Retrieve the data for a vertex; must be locked first.
 
-        :param BufferDatabase db: database to store into
         :param ~pacman.model.placements.Placement placement:
             the placement to get the data from
         :param int recording_region_id: desired recording data region
@@ -417,8 +415,10 @@ class BufferManager(object):
             size, addr, missing = sizes_and_addresses[region]
             data = self._request_data(
                 placement.x, placement.y, addr, size)
-            db.store_data_in_region_buffer(
-                placement.x, placement.y, placement.p, region, missing, data)
+            with BufferDatabase() as db:
+                db.store_data_in_region_buffer(
+                    placement.x, placement.y, placement.p, region, missing,
+                    data)
 
     def _get_region_information(self, addr, x, y):
         """

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
@@ -58,37 +58,35 @@ class BufferDatabase(BaseDatabase):
         :return: True if any region was changed
         :rtype: bool
         """
-        with self.transaction() as cursor:
-            for row in cursor.execute(
-                    """
-                    SELECT region_id FROM region_view
-                    WHERE x = ? AND y = ? AND processor = ?
-                        AND local_region_index = ? AND fetches > 0 LIMIT 1
-                    """, (x, y, p, region)):
-                locus = (row["region_id"], )
-                break
-            else:
-                return False
-            cursor.execute(
+        for row in self.execute(
                 """
-                UPDATE region SET
-                    content = CAST('' AS BLOB), content_len = 0,
-                    fetches = 0, append_time = NULL
-                WHERE region_id = ?
-                """, locus)
-            cursor.execute(
-                """
-                DELETE FROM region_extra WHERE region_id = ?
-                """, locus)
-            return True
+                SELECT region_id FROM region_view
+                WHERE x = ? AND y = ? AND processor = ?
+                    AND local_region_index = ? AND fetches > 0 LIMIT 1
+                """, (x, y, p, region)):
+            locus = (row["region_id"], )
+            break
+        else:
+            return False
+        self.execute(
+            """
+            UPDATE region SET
+                content = CAST('' AS BLOB), content_len = 0,
+                fetches = 0, append_time = NULL
+            WHERE region_id = ?
+            """, locus)
+        self.execute(
+            """
+            DELETE FROM region_extra WHERE region_id = ?
+            """, locus)
+        return True
 
-    def _read_contents(self, cursor, region_id):
+    def _read_contents(self, region_id):
         """
-        :param ~sqlite3.Cursor cursor:
         :param int region_id:
         :rtype: memoryview
         """
-        for row in cursor.execute(
+        for row in self.execute(
                 """
                 SELECT content
                 FROM region_view
@@ -101,7 +99,7 @@ class BufferDatabase(BaseDatabase):
             raise LookupError(f"no record for region {region_id}")
 
         c_buffer = None
-        for row in cursor.execute(
+        for row in self.execute(
                 """
                 SELECT r.content_len + (
                     SELECT SUM(x.content_len)
@@ -115,7 +113,7 @@ class BufferDatabase(BaseDatabase):
 
         if c_buffer is not None:
             idx = len(data)
-            for row in cursor.execute(
+            for row in self.execute(
                     """
                     SELECT content FROM region_extra
                     WHERE region_id = ? ORDER BY extra_id ASC
@@ -126,15 +124,14 @@ class BufferDatabase(BaseDatabase):
             data = c_buffer
         return memoryview(data)
 
-    def _get_region_id(self, cursor, x, y, p, region):
+    def _get_region_id(self, x, y, p, region):
         """
-        :param ~sqlite3.Cursor cursor:
         :param int x:
         :param int y:
         :param int p:
         :param int region:
         """
-        for row in cursor.execute(
+        for row in self.execute(
                 """
                 SELECT region_id FROM region_view
                 WHERE x = ? AND y = ? AND processor = ?
@@ -142,14 +139,14 @@ class BufferDatabase(BaseDatabase):
                 LIMIT 1
                 """, (x, y, p, region)):
             return row["region_id"]
-        core_id = self._get_core_id(cursor, x, y, p)
-        cursor.execute(
+        core_id = self._get_core_id(x, y, p)
+        self.execute(
             """
             INSERT INTO region(
                 core_id, local_region_index, content, content_len, fetches)
             VALUES(?, ?, CAST('' AS BLOB), 0, 0)
             """, (core_id, region))
-        return cursor.lastrowid
+        return self.lastrowid
 
     def store_data_in_region_buffer(self, x, y, p, region, missing, data):
         """
@@ -170,41 +167,39 @@ class BufferDatabase(BaseDatabase):
         # pylint: disable=too-many-arguments, unused-argument
         # TODO: Use missing
         datablob = sqlite3.Binary(data)
-        with self.transaction() as cursor:
-            region_id = self._get_region_id(cursor, x, y, p, region)
-            if self.__use_main_table(cursor, region_id):
-                cursor.execute(
-                    """
-                    UPDATE region SET
-                        content = CAST(? AS BLOB),
-                        content_len = ?,
-                        fetches = fetches + 1,
-                        append_time = ?
-                    WHERE region_id = ?
-                    """, (datablob, len(data), _timestamp(), region_id))
-            else:
-                cursor.execute(
-                    """
-                    UPDATE region SET
-                        fetches = fetches + 1,
-                        append_time = ?
-                    WHERE region_id = ?
-                    """, (_timestamp(), region_id))
-                assert cursor.rowcount == 1
-                cursor.execute(
-                    """
-                    INSERT INTO region_extra(
-                        region_id, content, content_len)
-                    VALUES (?, CAST(? AS BLOB), ?)
-                    """, (region_id, datablob, len(data)))
-            assert cursor.rowcount == 1
+        region_id = self._get_region_id(x, y, p, region)
+        if self.__use_main_table(region_id):
+            self.execute(
+                """
+                UPDATE region SET
+                    content = CAST(? AS BLOB),
+                    content_len = ?,
+                    fetches = fetches + 1,
+                    append_time = ?
+                WHERE region_id = ?
+                """, (datablob, len(data), _timestamp(), region_id))
+        else:
+            self.execute(
+                """
+                UPDATE region SET
+                    fetches = fetches + 1,
+                    append_time = ?
+                WHERE region_id = ?
+                """, (_timestamp(), region_id))
+            assert self.rowcount == 1
+            self.execute(
+                """
+                INSERT INTO region_extra(
+                    region_id, content, content_len)
+                VALUES (?, CAST(? AS BLOB), ?)
+                """, (region_id, datablob, len(data)))
+        assert self.rowcount == 1
 
-    def __use_main_table(self, cursor, region_id):
+    def __use_main_table(self, region_id):
         """
-        :param ~sqlite3.Cursor cursor:
         :param int region_id:
         """
-        for row in cursor.execute(
+        for row in self.execute(
                 """
                 SELECT COUNT(*) AS existing FROM region
                 WHERE region_id = ? AND fetches = 0
@@ -233,11 +228,10 @@ class BufferDatabase(BaseDatabase):
         :rtype: tuple(memoryview, bool)
         """
         try:
-            with self.transaction() as cursor:
-                region_id = self._get_region_id(cursor, x, y, p, region)
-                data = self._read_contents(cursor, region_id)
-                # TODO missing data
-                return data, False
+            region_id = self._get_region_id(x, y, p, region)
+            data = self._read_contents(region_id)
+            # TODO missing data
+            return data, False
         except LookupError:
             return memoryview(b''), True
 
@@ -254,48 +248,45 @@ class BufferDatabase(BaseDatabase):
             # can't check that because of import circularity.
             job = mac._job
             if isinstance(job, SpallocJob):
-                with self.transaction() as cur:
+                with self.get_cursor as cur:
                     job._write_session_credentials_to_db(cur)
 
-    def _set_core_name(self, cursor, x, y, p, core_name):
+    def _set_core_name(self, x, y, p, core_name):
         """
-        :param ~sqlite3.Cursor cursor:
         :param int x:
         :param int y:
         :param int p:
         :param str core_name:
         """
         try:
-            cursor.execute(
+            self.execute(
                 """
                 INSERT INTO core (x, y, processor, core_name)
                 VALUES (?, ?, ? ,?)
                 """, (x, y, p, core_name))
         except sqlite3.IntegrityError:
-            cursor.execute(
+            self.execute(
                 """
                 UPDATE core SET core_name = ?
                 WHERE x = ? AND y = ? and processor = ?
                 """, (core_name, x, y, p))
 
     def store_vertex_labels(self):
-        with self.transaction() as cursor:
-            for placement in FecDataView.iterate_placemements():
-                self._set_core_name(cursor, placement.x, placement.y,
-                                    placement.p, placement.vertex.label)
-            for chip in FecDataView.get_machine().chips:
-                for processor in chip.processors:
-                    if processor.is_monitor:
-                        self._set_core_name(
-                            cursor, chip.x, chip.y, processor.processor_id,
-                            f"SCAMP(OS)_{chip.x}:{chip.y}")
+        for placement in FecDataView.iterate_placemements():
+            self._set_core_name(placement.x, placement.y,
+                                placement.p, placement.vertex.label)
+        for chip in FecDataView.get_machine().chips:
+            for processor in chip.processors:
+                if processor.is_monitor:
+                    self._set_core_name(
+                        chip.x, chip.y, processor.processor_id,
+                        f"SCAMP(OS)_{chip.x}:{chip.y}")
 
     def get_core_name(self, x, y, p):
-        with self.transaction() as cursor:
-            for row in cursor.execute(
-                    """
-                    SELECT core_name
-                    FROM core
-                    WHERE x = ? AND y = ? and processor = ?
-                    """, (x, y, p)):
-                return str(row["core_name"], 'utf8')
+        for row in self.execute(
+                """
+                SELECT core_name
+                FROM core
+                WHERE x = ? AND y = ? and processor = ?
+                """, (x, y, p)):
+            return str(row["core_name"], 'utf8')

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
@@ -248,12 +248,11 @@ class BufferDatabase(BaseDatabase):
             # can't check that because of import circularity.
             job = mac._job
             if isinstance(job, SpallocJob):
-                with self.get_cursor as cur:
-                    config = job.get_session_credentials_for_db()
-                    cur.executemany("""
-                        INSERT INTO proxy_configuration(kind, name, value)
-                        VALUES(?, ?, ?)
-                        """, [(k1, k2, v) for (k1, k2), v in config.items()])
+                config = job.get_session_credentials_for_db()
+                self.executemany("""
+                    INSERT INTO proxy_configuration(kind, name, value)
+                    VALUES(?, ?, ?)
+                    """, [(k1, k2, v) for (k1, k2), v in config.items()])
 
     def _set_core_name(self, x, y, p, core_name):
         """

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
@@ -58,7 +58,7 @@ class BufferDatabase(BaseDatabase):
         :return: True if any region was changed
         :rtype: bool
         """
-        for row in self._execute(
+        for row in self.execute(
                 """
                 SELECT region_id FROM region_view
                 WHERE x = ? AND y = ? AND processor = ?
@@ -68,14 +68,14 @@ class BufferDatabase(BaseDatabase):
             break
         else:
             return False
-        self._execute(
+        self.execute(
             """
             UPDATE region SET
                 content = CAST('' AS BLOB), content_len = 0,
                 fetches = 0, append_time = NULL
             WHERE region_id = ?
             """, locus)
-        self._execute(
+        self.execute(
             """
             DELETE FROM region_extra WHERE region_id = ?
             """, locus)
@@ -86,7 +86,7 @@ class BufferDatabase(BaseDatabase):
         :param int region_id:
         :rtype: memoryview
         """
-        for row in self._execute(
+        for row in self.execute(
                 """
                 SELECT content
                 FROM region_view
@@ -99,7 +99,7 @@ class BufferDatabase(BaseDatabase):
             raise LookupError(f"no record for region {region_id}")
 
         c_buffer = None
-        for row in self._execute(
+        for row in self.execute(
                 """
                 SELECT r.content_len + (
                     SELECT SUM(x.content_len)
@@ -113,7 +113,7 @@ class BufferDatabase(BaseDatabase):
 
         if c_buffer is not None:
             idx = len(data)
-            for row in self._execute(
+            for row in self.execute(
                     """
                     SELECT content FROM region_extra
                     WHERE region_id = ? ORDER BY extra_id ASC
@@ -131,7 +131,7 @@ class BufferDatabase(BaseDatabase):
         :param int p:
         :param int region:
         """
-        for row in self._execute(
+        for row in self.execute(
                 """
                 SELECT region_id FROM region_view
                 WHERE x = ? AND y = ? AND processor = ?
@@ -140,13 +140,13 @@ class BufferDatabase(BaseDatabase):
                 """, (x, y, p, region)):
             return row["region_id"]
         core_id = self._get_core_id(x, y, p)
-        self._execute(
+        self.execute(
             """
             INSERT INTO region(
                 core_id, local_region_index, content, content_len, fetches)
             VALUES(?, ?, CAST('' AS BLOB), 0, 0)
             """, (core_id, region))
-        return self._lastrowid
+        return self.lastrowid
 
     def store_data_in_region_buffer(self, x, y, p, region, missing, data):
         """
@@ -169,7 +169,7 @@ class BufferDatabase(BaseDatabase):
         datablob = sqlite3.Binary(data)
         region_id = self._get_region_id(x, y, p, region)
         if self.__use_main_table(region_id):
-            self._execute(
+            self.execute(
                 """
                 UPDATE region SET
                     content = CAST(? AS BLOB),
@@ -179,27 +179,27 @@ class BufferDatabase(BaseDatabase):
                 WHERE region_id = ?
                 """, (datablob, len(data), _timestamp(), region_id))
         else:
-            self._execute(
+            self.execute(
                 """
                 UPDATE region SET
                     fetches = fetches + 1,
                     append_time = ?
                 WHERE region_id = ?
                 """, (_timestamp(), region_id))
-            assert self._rowcount == 1
-            self._execute(
+            assert self.rowcount == 1
+            self.execute(
                 """
                 INSERT INTO region_extra(
                     region_id, content, content_len)
                 VALUES (?, CAST(? AS BLOB), ?)
                 """, (region_id, datablob, len(data)))
-        assert self._rowcount == 1
+        assert self.rowcount == 1
 
     def __use_main_table(self, region_id):
         """
         :param int region_id:
         """
-        for row in self._execute(
+        for row in self.execute(
                 """
                 SELECT COUNT(*) AS existing FROM region
                 WHERE region_id = ? AND fetches = 0
@@ -249,7 +249,7 @@ class BufferDatabase(BaseDatabase):
             job = mac._job
             if isinstance(job, SpallocJob):
                 config = job.get_session_credentials_for_db()
-                self._executemany("""
+                self.executemany("""
                     INSERT INTO proxy_configuration(kind, name, value)
                     VALUES(?, ?, ?)
                     """, [(k1, k2, v) for (k1, k2), v in config.items()])
@@ -262,13 +262,13 @@ class BufferDatabase(BaseDatabase):
         :param str core_name:
         """
         try:
-            self._execute(
+            self.execute(
                 """
                 INSERT INTO core (x, y, processor, core_name)
                 VALUES (?, ?, ? ,?)
                 """, (x, y, p, core_name))
         except sqlite3.IntegrityError:
-            self._execute(
+            self.execute(
                 """
                 UPDATE core SET core_name = ?
                 WHERE x = ? AND y = ? and processor = ?
@@ -286,7 +286,7 @@ class BufferDatabase(BaseDatabase):
                         f"SCAMP(OS)_{chip.x}:{chip.y}")
 
     def get_core_name(self, x, y, p):
-        for row in self._execute(
+        for row in self.execute(
                 """
                 SELECT core_name
                 FROM core

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
@@ -249,7 +249,11 @@ class BufferDatabase(BaseDatabase):
             job = mac._job
             if isinstance(job, SpallocJob):
                 with self.get_cursor as cur:
-                    job._write_session_credentials_to_db(cur)
+                    config = job.get_session_credentials_for_db()
+                    cur.executemany("""
+                        INSERT INTO proxy_configuration(kind, name, value)
+                        VALUES(?, ?, ?)
+                        """, [(k1, k2, v) for (k1, k2), v in config.items()])
 
     def _set_core_name(self, x, y, p, core_name):
         """

--- a/spinn_front_end_common/interface/ds/ds_sqllite_database.py
+++ b/spinn_front_end_common/interface/ds/ds_sqllite_database.py
@@ -40,8 +40,9 @@ class DsSqlliteDatabase(SQLiteDB):
     """
     __slots__ = ["_init_file"]
 
-    def __init__(self):
-        database_file = self.default_database_file()
+    def __init__(self, database_file=None):
+        if database_file is None:
+            database_file = FecDataView.get_ds_database_path()
 
         self._init_file = not os.path.exists(database_file)
 
@@ -53,17 +54,6 @@ class DsSqlliteDatabase(SQLiteDB):
         if self._init_file:
             self.__init_ethernets()
             self._init_file = False
-
-    @classmethod
-    def default_database_file(cls):
-        """
-        Gets the path to the default/ current database file
-
-        :rtype: str
-        :return: Path where the database is or should be written
-        """
-        return os.path.join(FecDataView.get_run_dir_path(),
-                            f"ds{FecDataView.get_reset_str()}.sqlite3")
 
     def __init_ethernets(self):
         """

--- a/spinn_front_end_common/interface/ds/ds_sqllite_database.py
+++ b/spinn_front_end_common/interface/ds/ds_sqllite_database.py
@@ -625,7 +625,11 @@ class DsSqlliteDatabase(SQLiteDB):
             job = mac._job
             if isinstance(job, SpallocJob):
                 with self.transaction() as cur:
-                    job._write_session_credentials_to_db(cur)
+                    config = job.get_session_credentials_for_db
+                    cur.executemany("""
+                        INSERT INTO proxy_configuration(kind, name, value)
+                        VALUES(?, ?, ?)
+                        """, [(k1, k2, v) for (k1, k2), v in config.items()])
 
     def set_app_id(self):
         """

--- a/spinn_front_end_common/interface/ds/ds_sqllite_database.py
+++ b/spinn_front_end_common/interface/ds/ds_sqllite_database.py
@@ -600,7 +600,7 @@ class DsSqlliteDatabase(SQLiteDB):
             # can't check that because of import circularity.
             job = mac._job
             if isinstance(job, SpallocJob):
-                config = job.get_session_credentials_for_db
+                config = job.get_session_credentials_for_db()
                 self._executemany("""
                     INSERT INTO proxy_configuration(kind, name, value)
                     VALUES(?, ?, ?)

--- a/spinn_front_end_common/interface/interface_functions/dsg_region_reloader.py
+++ b/spinn_front_end_common/interface/interface_functions/dsg_region_reloader.py
@@ -14,7 +14,7 @@
 
 from spinn_utilities.progress_bar import ProgressBar
 from spinn_front_end_common.interface.ds import (
-    DataSpecificationReloader)
+    DsSqlliteDatabase, DataSpecificationReloader)
 from spinn_front_end_common.utilities.utility_calls import get_report_writer
 from spinn_front_end_common.abstract_models import (
     AbstractRewritesDataSpecification)
@@ -27,16 +27,19 @@ def reload_dsg_regions():
     """
     progress = ProgressBar(
         FecDataView.get_n_placements(), "Reloading data")
-    for placement in progress.over(FecDataView.iterate_placemements()):
-        # Generate the data spec for the placement if needed
-        regenerate_data_spec(placement)
+    with DsSqlliteDatabase as ds_database:
+        for placement in progress.over(FecDataView.iterate_placemements()):
+            # Generate the data spec for the placement if needed
+            regenerate_data_spec(placement, ds_database)
 
 
-def regenerate_data_spec(placement):
+def regenerate_data_spec(placement, ds_database):
     """
     Regenerate a data specification for a placement.
 
     :param ~.Placement placement: The placement to regenerate
+    :param ds_database: The database to use for reload
+    :type ds_database: ~spinn_front_end_common.interface.ds.DsSqlliteDatabas db
     :return: Whether the data was regenerated or not
     :rtype: bool
     """
@@ -55,8 +58,7 @@ def regenerate_data_spec(placement):
 
     # build the file writer for the spec
     reloader = DataSpecificationReloader(
-        placement.x, placement.y, placement.p, FecDataView.get_ds_database(),
-        report_writer)
+        placement.x, placement.y, placement.p, db)
 
     # Execute the regeneration
     vertex.regenerate_data_specification(reloader, placement)

--- a/spinn_front_end_common/interface/interface_functions/dsg_region_reloader.py
+++ b/spinn_front_end_common/interface/interface_functions/dsg_region_reloader.py
@@ -27,7 +27,7 @@ def reload_dsg_regions():
     """
     progress = ProgressBar(
         FecDataView.get_n_placements(), "Reloading data")
-    with DsSqlliteDatabase as ds_database:
+    with DsSqlliteDatabase() as ds_database:
         for placement in progress.over(FecDataView.iterate_placemements()):
             # Generate the data spec for the placement if needed
             regenerate_data_spec(placement, ds_database)
@@ -58,7 +58,7 @@ def regenerate_data_spec(placement, ds_database):
 
     # build the file writer for the spec
     reloader = DataSpecificationReloader(
-        placement.x, placement.y, placement.p, db)
+        placement.x, placement.y, placement.p, ds_database)
 
     # Execute the regeneration
     vertex.regenerate_data_specification(reloader, placement)

--- a/spinn_front_end_common/interface/interface_functions/dsg_region_reloader.py
+++ b/spinn_front_end_common/interface/interface_functions/dsg_region_reloader.py
@@ -58,7 +58,7 @@ def regenerate_data_spec(placement, ds_database):
 
     # build the file writer for the spec
     reloader = DataSpecificationReloader(
-        placement.x, placement.y, placement.p, ds_database)
+        placement.x, placement.y, placement.p, ds_database, report_writer)
 
     # Execute the regeneration
     vertex.regenerate_data_specification(reloader, placement)

--- a/spinn_front_end_common/interface/interface_functions/graph_data_specification_writer.py
+++ b/spinn_front_end_common/interface/interface_functions/graph_data_specification_writer.py
@@ -77,7 +77,8 @@ class _GraphDataSpecificationWriter(object):
             else:
                 n_placements = len(placement_order)
 
-            progress = ProgressBar(n_placements, "Generating data specifications")
+            progress = ProgressBar(
+                n_placements, "Generating data specifications")
             vertices_to_reset = list()
 
             for placement in progress.over(placement_order):

--- a/spinn_front_end_common/interface/interface_functions/graph_data_specification_writer.py
+++ b/spinn_front_end_common/interface/interface_functions/graph_data_specification_writer.py
@@ -35,12 +35,11 @@ def graph_data_specification_writer(placement_order=None):
     """
     :param list(~pacman.model.placements.Placement) placement_order:
         the optional order in which placements should be examined
-    :rtype: DsSqlliteDatabase
     :raises ConfigurationException:
         If the DSG asks to use more SDRAM than is available.
     """
     writer = _GraphDataSpecificationWriter()
-    return writer.run(placement_order)
+    writer.run(placement_order)
 
 
 class _GraphDataSpecificationWriter(object):
@@ -63,52 +62,49 @@ class _GraphDataSpecificationWriter(object):
         :param list(~pacman.model.placements.Placement) placement_order:
             the optional order in which placements should be examined
         :return: DSG targets
-        :rtype: DsSqlliteDatabase
         :raises ConfigurationException:
             If the DSG asks to use more SDRAM than is available.
         """
         # iterate though vertices and call generate_data_spec for each
         # vertex
-        ds_db = DsSqlliteDatabase()
-        ds_db.write_session_credentials_to_db()
-        ds_db. set_app_id()
+        with DsSqlliteDatabase() as ds_db:
+            ds_db.write_session_credentials_to_db()
+            ds_db. set_app_id()
 
-        if placement_order is None:
-            placement_order = FecDataView.iterate_placemements()
-            n_placements = FecDataView.get_n_placements()
-        else:
-            n_placements = len(placement_order)
+            if placement_order is None:
+                placement_order = FecDataView.iterate_placemements()
+                n_placements = FecDataView.get_n_placements()
+            else:
+                n_placements = len(placement_order)
 
-        progress = ProgressBar(n_placements, "Generating data specifications")
-        vertices_to_reset = list()
+            progress = ProgressBar(n_placements, "Generating data specifications")
+            vertices_to_reset = list()
 
-        for placement in progress.over(placement_order):
-            # Try to generate the data spec for the placement
-            vertex = placement.vertex
-            generated = self.__generate_data_spec_for_vertices(
-                placement, vertex, ds_db)
-
-            if generated and isinstance(
-                    vertex, AbstractRewritesDataSpecification):
-                vertices_to_reset.append(vertex)
-
-            # If the spec wasn't generated directly, and there is an
-            # application vertex, try with that
-            if not generated and vertex.app_vertex is not None:
+            for placement in progress.over(placement_order):
+                # Try to generate the data spec for the placement
+                vertex = placement.vertex
                 generated = self.__generate_data_spec_for_vertices(
-                    placement, vertex.app_vertex, ds_db)
+                    placement, vertex, ds_db)
+
                 if generated and isinstance(
-                        vertex.app_vertex,
-                        AbstractRewritesDataSpecification):
-                    vertices_to_reset.append(vertex.app_vertex)
+                        vertex, AbstractRewritesDataSpecification):
+                    vertices_to_reset.append(vertex)
 
-        # Ensure that the vertices know their regions have been reloaded
-        for vertex in vertices_to_reset:
-            vertex.set_reload_required(False)
+                # If the spec wasn't generated directly, and there is an
+                # application vertex, try with that
+                if not generated and vertex.app_vertex is not None:
+                    generated = self.__generate_data_spec_for_vertices(
+                        placement, vertex.app_vertex, ds_db)
+                    if generated and isinstance(
+                            vertex.app_vertex,
+                            AbstractRewritesDataSpecification):
+                        vertices_to_reset.append(vertex.app_vertex)
 
-        self._run_check_queries(ds_db)
+            # Ensure that the vertices know their regions have been reloaded
+            for vertex in vertices_to_reset:
+                vertex.set_reload_required(False)
 
-        return ds_db
+            self._run_check_queries(ds_db)
 
     def __generate_data_spec_for_vertices(self, pl, vertex, ds_db):
         """

--- a/spinn_front_end_common/interface/interface_functions/spalloc_allocator.py
+++ b/spinn_front_end_common/interface/interface_functions/spalloc_allocator.py
@@ -316,7 +316,8 @@ def _allocate_job_new(
         stack.enter_context(task)
         job.wait_until_ready()
         connections = job.get_connections()
-        ProvenanceWriter().insert_board_provenance(connections)
+        with ProvenanceWriter() as db:
+            db.insert_board_provenance(connections)
         root = connections.get((0, 0), None)
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(

--- a/spinn_front_end_common/interface/java_caller.py
+++ b/spinn_front_end_common/interface/java_caller.py
@@ -380,7 +380,7 @@ class JavaCaller(object):
         """
         result = self._run_java(
             'dse_sys', self._machine_json(),
-            DsSqlliteDatabase.default_database_file(),
+            FecDataView.get_ds_database_path(),
             FecDataView.get_run_dir_path())
         if result != 0:
             log_file = os.path.join(
@@ -405,12 +405,12 @@ class JavaCaller(object):
         if use_monitors:
             result = self._run_java(
                 'dse_app_mon', self._placement_json, self._machine_json(),
-                DsSqlliteDatabase.default_database_file(),
+                FecDataView.get_ds_database_path(),
                 FecDataView.get_run_dir_path())
         else:
             result = self._run_java(
                 'dse_app', self._machine_json(),
-                DsSqlliteDatabase.default_database_file(),
+                FecDataView.get_ds_database_path(),
                 FecDataView.get_run_dir_path())
         if result != 0:
             log_file = os.path.join(

--- a/spinn_front_end_common/interface/java_caller.py
+++ b/spinn_front_end_common/interface/java_caller.py
@@ -30,7 +30,6 @@ from spinn_front_end_common.interface.buffer_management.buffer_models import (
     AbstractReceiveBuffersToHost)
 from spinn_front_end_common.interface.buffer_management.storage_objects \
     import BufferDatabase
-from spinn_front_end_common.interface.ds import DsSqlliteDatabase
 
 logger = FormatAdapter(logging.getLogger(__name__))
 

--- a/spinn_front_end_common/interface/provenance/global_provenance.py
+++ b/spinn_front_end_common/interface/provenance/global_provenance.py
@@ -87,7 +87,7 @@ class GlobalProvenance(SQLiteDB):
         :param str description: The package for which the version applies
         :param str the_value: The version to be recorded
         """
-        self._execute(
+        self.execute(
             """
             INSERT INTO version_provenance(
                 description, the_value)
@@ -102,7 +102,7 @@ class GlobalProvenance(SQLiteDB):
         :param bool machine_on: If the machine was done during all
             or some of the time
         """
-        self._execute(
+        self.execute(
             """
             INSERT INTO category_timer_provenance(
                 category, machine_on, n_run, n_loop)
@@ -111,7 +111,7 @@ class GlobalProvenance(SQLiteDB):
             [category.category_name, machine_on,
              FecDataView.get_run_number(),
              FecDataView.get_run_step()])
-        return self._lastrowid
+        return self.lastrowid
 
     def insert_category_timing(self, category_id, timedelta):
         """
@@ -124,7 +124,7 @@ class GlobalProvenance(SQLiteDB):
                 (timedelta.seconds * MICRO_TO_MILLISECOND_CONVERSION) +
                 (timedelta.microseconds / MICRO_TO_MILLISECOND_CONVERSION))
 
-        self._execute(
+        self.execute(
             """
             UPDATE category_timer_provenance
             SET
@@ -148,7 +148,7 @@ class GlobalProvenance(SQLiteDB):
         time_taken = (
                 (timedelta.seconds * MICRO_TO_MILLISECOND_CONVERSION) +
                 (timedelta.microseconds / MICRO_TO_MILLISECOND_CONVERSION))
-        self._execute(
+        self.execute(
             """
             INSERT INTO timer_provenance(
                 category_id, algorithm, work, time_taken, skip_reason)
@@ -165,7 +165,7 @@ class GlobalProvenance(SQLiteDB):
         """
         if timestamp is None:
             timestamp = datetime.now()
-        self._execute(
+        self.execute(
             """
             INSERT INTO p_log_provenance(
                 timestamp, level, message)
@@ -180,7 +180,7 @@ class GlobalProvenance(SQLiteDB):
         This will lock the database and then try to do a log
         """
         # lock the database
-        self._execute(
+        self.execute(
             """
             INSERT INTO version_provenance(
                 description, the_value)
@@ -220,7 +220,7 @@ class GlobalProvenance(SQLiteDB):
         :rtype: list(tuple or ~sqlite3.Row)
         """
         results = []
-        for row in self._execute(query, params):
+        for row in self.execute(query, params):
             results.append(row)
         return results
 

--- a/spinn_front_end_common/interface/provenance/global_provenance.py
+++ b/spinn_front_end_common/interface/provenance/global_provenance.py
@@ -87,13 +87,12 @@ class GlobalProvenance(SQLiteDB):
         :param str description: The package for which the version applies
         :param str the_value: The version to be recorded
         """
-        with self.transaction() as cur:
-            cur.execute(
-                """
-                INSERT INTO version_provenance(
-                    description, the_value)
-                VALUES(?, ?)
-                """, [description, the_value])
+        self._execute(
+            """
+            INSERT INTO version_provenance(
+                description, the_value)
+            VALUES(?, ?)
+            """, [description, the_value])
 
     def insert_category(self, category, machine_on):
         """
@@ -103,17 +102,16 @@ class GlobalProvenance(SQLiteDB):
         :param bool machine_on: If the machine was done during all
             or some of the time
         """
-        with self.transaction() as cur:
-            cur.execute(
-                """
-                INSERT INTO category_timer_provenance(
-                    category, machine_on, n_run, n_loop)
-                VALUES(?, ?, ?, ?)
-                """,
-                [category.category_name, machine_on,
-                 FecDataView.get_run_number(),
-                 FecDataView.get_run_step()])
-            return cur.lastrowid
+        self._execute(
+            """
+            INSERT INTO category_timer_provenance(
+                category, machine_on, n_run, n_loop)
+            VALUES(?, ?, ?, ?)
+            """,
+            [category.category_name, machine_on,
+             FecDataView.get_run_number(),
+             FecDataView.get_run_step()])
+        return self._lastrowid
 
     def insert_category_timing(self, category_id, timedelta):
         """
@@ -126,14 +124,13 @@ class GlobalProvenance(SQLiteDB):
                 (timedelta.seconds * MICRO_TO_MILLISECOND_CONVERSION) +
                 (timedelta.microseconds / MICRO_TO_MILLISECOND_CONVERSION))
 
-        with self.transaction() as cur:
-            cur.execute(
-                """
-                UPDATE category_timer_provenance
-                SET
-                    time_taken = ?
-                WHERE category_id = ?
-                """, (time_taken, category_id))
+        self._execute(
+            """
+            UPDATE category_timer_provenance
+            SET
+                time_taken = ?
+            WHERE category_id = ?
+            """, (time_taken, category_id))
 
     def insert_timing(
             self, category, algorithm, work, timedelta, skip_reason):
@@ -151,14 +148,13 @@ class GlobalProvenance(SQLiteDB):
         time_taken = (
                 (timedelta.seconds * MICRO_TO_MILLISECOND_CONVERSION) +
                 (timedelta.microseconds / MICRO_TO_MILLISECOND_CONVERSION))
-        with self.transaction() as cur:
-            cur.execute(
-                """
-                INSERT INTO timer_provenance(
-                    category_id, algorithm, work, time_taken, skip_reason)
-                VALUES(?, ?, ?, ?, ?)
-                """,
-                [category, algorithm, work.work_name, time_taken, skip_reason])
+        self._execute(
+            """
+            INSERT INTO timer_provenance(
+                category_id, algorithm, work, time_taken, skip_reason)
+            VALUES(?, ?, ?, ?, ?)
+            """,
+            [category, algorithm, work.work_name, time_taken, skip_reason])
 
     def store_log(self, level, message, timestamp=None):
         """
@@ -169,14 +165,13 @@ class GlobalProvenance(SQLiteDB):
         """
         if timestamp is None:
             timestamp = datetime.now()
-        with self.transaction() as cur:
-            cur.execute(
-                """
-                INSERT INTO p_log_provenance(
-                    timestamp, level, message)
-                VALUES(?, ?, ?)
-                """,
-                [timestamp, level, message])
+        self._execute(
+            """
+            INSERT INTO p_log_provenance(
+                timestamp, level, message)
+            VALUES(?, ?, ?)
+            """,
+            [timestamp, level, message])
 
     def _test_log_locked(self, text):
         """
@@ -184,16 +179,15 @@ class GlobalProvenance(SQLiteDB):
 
         This will lock the database and then try to do a log
         """
-        with self.transaction() as cur:
-            # lock the database
-            cur.execute(
-                """
-                INSERT INTO version_provenance(
-                    description, the_value)
-                VALUES("foo", "bar")
-                """)
-            # try logging and storing while locked.
-            logger.warning(text)
+        # lock the database
+        self._execute(
+            """
+            INSERT INTO version_provenance(
+                description, the_value)
+            VALUES("foo", "bar")
+            """)
+        # try logging and storing while locked.
+        logger.warning(text)
 
     def run_query(self, query, params=()):
         """
@@ -226,9 +220,8 @@ class GlobalProvenance(SQLiteDB):
         :rtype: list(tuple or ~sqlite3.Row)
         """
         results = []
-        with self.transaction() as cur:
-            for row in cur.execute(query, params):
-                results.append(row)
+        for row in self._execute(query, params):
+            results.append(row)
         return results
 
     def get_timer_provenance(self, algorithm):

--- a/spinn_front_end_common/interface/provenance/provenance_reader.py
+++ b/spinn_front_end_common/interface/provenance/provenance_reader.py
@@ -99,7 +99,7 @@ class ProvenanceReader(BaseDatabase):
         :rtype: list(tuple or ~sqlite3.Row)
         """
         results = []
-        for row in self._execute(query, params):
+        for row in self.execute(query, params):
             results.append(row)
         return results
 

--- a/spinn_front_end_common/interface/provenance/provenance_reader.py
+++ b/spinn_front_end_common/interface/provenance/provenance_reader.py
@@ -99,9 +99,8 @@ class ProvenanceReader(BaseDatabase):
         :rtype: list(tuple or ~sqlite3.Row)
         """
         results = []
-        with self.transaction() as cur:
-            for row in cur.execute(query, params):
-                results.append(row)
+        for row in self._execute(query, params):
+            results.append(row)
         return results
 
     def cores_with_late_spikes(self):

--- a/spinn_front_end_common/interface/provenance/provenance_writer.py
+++ b/spinn_front_end_common/interface/provenance/provenance_writer.py
@@ -56,13 +56,12 @@ class ProvenanceWriter(BaseDatabase):
         :param str description: Type of value
         :param float the_value: data
         """
-        with self.transaction() as cur:
-            cur.execute(
-                """
-                INSERT INTO power_provenance(
-                    description, the_value)
-                VALUES(?, ?)
-                """, [description, the_value])
+        self.execute(
+            """
+            INSERT INTO power_provenance(
+                description, the_value)
+            VALUES(?, ?)
+            """, [description, the_value])
 
     def insert_gatherer(self, x, y, address, bytes_read, run, description,
                         the_value):
@@ -77,13 +76,12 @@ class ProvenanceWriter(BaseDatabase):
         :param str description: type of value
         :param float the_value: data
         """
-        with self.transaction() as cur:
-            cur.execute(
-                """
-                INSERT INTO gatherer_provenance(
-                    x, y, address, bytes, run, description, the_value)
-                VALUES(?, ?, ?, ?, ?, ?, ?)
-                """, [x, y, address, bytes_read, run, description, the_value])
+        self.execute(
+            """
+            INSERT INTO gatherer_provenance(
+                x, y, address, bytes, run, description, the_value)
+            VALUES(?, ?, ?, ?, ?, ?, ?)
+            """, [x, y, address, bytes_read, run, description, the_value])
 
     def insert_monitor(self, x, y, description, the_value):
         """
@@ -94,13 +92,12 @@ class ProvenanceWriter(BaseDatabase):
         :param str description: type of value
         :param int the_value: data
         """
-        with self.transaction() as cur:
-            cur.execute(
-                """
-                INSERT INTO monitor_provenance(
-                    x, y, description, the_value)
-                VALUES(?, ?, ?, ?)
-                """, [x, y, description, the_value])
+        self.execute(
+            """
+            INSERT INTO monitor_provenance(
+                x, y, description, the_value)
+            VALUES(?, ?, ?, ?)
+            """, [x, y, description, the_value])
 
     def insert_router(
             self, x, y, description, the_value, expected=True):
@@ -113,13 +110,12 @@ class ProvenanceWriter(BaseDatabase):
         :param float the_value: data
         :param bool expected: Flag to say this data was expected
         """
-        with self.transaction() as cur:
-            cur.execute(
-                """
-                INSERT INTO router_provenance(
-                    x, y, description, the_value, expected)
-                VALUES(?, ?, ?, ?, ?)
-                """, [x, y, description, the_value, expected])
+        self.execute(
+            """
+            INSERT INTO router_provenance(
+                x, y, description, the_value, expected)
+            VALUES(?, ?, ?, ?, ?)
+            """, [x, y, description, the_value, expected])
 
     def insert_core(self, x, y, p, description, the_value):
         """
@@ -131,14 +127,13 @@ class ProvenanceWriter(BaseDatabase):
         :param str description: type of value
         :param int the_value: data
         """
-        with self.transaction() as cur:
-            core_id = self._get_core_id(cur, x, y, p)
-            cur.execute(
-                """
-                INSERT INTO core_provenance(
-                    core_id, description, the_value)
-                VALUES(?, ?, ?)
-                """, [core_id, description, the_value])
+        core_id = self._get_core_id(x, y, p)
+        self.execute(
+            """
+            INSERT INTO core_provenance(
+                core_id, description, the_value)
+            VALUES(?, ?, ?)
+            """, [core_id, description, the_value])
 
     def insert_report(self, message):
         """
@@ -149,13 +144,12 @@ class ProvenanceWriter(BaseDatabase):
 
         :param str message:
         """
-        with self.transaction() as cur:
-            cur.execute(
-                """
-                INSERT INTO reports(message)
-                VALUES(?)
-                """, [message])
-            recorded = cur.lastrowid
+        self.execute(
+            """
+            INSERT INTO reports(message)
+            VALUES(?)
+            """, [message])
+        recorded = self.lastrowid
         cutoff = get_config_int_or_none("Reports", "provenance_report_cutoff")
         if cutoff is None or recorded < cutoff:
             logger.warning(message)
@@ -175,16 +169,15 @@ class ProvenanceWriter(BaseDatabase):
         :param str description: type of value
         :param int the_value: data
         """
-        with self.transaction() as cur:
-            cur.execute(
-                """
-                INSERT OR IGNORE INTO connector_provenance(
-                    pre_population, post_population, the_type, description,
-                    the_value)
-                VALUES(?, ?, ?, ?, ?)
-                """,
-                [pre_population, post_population, the_type, description,
-                 the_value])
+        self.execute(
+            """
+            INSERT OR IGNORE INTO connector_provenance(
+                pre_population, post_population, the_type, description,
+                the_value)
+            VALUES(?, ?, ?, ?, ?)
+            """,
+            [pre_population, post_population, the_type, description,
+             the_value])
 
     def insert_board_provenance(self, connections):
         """
@@ -196,28 +189,10 @@ class ProvenanceWriter(BaseDatabase):
         """
         if not connections:
             return
-        with self.transaction() as cursor:
-            cursor.executemany(
-                """
-                INSERT OR IGNORE INTO boards_provenance(
-                ethernet_x, ethernet_y, ip_addres)
-                VALUES (?, ?, ?)
-                """, ((x, y, ipaddress)
-                      for ((x, y), ipaddress) in connections.items()))
-
-    def _test_log_locked(self, text):
-        """
-        THIS IS A TESTING METHOD.
-
-        This will lock the database and then try to do a log
-        """
-        with self.transaction() as cur:
-            # lock the database
-            cur.execute(
-                """
-                INSERT INTO reports(message)
-                VALUES(?)
-                """, [text])
-            cur.lastrowid  # pylint: disable=pointless-statement
-            # try logging and storing while locked.
-            logger.warning(text)
+        self.executemany(
+            """
+            INSERT OR IGNORE INTO boards_provenance(
+            ethernet_x, ethernet_y, ip_addres)
+            VALUES (?, ?, ?)
+            """, ((x, y, ipaddress)
+                  for ((x, y), ipaddress) in connections.items()))

--- a/spinn_front_end_common/interface/provenance/provenance_writer.py
+++ b/spinn_front_end_common/interface/provenance/provenance_writer.py
@@ -56,7 +56,7 @@ class ProvenanceWriter(BaseDatabase):
         :param str description: Type of value
         :param float the_value: data
         """
-        self.execute(
+        self._execute(
             """
             INSERT INTO power_provenance(
                 description, the_value)
@@ -76,7 +76,7 @@ class ProvenanceWriter(BaseDatabase):
         :param str description: type of value
         :param float the_value: data
         """
-        self.execute(
+        self._execute(
             """
             INSERT INTO gatherer_provenance(
                 x, y, address, bytes, run, description, the_value)
@@ -92,7 +92,7 @@ class ProvenanceWriter(BaseDatabase):
         :param str description: type of value
         :param int the_value: data
         """
-        self.execute(
+        self._execute(
             """
             INSERT INTO monitor_provenance(
                 x, y, description, the_value)
@@ -110,7 +110,7 @@ class ProvenanceWriter(BaseDatabase):
         :param float the_value: data
         :param bool expected: Flag to say this data was expected
         """
-        self.execute(
+        self._execute(
             """
             INSERT INTO router_provenance(
                 x, y, description, the_value, expected)
@@ -128,7 +128,7 @@ class ProvenanceWriter(BaseDatabase):
         :param int the_value: data
         """
         core_id = self._get_core_id(x, y, p)
-        self.execute(
+        self._execute(
             """
             INSERT INTO core_provenance(
                 core_id, description, the_value)
@@ -144,12 +144,12 @@ class ProvenanceWriter(BaseDatabase):
 
         :param str message:
         """
-        self.execute(
+        self._execute(
             """
             INSERT INTO reports(message)
             VALUES(?)
             """, [message])
-        recorded = self.lastrowid
+        recorded = self._lastrowid
         cutoff = get_config_int_or_none("Reports", "provenance_report_cutoff")
         if cutoff is None or recorded < cutoff:
             logger.warning(message)
@@ -169,7 +169,7 @@ class ProvenanceWriter(BaseDatabase):
         :param str description: type of value
         :param int the_value: data
         """
-        self.execute(
+        self._execute(
             """
             INSERT OR IGNORE INTO connector_provenance(
                 pre_population, post_population, the_type, description,
@@ -189,7 +189,7 @@ class ProvenanceWriter(BaseDatabase):
         """
         if not connections:
             return
-        self.executemany(
+        self._executemany(
             """
             INSERT OR IGNORE INTO boards_provenance(
             ethernet_x, ethernet_y, ip_addres)

--- a/spinn_front_end_common/interface/provenance/provenance_writer.py
+++ b/spinn_front_end_common/interface/provenance/provenance_writer.py
@@ -56,7 +56,7 @@ class ProvenanceWriter(BaseDatabase):
         :param str description: Type of value
         :param float the_value: data
         """
-        self._execute(
+        self.execute(
             """
             INSERT INTO power_provenance(
                 description, the_value)
@@ -76,7 +76,7 @@ class ProvenanceWriter(BaseDatabase):
         :param str description: type of value
         :param float the_value: data
         """
-        self._execute(
+        self.execute(
             """
             INSERT INTO gatherer_provenance(
                 x, y, address, bytes, run, description, the_value)
@@ -92,7 +92,7 @@ class ProvenanceWriter(BaseDatabase):
         :param str description: type of value
         :param int the_value: data
         """
-        self._execute(
+        self.execute(
             """
             INSERT INTO monitor_provenance(
                 x, y, description, the_value)
@@ -110,7 +110,7 @@ class ProvenanceWriter(BaseDatabase):
         :param float the_value: data
         :param bool expected: Flag to say this data was expected
         """
-        self._execute(
+        self.execute(
             """
             INSERT INTO router_provenance(
                 x, y, description, the_value, expected)
@@ -128,7 +128,7 @@ class ProvenanceWriter(BaseDatabase):
         :param int the_value: data
         """
         core_id = self._get_core_id(x, y, p)
-        self._execute(
+        self.execute(
             """
             INSERT INTO core_provenance(
                 core_id, description, the_value)
@@ -144,12 +144,12 @@ class ProvenanceWriter(BaseDatabase):
 
         :param str message:
         """
-        self._execute(
+        self.execute(
             """
             INSERT INTO reports(message)
             VALUES(?)
             """, [message])
-        recorded = self._lastrowid
+        recorded = self.lastrowid
         cutoff = get_config_int_or_none("Reports", "provenance_report_cutoff")
         if cutoff is None or recorded < cutoff:
             logger.warning(message)
@@ -169,7 +169,7 @@ class ProvenanceWriter(BaseDatabase):
         :param str description: type of value
         :param int the_value: data
         """
-        self._execute(
+        self.execute(
             """
             INSERT OR IGNORE INTO connector_provenance(
                 pre_population, post_population, the_type, description,
@@ -189,7 +189,7 @@ class ProvenanceWriter(BaseDatabase):
         """
         if not connections:
             return
-        self._executemany(
+        self.executemany(
             """
             INSERT OR IGNORE INTO boards_provenance(
             ethernet_x, ethernet_y, ip_addres)

--- a/spinn_front_end_common/interface/provenance/router_prov_mapper.py
+++ b/spinn_front_end_common/interface/provenance/router_prov_mapper.py
@@ -68,7 +68,7 @@ class Plotter(object):
         # Does the query in one of two ways, depending on schema version
         if self.__have_insertion_order:
             try:
-                return self._db._execute("""
+                return self._db.execute("""
                     SELECT source_name AS "source", x, y,
                         description_name AS "description",
                         the_value AS "value"
@@ -81,7 +81,7 @@ class Plotter(object):
                 if "no such column: insertion_order" != str(e):
                     raise
                 self.__have_insertion_order = False
-        return self._db._execute("""
+        return self._db.execute("""
             SELECT source_name AS "source", x, y,
                 description_name AS "description",
                 MAX(the_value) AS "value"
@@ -96,7 +96,7 @@ class Plotter(object):
             FROM provenance_view
             WHERE x IS NOT NULL AND p IS NULL AND "description" IS NOT NULL
             """
-        return frozenset(row["description"] for row in self._db._execute(
+        return frozenset(row["description"] for row in self._db.execute(
             query))
 
     def get_per_chip_prov_details(self, info):
@@ -123,7 +123,7 @@ class Plotter(object):
         # Does the query in one of two ways, depending on schema version
         if self.__have_insertion_order:
             try:
-                return self._db._execute("""
+                return self._db.execute("""
                     SELECT "source", x, y, "description",
                         SUM("value") AS "value"
                     FROM (
@@ -140,7 +140,7 @@ class Plotter(object):
                 if "no such column: insertion_order" != str(e):
                     raise
                 self.__have_insertion_order = False
-        return self._db._execute("""
+        return self._db.execute("""
             SELECT "source", x, y, "description",
                 SUM("value") AS "value"
             FROM (
@@ -160,7 +160,7 @@ class Plotter(object):
             WHERE x IS NOT NULL AND p IS NOT NULL
                 AND "description" IS NOT NULL
             """
-        return frozenset(row["description"] for row in self._db._execute(
+        return frozenset(row["description"] for row in self._db.execute(
             query))
 
     def get_sum_chip_prov_details(self, info):

--- a/spinn_front_end_common/interface/provenance/router_prov_mapper.py
+++ b/spinn_front_end_common/interface/provenance/router_prov_mapper.py
@@ -66,30 +66,29 @@ class Plotter(object):
 
     def __do_chip_query(self, description):
         # Does the query in one of two ways, depending on schema version
-        with self._db.transaction() as cur:
-            if self.__have_insertion_order:
-                try:
-                    return cur.execute("""
-                        SELECT source_name AS "source", x, y,
-                            description_name AS "description",
-                            the_value AS "value"
-                        FROM provenance_view
-                        WHERE description LIKE ?
-                        GROUP BY x, y, p
-                        HAVING insertion_order = MAX(insertion_order)
-                        """, (description, ))
-                except sqlite3.OperationalError as e:
-                    if "no such column: insertion_order" != str(e):
-                        raise
-                    self.__have_insertion_order = False
-            return cur.execute("""
-                SELECT source_name AS "source", x, y,
-                    description_name AS "description",
-                    MAX(the_value) AS "value"
-                FROM provenance_view
-                WHERE description LIKE ?
-                GROUP BY x, y, p
-                """, (description, ))
+        if self.__have_insertion_order:
+            try:
+                return self._db._execute("""
+                    SELECT source_name AS "source", x, y,
+                        description_name AS "description",
+                        the_value AS "value"
+                    FROM provenance_view
+                    WHERE description LIKE ?
+                    GROUP BY x, y, p
+                    HAVING insertion_order = MAX(insertion_order)
+                    """, (description, ))
+            except sqlite3.OperationalError as e:
+                if "no such column: insertion_order" != str(e):
+                    raise
+                self.__have_insertion_order = False
+        return self._db._execute("""
+            SELECT source_name AS "source", x, y,
+                description_name AS "description",
+                MAX(the_value) AS "value"
+            FROM provenance_view
+            WHERE description LIKE ?
+            GROUP BY x, y, p
+            """, (description, ))
 
     def get_per_chip_prov_types(self):
         query = """
@@ -97,8 +96,8 @@ class Plotter(object):
             FROM provenance_view
             WHERE x IS NOT NULL AND p IS NULL AND "description" IS NOT NULL
             """
-        with self._db.transaction() as cur:
-            return frozenset(row["description"] for row in cur.execute(query))
+        return frozenset(row["description"] for row in self._db._execute(
+            query))
 
     def get_per_chip_prov_details(self, info):
         data = []
@@ -122,38 +121,37 @@ class Plotter(object):
 
     def __do_sum_query(self, description):
         # Does the query in one of two ways, depending on schema version
-        with self._db.transaction() as cur:
-            if self.__have_insertion_order:
-                try:
-                    return cur.execute("""
-                        SELECT "source", x, y, "description",
-                            SUM("value") AS "value"
-                        FROM (
-                            SELECT source_name AS "source", x, y, p,
-                                description_name AS "description",
-                                the_value AS "value"
-                            FROM provenance_view
-                            WHERE description LIKE ? AND p IS NOT NULL
-                            GROUP BY x, y, p
-                            HAVING insertion_order = MAX(insertion_order))
-                        GROUP BY x, y
-                        """, (description, ))
-                except sqlite3.OperationalError as e:
-                    if "no such column: insertion_order" != str(e):
-                        raise
-                    self.__have_insertion_order = False
-            return cur.execute("""
-                SELECT "source", x, y, "description",
-                    SUM("value") AS "value"
-                FROM (
-                    SELECT source_name AS "source", x, y,
-                        description_name AS "description",
-                        MAX(the_value) AS "value"
-                    FROM provenance_view
-                    WHERE description LIKE ? AND p IS NOT NULL
-                    GROUP BY x, y, p)
-                GROUP BY x, y
-                """, (description, ))
+        if self.__have_insertion_order:
+            try:
+                return self._db._execute("""
+                    SELECT "source", x, y, "description",
+                        SUM("value") AS "value"
+                    FROM (
+                        SELECT source_name AS "source", x, y, p,
+                            description_name AS "description",
+                            the_value AS "value"
+                        FROM provenance_view
+                        WHERE description LIKE ? AND p IS NOT NULL
+                        GROUP BY x, y, p
+                        HAVING insertion_order = MAX(insertion_order))
+                    GROUP BY x, y
+                    """, (description, ))
+            except sqlite3.OperationalError as e:
+                if "no such column: insertion_order" != str(e):
+                    raise
+                self.__have_insertion_order = False
+        return self._db._execute("""
+            SELECT "source", x, y, "description",
+                SUM("value") AS "value"
+            FROM (
+                SELECT source_name AS "source", x, y,
+                    description_name AS "description",
+                    MAX(the_value) AS "value"
+                FROM provenance_view
+                WHERE description LIKE ? AND p IS NOT NULL
+                GROUP BY x, y, p)
+            GROUP BY x, y
+            """, (description, ))
 
     def get_per_core_prov_types(self):
         query = """
@@ -162,8 +160,8 @@ class Plotter(object):
             WHERE x IS NOT NULL AND p IS NOT NULL
                 AND "description" IS NOT NULL
             """
-        with self._db.transaction() as cur:
-            return frozenset(row["description"] for row in cur.execute(query))
+        return frozenset(row["description"] for row in self._db._execute(
+            query))
 
     def get_sum_chip_prov_details(self, info):
         data = []

--- a/spinn_front_end_common/utilities/base_database.py
+++ b/spinn_front_end_common/utilities/base_database.py
@@ -75,15 +75,15 @@ class BaseDatabase(SQLiteDB, AbstractContextManager):
         :param int p:
         :rtype: int
         """
-        for row in self._execute(
+        for row in self.execute(
                 """
                 SELECT core_id FROM core
                 WHERE x = ? AND y = ? AND processor = ?
                 LIMIT 1
                 """, (x, y, p)):
             return row["core_id"]
-        self._execute(
+        self.execute(
             """
             INSERT INTO core(x, y, processor) VALUES(?, ?, ?)
             """, (x, y, p))
-        return self._lastrowid
+        return self.lastrowid

--- a/spinn_front_end_common/utilities/base_database.py
+++ b/spinn_front_end_common/utilities/base_database.py
@@ -68,23 +68,22 @@ class BaseDatabase(SQLiteDB, AbstractContextManager):
         return os.path.join(FecDataView.get_run_dir_path(),
                             f"data{FecDataView.get_reset_str()}.sqlite3")
 
-    def _get_core_id(self, cursor, x, y, p):
+    def _get_core_id(self, x, y, p):
         """
-        :param ~sqlite3.Cursor cursor:
         :param int x:
         :param int y:
         :param int p:
         :rtype: int
         """
-        for row in cursor.execute(
+        for row in self.execute(
                 """
                 SELECT core_id FROM core
                 WHERE x = ? AND y = ? AND processor = ?
                 LIMIT 1
                 """, (x, y, p)):
             return row["core_id"]
-        cursor.execute(
+        self.execute(
             """
             INSERT INTO core(x, y, processor) VALUES(?, ?, ?)
             """, (x, y, p))
-        return cursor.lastrowid
+        return self.lastrowid

--- a/spinn_front_end_common/utilities/base_database.py
+++ b/spinn_front_end_common/utilities/base_database.py
@@ -75,15 +75,15 @@ class BaseDatabase(SQLiteDB, AbstractContextManager):
         :param int p:
         :rtype: int
         """
-        for row in self.execute(
+        for row in self._execute(
                 """
                 SELECT core_id FROM core
                 WHERE x = ? AND y = ? AND processor = ?
                 LIMIT 1
                 """, (x, y, p)):
             return row["core_id"]
-        self.execute(
+        self._execute(
             """
             INSERT INTO core(x, y, processor) VALUES(?, ?, ?)
             """, (x, y, p))
-        return self.lastrowid
+        return self._lastrowid

--- a/spinn_front_end_common/utilities/database/database_reader.py
+++ b/spinn_front_end_common/utilities/database/database_reader.py
@@ -30,9 +30,8 @@ class DatabaseReader(SQLiteDB):
         self.__looked_for_job = False
 
     def __exec_one(self, query, *args):
-        with self.transaction() as cur:
-            cur._execute(query + " LIMIT 1", args)
-            return cur.fetchone()
+        self._execute(query + " LIMIT 1", args)
+        return self._fetchone()
 
     @staticmethod
     def __r2t(row, *args):
@@ -48,9 +47,29 @@ class DatabaseReader(SQLiteDB):
         """
         # This is maintaining an object we only make once
         if not self.__looked_for_job:
-            with self.transaction() as cur:
-                self.__job = SpallocClient.open_job_from_database(cur)
+            service_url = None
+            job_url = None
+            cookies = {}
+            headers = {}
+            for row in self._execute("""
+                    SELECT kind, name, value FROM proxy_configuration
+                    """):
+                kind, name, value = row
+                if kind == "SPALLOC":
+                    if name == "service uri":
+                        service_url = value
+                    elif name == "job uri":
+                        job_url = value
+                elif kind == "COOKIE":
+                    cookies[name] = value
+                elif kind == "HEADER":
+                    headers[name] = value
             self.__looked_for_job = True
+            if not service_url or not job_url or not cookies or not headers:
+                # Cannot possibly work without a session or job
+                return None
+            self.__job = SpallocClient.open_job_from_database(
+                service_url, job_url, cookies, headers)
         return self.__job
 
     def get_key_to_atom_id_mapping(self, label):
@@ -61,14 +80,13 @@ class DatabaseReader(SQLiteDB):
         :return: dictionary of atom IDs indexed by event key
         :rtype: dict(int, int)
         """
-        with self.transaction() as cur:
-            return {
-                row["event"]: row["atom"]
-                for row in cur._execute(
-                    """
-                    SELECT * FROM label_event_atom_view
-                    WHERE label = ?
-                    """, (label, ))}
+        return {
+            row["event"]: row["atom"]
+            for row in self._execute(
+                """
+                SELECT * FROM label_event_atom_view
+                WHERE label = ?
+                """, (label, ))}
 
     def get_atom_id_to_key_mapping(self, label):
         """
@@ -78,14 +96,13 @@ class DatabaseReader(SQLiteDB):
         :return: dictionary of event keys indexed by atom ID
         :rtype: dict(int, int)
         """
-        with self.transaction() as cur:
-            return {
-                row["atom"]: row["event"]
-                for row in cur._execute(
-                    """
-                    SELECT * FROM label_event_atom_view
-                    WHERE label = ?
-                    """, (label, ))}
+        return {
+            row["atom"]: row["event"]
+            for row in self._execute(
+                """
+                SELECT * FROM label_event_atom_view
+                WHERE label = ?
+                """, (label, ))}
 
     def get_live_output_details(self, label, receiver_label):
         """
@@ -134,13 +151,12 @@ class DatabaseReader(SQLiteDB):
         :return: A list of x, y, p coordinates of the vertices
         :rtype: list(tuple(int, int, int))
         """
-        with self.transaction() as cur:
-            return [
-                self.__xyp(row) for row in cur._execute(
-                    """
-                    SELECT x, y, p FROM application_vertex_placements
-                    WHERE vertex_label = ?
-                    """, (label, ))]
+        return [
+            self.__xyp(row) for row in self._execute(
+                """
+                SELECT x, y, p FROM application_vertex_placements
+                WHERE vertex_label = ?
+                """, (label, ))]
 
     def get_ip_address(self, x, y):
         """

--- a/spinn_front_end_common/utilities/database/database_reader.py
+++ b/spinn_front_end_common/utilities/database/database_reader.py
@@ -30,8 +30,8 @@ class DatabaseReader(SQLiteDB):
         self.__looked_for_job = False
 
     def __exec_one(self, query, *args):
-        self._execute(query + " LIMIT 1", args)
-        return self._fetchone()
+        self.execute(query + " LIMIT 1", args)
+        return self.fetchone()
 
     @staticmethod
     def __r2t(row, *args):
@@ -51,7 +51,7 @@ class DatabaseReader(SQLiteDB):
             job_url = None
             cookies = {}
             headers = {}
-            for row in self._execute("""
+            for row in self.execute("""
                     SELECT kind, name, value FROM proxy_configuration
                     """):
                 kind, name, value = row
@@ -82,7 +82,7 @@ class DatabaseReader(SQLiteDB):
         """
         return {
             row["event"]: row["atom"]
-            for row in self._execute(
+            for row in self.execute(
                 """
                 SELECT * FROM label_event_atom_view
                 WHERE label = ?
@@ -98,7 +98,7 @@ class DatabaseReader(SQLiteDB):
         """
         return {
             row["atom"]: row["event"]
-            for row in self._execute(
+            for row in self.execute(
                 """
                 SELECT * FROM label_event_atom_view
                 WHERE label = ?
@@ -152,7 +152,7 @@ class DatabaseReader(SQLiteDB):
         :rtype: list(tuple(int, int, int))
         """
         return [
-            self.__xyp(row) for row in self._execute(
+            self.__xyp(row) for row in self.execute(
                 """
                 SELECT x, y, p FROM application_vertex_placements
                 WHERE vertex_label = ?

--- a/spinn_front_end_common/utilities/database/database_reader.py
+++ b/spinn_front_end_common/utilities/database/database_reader.py
@@ -31,7 +31,7 @@ class DatabaseReader(SQLiteDB):
 
     def __exec_one(self, query, *args):
         with self.transaction() as cur:
-            cur.execute(query + " LIMIT 1", args)
+            cur._execute(query + " LIMIT 1", args)
             return cur.fetchone()
 
     @staticmethod
@@ -64,7 +64,7 @@ class DatabaseReader(SQLiteDB):
         with self.transaction() as cur:
             return {
                 row["event"]: row["atom"]
-                for row in cur.execute(
+                for row in cur._execute(
                     """
                     SELECT * FROM label_event_atom_view
                     WHERE label = ?
@@ -81,7 +81,7 @@ class DatabaseReader(SQLiteDB):
         with self.transaction() as cur:
             return {
                 row["atom"]: row["event"]
-                for row in cur.execute(
+                for row in cur._execute(
                     """
                     SELECT * FROM label_event_atom_view
                     WHERE label = ?
@@ -136,7 +136,7 @@ class DatabaseReader(SQLiteDB):
         """
         with self.transaction() as cur:
             return [
-                self.__xyp(row) for row in cur.execute(
+                self.__xyp(row) for row in cur._execute(
                     """
                     SELECT x, y, p FROM application_vertex_placements
                     WHERE vertex_label = ?

--- a/spinn_front_end_common/utilities/database/database_writer.py
+++ b/spinn_front_end_common/utilities/database/database_writer.py
@@ -99,8 +99,8 @@ class DatabaseWriter(SQLiteDB):
         :rtype: int
         """
         try:
-            cur.execute(sql, args)
-            return cur.lastrowid
+            cur._execute(sql, args)
+            return cur._lastrowid
         except Exception:
             logger.exception("problem with insertion; argument types are {}",
                              str(map(type, args)))
@@ -119,7 +119,7 @@ class DatabaseWriter(SQLiteDB):
                     x_dimension, y_dimension)
                 VALUES(?, ?)
                 """, machine.width, machine.height)
-            cur.executemany(
+            cur._executemany(
                 """
                 INSERT INTO Machine_chip(
                     no_processors, chip_x, chip_y, machine_id,
@@ -168,7 +168,7 @@ class DatabaseWriter(SQLiteDB):
         :param int runtime: the amount of time the application is to run for
         """
         with self.transaction() as cur:
-            cur.executemany(
+            cur._executemany(
                 """
                 INSERT INTO configuration_parameters (
                     parameter_id, value)
@@ -197,7 +197,7 @@ class DatabaseWriter(SQLiteDB):
             if isinstance(job, SpallocJob):
                 with self.transaction() as cur:
                     config = job.get_session_credentials_for_db()
-                    cur.executemany("""
+                    cur._executemany("""
                         INSERT INTO proxy_configuration(kind, name, value)
                         VALUES(?, ?, ?)
                         """, [(k1, k2, v) for (k1, k2), v in config.items()])
@@ -212,7 +212,7 @@ class DatabaseWriter(SQLiteDB):
                 if placement.vertex not in self.__vertex_to_id:
                     self.__add_machine_vertex(cur, placement.vertex)
             # add records
-            cur.executemany(
+            cur._executemany(
                 """
                 INSERT INTO Placements(
                     vertex_id, chip_x, chip_y, chip_p, machine_id)
@@ -228,7 +228,7 @@ class DatabaseWriter(SQLiteDB):
         """
         tags = FecDataView.get_tags()
         with self.transaction() as cur:
-            cur.executemany(
+            cur._executemany(
                 """
                 INSERT INTO IP_tags(
                     vertex_id, tag, board_address, ip_address, port,
@@ -266,7 +266,7 @@ class DatabaseWriter(SQLiteDB):
                         start = vertex_slice.lo_atom
                         atom_keys = [(i, k) for i, k in enumerate(keys, start)]
                 m_vertex_id = self.__vertex_to_id[m_vertex]
-                cur.executemany(
+                cur._executemany(
                     """
                     INSERT INTO event_to_atom_mapping(
                         vertex_id, event_id, atom_id)
@@ -308,7 +308,7 @@ class DatabaseWriter(SQLiteDB):
                        self._get_machine_lpg_mappings(part))
 
         with self.transaction() as cur:
-            cur.executemany(
+            cur._executemany(
                 """
                 INSERT INTO m_vertex_to_lpg_vertex(
                     pre_vertex_id, partition_id, post_vertex_id)

--- a/spinn_front_end_common/utilities/database/database_writer.py
+++ b/spinn_front_end_common/utilities/database/database_writer.py
@@ -196,7 +196,11 @@ class DatabaseWriter(SQLiteDB):
             job = mac._job
             if isinstance(job, SpallocJob):
                 with self.transaction() as cur:
-                    job._write_session_credentials_to_db(cur)
+                    config = job.get_session_credentials_for_db()
+                    cur.executemany("""
+                        INSERT INTO proxy_configuration(kind, name, value)
+                        VALUES(?, ?, ?)
+                        """, [(k1, k2, v) for (k1, k2), v in config.items()])
 
     def add_placements(self):
         """

--- a/spinn_front_end_common/utilities/database/database_writer.py
+++ b/spinn_front_end_common/utilities/database/database_writer.py
@@ -99,8 +99,8 @@ class DatabaseWriter(SQLiteDB):
         :rtype: int
         """
         try:
-            self._execute(sql, args)
-            return self._lastrowid
+            self.execute(sql, args)
+            return self.lastrowid
         except Exception:
             logger.exception("problem with insertion; argument types are {}",
                              str(map(type, args)))
@@ -117,7 +117,7 @@ class DatabaseWriter(SQLiteDB):
                 x_dimension, y_dimension)
             VALUES(?, ?)
             """, machine.width, machine.height)
-        self._executemany(
+        self.executemany(
             """
             INSERT INTO Machine_chip(
                 no_processors, chip_x, chip_y, machine_id,
@@ -162,7 +162,7 @@ class DatabaseWriter(SQLiteDB):
 
         :param int runtime: the amount of time the application is to run for
         """
-        self._executemany(
+        self.executemany(
             """
             INSERT INTO configuration_parameters (
                 parameter_id, value)
@@ -190,7 +190,7 @@ class DatabaseWriter(SQLiteDB):
             job = mac._job
             if isinstance(job, SpallocJob):
                 config = job.get_session_credentials_for_db()
-                self._executemany("""
+                self.executemany("""
                     INSERT INTO proxy_configuration(kind, name, value)
                     VALUES(?, ?, ?)
                     """, [(k1, k2, v) for (k1, k2), v in config.items()])
@@ -204,7 +204,7 @@ class DatabaseWriter(SQLiteDB):
             if placement.vertex not in self.__vertex_to_id:
                 self.__add_machine_vertex(placement.vertex)
         # add records
-        self._executemany(
+        self.executemany(
             """
             INSERT INTO Placements(
                 vertex_id, chip_x, chip_y, chip_p, machine_id)
@@ -219,7 +219,7 @@ class DatabaseWriter(SQLiteDB):
         Adds the tags into the database.
         """
         tags = FecDataView.get_tags()
-        self._executemany(
+        self.executemany(
             """
             INSERT INTO IP_tags(
                 vertex_id, tag, board_address, ip_address, port,
@@ -256,7 +256,7 @@ class DatabaseWriter(SQLiteDB):
                     start = vertex_slice.lo_atom
                     atom_keys = [(i, k) for i, k in enumerate(keys, start)]
             m_vertex_id = self.__vertex_to_id[m_vertex]
-            self._executemany(
+            self.executemany(
                 """
                 INSERT INTO event_to_atom_mapping(
                     vertex_id, event_id, atom_id)
@@ -297,7 +297,7 @@ class DatabaseWriter(SQLiteDB):
                        for (m_vertex, part_id, lpg_m_vertex) in
                        self._get_machine_lpg_mappings(part))
 
-        self._executemany(
+        self.executemany(
             """
             INSERT INTO m_vertex_to_lpg_vertex(
                 pre_vertex_id, partition_id, post_vertex_id)

--- a/spinn_front_end_common/utilities/database/database_writer.py
+++ b/spinn_front_end_common/utilities/database/database_writer.py
@@ -92,15 +92,15 @@ class DatabaseWriter(SQLiteDB):
         """
         return self._database_path
 
-    def __insert(self, cur, sql, *args):
+    def __insert(self, sql, *args):
         """
         :param ~sqlite3.Cursor cur:
         :param str sql:
         :rtype: int
         """
         try:
-            cur._execute(sql, args)
-            return cur._lastrowid
+            self._execute(sql, args)
+            return self._lastrowid
         except Exception:
             logger.exception("problem with insertion; argument types are {}",
                              str(map(type, args)))
@@ -111,52 +111,47 @@ class DatabaseWriter(SQLiteDB):
         Store the machine object into the database.
         """
         machine = FecDataView.get_machine()
-        with self.transaction() as cur:
-            self.__machine_to_id[machine] = self._machine_id = self.__insert(
-                cur,
-                """
-                INSERT INTO Machine_layout(
-                    x_dimension, y_dimension)
-                VALUES(?, ?)
-                """, machine.width, machine.height)
-            cur._executemany(
-                """
-                INSERT INTO Machine_chip(
-                    no_processors, chip_x, chip_y, machine_id,
-                    ip_address, nearest_ethernet_x, nearest_ethernet_y)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
-                """, (
-                    (chip.n_processors, chip.x, chip.y, self._machine_id,
-                     chip.ip_address,
-                     chip.nearest_ethernet_x, chip.nearest_ethernet_y)
-                    for chip in machine.chips))
+        self.__machine_to_id[machine] = self._machine_id = self.__insert(
+            """
+            INSERT INTO Machine_layout(
+                x_dimension, y_dimension)
+            VALUES(?, ?)
+            """, machine.width, machine.height)
+        self._executemany(
+            """
+            INSERT INTO Machine_chip(
+                no_processors, chip_x, chip_y, machine_id,
+                ip_address, nearest_ethernet_x, nearest_ethernet_y)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """, (
+                (chip.n_processors, chip.x, chip.y, self._machine_id,
+                 chip.ip_address,
+                 chip.nearest_ethernet_x, chip.nearest_ethernet_y)
+                for chip in machine.chips))
 
     def add_application_vertices(self):
         """
         Stores the main application graph description (vertices, edges).
         """
-        with self.transaction() as cur:
-            # add vertices
-            for vertex in FecDataView.iterate_vertices():
-                vertex_id = self.__insert(
-                    cur,
-                    "INSERT INTO Application_vertices(vertex_label) VALUES(?)",
-                    vertex.label)
-                self.__vertex_to_id[vertex] = vertex_id
-                for m_vertex in vertex.machine_vertices:
-                    m_vertex_id = self.__add_machine_vertex(cur, m_vertex)
-                    self.__insert(
-                        cur,
-                        """
-                        INSERT INTO graph_mapper_vertex (
-                            application_vertex_id, machine_vertex_id)
-                        VALUES(?, ?)
-                        """,
-                        vertex_id, m_vertex_id)
+        # add vertices
+        for vertex in FecDataView.iterate_vertices():
+            vertex_id = self.__insert(
+                "INSERT INTO Application_vertices(vertex_label) VALUES(?)",
+                vertex.label)
+            self.__vertex_to_id[vertex] = vertex_id
+            for m_vertex in vertex.machine_vertices:
+                m_vertex_id = self.__add_machine_vertex(m_vertex)
+                self.__insert(
+                    """
+                    INSERT INTO graph_mapper_vertex (
+                        application_vertex_id, machine_vertex_id)
+                    VALUES(?, ?)
+                    """,
+                    vertex_id, m_vertex_id)
 
-    def __add_machine_vertex(self, cur, m_vertex):
+    def __add_machine_vertex(self, m_vertex):
         m_vertex_id = self.__insert(
-            cur, "INSERT INTO Machine_vertices (label)  VALUES(?)",
+            "INSERT INTO Machine_vertices (label)  VALUES(?)",
             str(m_vertex.label))
         self.__vertex_to_id[m_vertex] = m_vertex_id
         return m_vertex_id
@@ -167,20 +162,19 @@ class DatabaseWriter(SQLiteDB):
 
         :param int runtime: the amount of time the application is to run for
         """
-        with self.transaction() as cur:
-            cur._executemany(
-                """
-                INSERT INTO configuration_parameters (
-                    parameter_id, value)
-                VALUES (?, ?)
-                """, [
-                    ("machine_time_step",
-                     FecDataView.get_simulation_time_step_us()),
-                    ("time_scale_factor",
-                     FecDataView.get_time_scale_factor()),
-                    ("infinite_run", str(runtime is None)),
-                    ("runtime", -1 if runtime is None else runtime),
-                    ("app_id", FecDataView.get_app_id())])
+        self._executemany(
+            """
+            INSERT INTO configuration_parameters (
+                parameter_id, value)
+            VALUES (?, ?)
+            """, [
+                ("machine_time_step",
+                 FecDataView.get_simulation_time_step_us()),
+                ("time_scale_factor",
+                 FecDataView.get_time_scale_factor()),
+                ("infinite_run", str(runtime is None)),
+                ("runtime", -1 if runtime is None else runtime),
+                ("app_id", FecDataView.get_app_id())])
 
     def add_proxy_configuration(self):
         """
@@ -195,49 +189,46 @@ class DatabaseWriter(SQLiteDB):
             # can't check that because of import circularity.
             job = mac._job
             if isinstance(job, SpallocJob):
-                with self.transaction() as cur:
-                    config = job.get_session_credentials_for_db()
-                    cur._executemany("""
-                        INSERT INTO proxy_configuration(kind, name, value)
-                        VALUES(?, ?, ?)
-                        """, [(k1, k2, v) for (k1, k2), v in config.items()])
+                config = job.get_session_credentials_for_db()
+                self._executemany("""
+                    INSERT INTO proxy_configuration(kind, name, value)
+                    VALUES(?, ?, ?)
+                    """, [(k1, k2, v) for (k1, k2), v in config.items()])
 
     def add_placements(self):
         """
         Adds the placements objects into the database.
         """
-        with self.transaction() as cur:
-            # Make sure machine vertices are represented
-            for placement in FecDataView.iterate_placemements():
-                if placement.vertex not in self.__vertex_to_id:
-                    self.__add_machine_vertex(cur, placement.vertex)
-            # add records
-            cur._executemany(
-                """
-                INSERT INTO Placements(
-                    vertex_id, chip_x, chip_y, chip_p, machine_id)
-                VALUES(?, ?, ?, ?, ?)
-                """, (
-                    (self.__vertex_to_id[placement.vertex],
-                     placement.x, placement.y, placement.p, self._machine_id)
-                    for placement in FecDataView.iterate_placemements()))
+        # Make sure machine vertices are represented
+        for placement in FecDataView.iterate_placemements():
+            if placement.vertex not in self.__vertex_to_id:
+                self.__add_machine_vertex(placement.vertex)
+        # add records
+        self._executemany(
+            """
+            INSERT INTO Placements(
+                vertex_id, chip_x, chip_y, chip_p, machine_id)
+            VALUES(?, ?, ?, ?, ?)
+            """, (
+                (self.__vertex_to_id[placement.vertex],
+                 placement.x, placement.y, placement.p, self._machine_id)
+                for placement in FecDataView.iterate_placemements()))
 
     def add_tags(self):
         """
         Adds the tags into the database.
         """
         tags = FecDataView.get_tags()
-        with self.transaction() as cur:
-            cur._executemany(
-                """
-                INSERT INTO IP_tags(
-                    vertex_id, tag, board_address, ip_address, port,
-                    strip_sdp)
-                VALUES (?, ?, ?, ?, ?, ?)
-                """, (
-                    (self.__vertex_to_id[vert], ipt.tag, ipt.board_address,
-                     ipt.ip_address, ipt.port or 0, 1 if ipt.strip_sdp else 0)
-                    for ipt, vert in tags.ip_tags_vertices))
+        self._executemany(
+            """
+            INSERT INTO IP_tags(
+                vertex_id, tag, board_address, ip_address, port,
+                strip_sdp)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """, (
+                (self.__vertex_to_id[vert], ipt.tag, ipt.board_address,
+                 ipt.ip_address, ipt.port or 0, 1 if ipt.strip_sdp else 0)
+                for ipt, vert in tags.ip_tags_vertices))
 
     def create_atom_to_event_id_mapping(self, machine_vertices):
         """
@@ -249,30 +240,29 @@ class DatabaseWriter(SQLiteDB):
         # This could happen if there are no LPGs
         if machine_vertices is None:
             return
-        with self.transaction() as cur:
-            for (m_vertex, partition_id) in machine_vertices:
-                atom_keys = list()
-                if isinstance(m_vertex.app_vertex, HasCustomAtomKeyMap):
-                    atom_keys = m_vertex.app_vertex.get_atom_key_map(
-                        m_vertex, partition_id, routing_infos)
-                else:
-                    r_info = routing_infos.get_routing_info_from_pre_vertex(
-                        m_vertex, partition_id)
-                    # r_info could be None if there are no outgoing edges,
-                    # at which point there is nothing to do here anyway
-                    if r_info is not None:
-                        vertex_slice = m_vertex.vertex_slice
-                        keys = get_field_based_keys(r_info.key, vertex_slice)
-                        start = vertex_slice.lo_atom
-                        atom_keys = [(i, k) for i, k in enumerate(keys, start)]
-                m_vertex_id = self.__vertex_to_id[m_vertex]
-                cur._executemany(
-                    """
-                    INSERT INTO event_to_atom_mapping(
-                        vertex_id, event_id, atom_id)
-                    VALUES (?, ?, ?)
-                    """, ((m_vertex_id, int(key), i) for i, key in atom_keys)
-                )
+        for (m_vertex, partition_id) in machine_vertices:
+            atom_keys = list()
+            if isinstance(m_vertex.app_vertex, HasCustomAtomKeyMap):
+                atom_keys = m_vertex.app_vertex.get_atom_key_map(
+                    m_vertex, partition_id, routing_infos)
+            else:
+                r_info = routing_infos.get_routing_info_from_pre_vertex(
+                    m_vertex, partition_id)
+                # r_info could be None if there are no outgoing edges,
+                # at which point there is nothing to do here anyway
+                if r_info is not None:
+                    vertex_slice = m_vertex.vertex_slice
+                    keys = get_field_based_keys(r_info.key, vertex_slice)
+                    start = vertex_slice.lo_atom
+                    atom_keys = [(i, k) for i, k in enumerate(keys, start)]
+            m_vertex_id = self.__vertex_to_id[m_vertex]
+            self._executemany(
+                """
+                INSERT INTO event_to_atom_mapping(
+                    vertex_id, event_id, atom_id)
+                VALUES (?, ?, ?)
+                """, ((m_vertex_id, int(key), i) for i, key in atom_keys)
+            )
 
     def _get_machine_lpg_mappings(self, part):
         """ Get places where an LPG Machine vertex has been added to a graph
@@ -307,14 +297,13 @@ class DatabaseWriter(SQLiteDB):
                        for (m_vertex, part_id, lpg_m_vertex) in
                        self._get_machine_lpg_mappings(part))
 
-        with self.transaction() as cur:
-            cur._executemany(
-                """
-                INSERT INTO m_vertex_to_lpg_vertex(
-                    pre_vertex_id, partition_id, post_vertex_id)
-                VALUES(?, ?, ?)
-                """, ((self.__vertex_to_id[m_vertex], part_id,
-                       self.__vertex_to_id[lpg_m_vertex])
-                      for m_vertex, part_id, lpg_m_vertex in targets))
+        self._executemany(
+            """
+            INSERT INTO m_vertex_to_lpg_vertex(
+                pre_vertex_id, partition_id, post_vertex_id)
+            VALUES(?, ?, ?)
+            """, ((self.__vertex_to_id[m_vertex], part_id,
+                   self.__vertex_to_id[lpg_m_vertex])
+                  for m_vertex, part_id, lpg_m_vertex in targets))
 
         return [(source, part_id) for source, part_id, _target in targets]

--- a/spinn_front_end_common/utilities/exceptions.py
+++ b/spinn_front_end_common/utilities/exceptions.py
@@ -76,6 +76,12 @@ class DsDatabaseException(SpinnFrontEndException):
     """
 
 
+class DatabaseException(SpinnFrontEndException):
+    """
+    Raise when something in a database failed.
+    """
+
+
 class DataSpecException(SpinnFrontEndException):
     """
     Raise when Data Specification did something wrong

--- a/spinn_front_end_common/utilities/report_functions/memory_map_on_host_chip_report.py
+++ b/spinn_front_end_common/utilities/report_functions/memory_map_on_host_chip_report.py
@@ -49,7 +49,8 @@ def memory_map_on_host_chip_report():
                     _describe_mem_map(f, transceiver, x, y, p)
             except IOError:
                 logger.exception(
-                    "Generate_placement_reports: Can't open file {} for writing.",
+                    "Generate_placement_reports: "
+                    "Can't open file {} for writing.",
                     file_name)
 
 

--- a/spinn_front_end_common/utilities/report_functions/memory_map_on_host_chip_report.py
+++ b/spinn_front_end_common/utilities/report_functions/memory_map_on_host_chip_report.py
@@ -18,6 +18,7 @@ import struct
 from spinn_utilities.log import FormatAdapter
 from spinn_utilities.progress_bar import ProgressBar
 from spinn_front_end_common.data import FecDataView
+from spinn_front_end_common.interface.ds import DsSqlliteDatabase
 from spinn_front_end_common.utilities.constants import (
     BYTES_PER_WORD, MAX_MEM_REGIONS)
 
@@ -37,19 +38,19 @@ def memory_map_on_host_chip_report():
         os.makedirs(directory_name)
 
     transceiver = FecDataView.get_transceiver()
-    ds_database = FecDataView.get_ds_database()
-    progress = ProgressBar(
-        ds_database.get_n_ds_cores(), "Writing memory map reports")
-    for (x, y, p) in progress.over(ds_database.get_ds_cores()):
-        file_name = os.path.join(
-            directory_name, f"memory_map_from_processor_{x}_{y}_{p}.txt")
-        try:
-            with open(file_name, "w", encoding="utf-8") as f:
-                _describe_mem_map(f, transceiver, x, y, p)
-        except IOError:
-            logger.exception(
-                "Generate_placement_reports: Can't open file {} for writing.",
-                file_name)
+    with DsSqlliteDatabase() as ds_database:
+        progress = ProgressBar(
+            ds_database.get_n_ds_cores(), "Writing memory map reports")
+        for (x, y, p) in progress.over(ds_database.get_ds_cores()):
+            file_name = os.path.join(
+                directory_name, f"memory_map_from_processor_{x}_{y}_{p}.txt")
+            try:
+                with open(file_name, "w", encoding="utf-8") as f:
+                    _describe_mem_map(f, transceiver, x, y, p)
+            except IOError:
+                logger.exception(
+                    "Generate_placement_reports: Can't open file {} for writing.",
+                    file_name)
 
 
 def _describe_mem_map(f, txrx, x, y, p):

--- a/spinn_front_end_common/utilities/report_functions/memory_map_on_host_report.py
+++ b/spinn_front_end_common/utilities/report_functions/memory_map_on_host_report.py
@@ -16,6 +16,7 @@ import logging
 import os
 from spinn_utilities.log import FormatAdapter
 from spinn_front_end_common.data import FecDataView
+from spinn_front_end_common.interface.ds import DsSqlliteDatabase
 logger = FormatAdapter(logging.getLogger(__name__))
 
 _FOLDER_NAME = "memory_map_from_processor_to_address_space"
@@ -29,13 +30,14 @@ def memory_map_on_host_report():
     try:
         with open(file_name, "w", encoding="utf-8") as f:
             f.write("On host data specification executor\n")
-            for xyp, start_address, memory_used, memory_written in \
-                    FecDataView.get_ds_database().get_info_for_cores():
-                f.write(
-                    f"{xyp}: ('start_address': {start_address}, "
-                    f"hex:{hex(start_address)}), "
-                    f"'memory_used': {memory_used}, "
-                    f"'memory_written': {memory_written} \n")
+            with DsSqlliteDatabase() as ds_database:
+                for xyp, start_address, memory_used, memory_written in \
+                        ds_database.get_info_for_cores():
+                    f.write(
+                        f"{xyp}: ('start_address': {start_address}, "
+                        f"hex:{hex(start_address)}), "
+                        f"'memory_used': {memory_used}, "
+                        f"'memory_written': {memory_written} \n")
     except IOError:
         logger.exception("Generate_placement_reports: Can't open file"
                          " {} for writing.", file_name)

--- a/spinn_front_end_common/utilities/sqlite_db.py
+++ b/spinn_front_end_common/utilities/sqlite_db.py
@@ -122,13 +122,13 @@ class SQLiteDB(AbstractContextManager):
             # The application_id pragma would be used within the DDL schema.
             ddl_hash, = struct.unpack_from(
                 ">I", hashlib.md5(sql.encode()).digest())
-            self.pragma("user_version", ddl_hash)
+            self.__pragma("user_version", ddl_hash)
         if case_insensitive_like:
-            self.pragma("case_sensitive_like", False)
+            self.__pragma("case_sensitive_like", False)
         # Official recommendations!
-        self.pragma("foreign_keys", True)
-        self.pragma("recursive_triggers", True)
-        self.pragma("trusted_schema", False)
+        self.__pragma("foreign_keys", True)
+        self.__pragma("recursive_triggers", True)
+        self.__pragma("trusted_schema", False)
 
     def __del__(self):
         self.close()
@@ -144,7 +144,7 @@ class SQLiteDB(AbstractContextManager):
         except AttributeError:
             self.__db = None
 
-    def pragma(self, pragma_name, value):
+    def __pragma(self, pragma_name, value):
         """
         Set a database ``PRAGMA``. See the `SQLite PRAGMA documentation
         <https://www.sqlite.org/pragma.html>`_ for details.

--- a/spinn_front_end_common/utilities/sqlite_db.py
+++ b/spinn_front_end_common/utilities/sqlite_db.py
@@ -192,31 +192,31 @@ class SQLiteDB(AbstractContextManager):
         else:
             raise TypeError("can only set pragmas to bool, int or str")
 
-    def execute(self, sql, paramters=()):
+    def _execute(self, sql, paramters=()):
         if self.__cursor is None:
             raise DatabaseException(
                 "This method should only be used inside a with")
-        return self.__cursor.execute(sql, paramters)
+        return self.__cursor._execute(sql, paramters)
 
-    def executemany(self, sql, paramters=()):
+    def _executemany(self, sql, paramters=()):
         if self.__cursor is None:
             raise DatabaseException(
                 "This method should only be used inside a with")
-        return self.__cursor.executemany(sql, paramters)
-
-    @property
-    def lastrowid(self):
-        if self.__cursor is None:
-            raise DatabaseException(
-                "This method should only be used inside a with")
-        return self.__cursor.lastrowid
+        return self.__cursor._executemany(sql, paramters)
 
     @property
-    def rowcount(self):
+    def _lastrowid(self):
         if self.__cursor is None:
             raise DatabaseException(
                 "This method should only be used inside a with")
-        return self.__cursor.rowcount
+        return self.__cursor._lastrowid
+
+    @property
+    def _rowcount(self):
+        if self.__cursor is None:
+            raise DatabaseException(
+                "This method should only be used inside a with")
+        return self.__cursor._rowcount
 
     def transaction(self, isolation_level=None):
         """

--- a/spinn_front_end_common/utilities/sqlite_db.py
+++ b/spinn_front_end_common/utilities/sqlite_db.py
@@ -218,12 +218,6 @@ class SQLiteDB(AbstractContextManager):
                 "This method should only be used inside a with")
         return self.__cursor.rowcount
 
-    def get_cursor(self):
-        if self.__cursor is None:
-            raise DatabaseException(
-                "This method should only be used inside a with")
-        return self.__cursor
-
     def transaction(self, isolation_level=None):
         """
         Get a context manager that manages a transaction on the database.

--- a/spinn_front_end_common/utilities/sqlite_db.py
+++ b/spinn_front_end_common/utilities/sqlite_db.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from contextlib import AbstractContextManager as ACMBase
 import enum
 import hashlib
 import logging
@@ -21,7 +20,6 @@ import pathlib
 import sqlite3
 import struct
 from spinn_utilities.abstract_context_manager import AbstractContextManager
-from spinn_utilities.logger_utils import warn_once
 from spinn_front_end_common.utilities.exceptions import DatabaseException
 
 logger = logging.getLogger(__name__)

--- a/spinn_front_end_common/utilities/sqlite_db.py
+++ b/spinn_front_end_common/utilities/sqlite_db.py
@@ -196,27 +196,27 @@ class SQLiteDB(AbstractContextManager):
         if self.__cursor is None:
             raise DatabaseException(
                 "This method should only be used inside a with")
-        return self.__cursor._execute(sql, paramters)
+        return self.__cursor.execute(sql, paramters)
 
     def _executemany(self, sql, paramters=()):
         if self.__cursor is None:
             raise DatabaseException(
                 "This method should only be used inside a with")
-        return self.__cursor._executemany(sql, paramters)
+        return self.__cursor.executemany(sql, paramters)
 
     @property
     def _lastrowid(self):
         if self.__cursor is None:
             raise DatabaseException(
                 "This method should only be used inside a with")
-        return self.__cursor._lastrowid
+        return self.__cursor.lastrowid
 
     @property
     def _rowcount(self):
         if self.__cursor is None:
             raise DatabaseException(
                 "This method should only be used inside a with")
-        return self.__cursor._rowcount
+        return self.__cursor.rowcount
 
     def transaction(self, isolation_level=None):
         """

--- a/spinn_front_end_common/utilities/sqlite_db.py
+++ b/spinn_front_end_common/utilities/sqlite_db.py
@@ -190,7 +190,7 @@ class SQLiteDB(AbstractContextManager):
         else:
             raise TypeError("can only set pragmas to bool, int or str")
 
-    def _execute(self, sql, paramters=()):
+    def execute(self, sql, paramters=()):
         """
         Executes a query by passing it to the database
 
@@ -204,7 +204,7 @@ class SQLiteDB(AbstractContextManager):
                 "This method should only be used inside a with")
         return self.__cursor.execute(sql, paramters)
 
-    def _executemany(self, sql, paramters=()):
+    def executemany(self, sql, paramters=()):
         """
         Repeatedly executes a query by passing it to the database
 
@@ -219,9 +219,9 @@ class SQLiteDB(AbstractContextManager):
         return self.__cursor.executemany(sql, paramters)
 
     @property
-    def _lastrowid(self):
+    def lastrowid(self):
         """
-        Gets the lastrow from the last query run
+        Gets the lastrow from the last query run/ execute
 
         :rtype: int
         :raises DatabaseException: If there is no cursor.
@@ -233,9 +233,9 @@ class SQLiteDB(AbstractContextManager):
         return self.__cursor.lastrowid
 
     @property
-    def _rowcount(self):
+    def rowcount(self):
         """
-        Gets the rowcount from the last query run
+        Gets the rowcount from the last query run/ execute
 
         :rtype: int
         :raises DatabaseException: If there is no cursor.
@@ -246,7 +246,7 @@ class SQLiteDB(AbstractContextManager):
                 "This method should only be used inside a with")
         return self.__cursor.rowcount
 
-    def _fetchone(self):
+    def fetchone(self):
         """
         Gets the fetchone from the last query run
 

--- a/spinn_front_end_common/utilities/sqlite_db.py
+++ b/spinn_front_end_common/utilities/sqlite_db.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import enum
 import hashlib
 import logging
 import os
@@ -23,18 +22,6 @@ from spinn_utilities.abstract_context_manager import AbstractContextManager
 from spinn_front_end_common.utilities.exceptions import DatabaseException
 
 logger = logging.getLogger(__name__)
-
-
-class Isolation(enum.Enum):
-    """
-    Transaction isolation levels for :py:meth:`SQLiteDB.transaction`.
-    """
-    #: Standard transaction type; postpones holding a lock until required.
-    DEFERRED = "DEFERRED"
-    #: Take the lock immediately; this may be a read-lock that gets upgraded.
-    IMMEDIATE = "IMMEDIATE"
-    #: Take a write lock immediately. This is the strongest lock type.
-    EXCLUSIVE = "EXCLUSIVE"
 
 
 class SQLiteDB(AbstractContextManager):

--- a/spinn_front_end_common/utilities/sqlite_db.py
+++ b/spinn_front_end_common/utilities/sqlite_db.py
@@ -218,6 +218,12 @@ class SQLiteDB(AbstractContextManager):
                 "This method should only be used inside a with")
         return self.__cursor.rowcount
 
+    def _fetchone(self):
+        if self.__cursor is None:
+            raise DatabaseException(
+                "This method should only be used inside a with")
+        return self.__cursor.fetchone()
+
     def transaction(self, isolation_level=None):
         """
         Get a context manager that manages a transaction on the database.

--- a/spinn_front_end_common/utilities/sqlite_db.py
+++ b/spinn_front_end_common/utilities/sqlite_db.py
@@ -193,12 +193,28 @@ class SQLiteDB(AbstractContextManager):
             raise TypeError("can only set pragmas to bool, int or str")
 
     def _execute(self, sql, paramters=()):
+        """
+        Executes a query by passing it to the database
+
+        :param str sql:
+        :param paramters:
+        :raises DatabaseException: If there is no cursor.
+            Typically because database was used outside of a with
+        """
         if self.__cursor is None:
             raise DatabaseException(
                 "This method should only be used inside a with")
         return self.__cursor.execute(sql, paramters)
 
     def _executemany(self, sql, paramters=()):
+        """
+        Repeatedly executes a query by passing it to the database
+
+        :param str sql:
+        :param paramters:
+        :raises DatabaseException: If there is no cursor.
+            Typically because database was used outside of a with
+        """
         if self.__cursor is None:
             raise DatabaseException(
                 "This method should only be used inside a with")
@@ -206,6 +222,13 @@ class SQLiteDB(AbstractContextManager):
 
     @property
     def _lastrowid(self):
+        """
+        Gets the lastrow from the last query run
+
+        :rtype: int
+        :raises DatabaseException: If there is no cursor.
+            Typically because database was used outside of a with
+        """
         if self.__cursor is None:
             raise DatabaseException(
                 "This method should only be used inside a with")
@@ -213,49 +236,26 @@ class SQLiteDB(AbstractContextManager):
 
     @property
     def _rowcount(self):
+        """
+        Gets the rowcount from the last query run
+
+        :rtype: int
+        :raises DatabaseException: If there is no cursor.
+            Typically because database was used outside of a with
+        """
         if self.__cursor is None:
             raise DatabaseException(
                 "This method should only be used inside a with")
         return self.__cursor.rowcount
 
     def _fetchone(self):
+        """
+        Gets the fetchone from the last query run
+
+        :raises DatabaseException: If there is no cursor.
+            Typically because database was used outside of a with
+        """
         if self.__cursor is None:
             raise DatabaseException(
                 "This method should only be used inside a with")
         return self.__cursor.fetchone()
-
-    def transaction(self, isolation_level=None):
-        """
-        Get a context manager that manages a transaction on the database.
-        The value of the context manager is a :py:class:`~sqlite3.Cursor`.
-        This means you can do this::
-
-            with db.transaction() as cursor:
-                cursor.execute(...)
-
-        :param Isolation isolation_level:
-            The transaction isolation level.
-
-            .. note::
-                This sets it for the connection!
-                Can usually be *not* specified.
-        :rtype: ~typing.ContextManager(~sqlite3.Cursor)
-        """
-        if not self.__db:
-            raise AttributeError("database has been closed")
-        db = self.__db
-        if isolation_level:
-            db.isolation_level = isolation_level.value
-        return _DbWrapper(db)
-
-
-class _DbWrapper(ACMBase):
-    def __init__(self, db):
-        self.__d = db
-
-    def __enter__(self):
-        self.__d.__enter__()
-        return self.__d.cursor()
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        return self.__d.__exit__(exc_type, exc_value, traceback)

--- a/unittests/data/test_simulator_data.py
+++ b/unittests/data/test_simulator_data.py
@@ -31,7 +31,6 @@ from spinn_front_end_common.data import FecDataView
 from spinn_front_end_common.data.fec_data_writer import FecDataWriter
 from spinn_front_end_common.interface.buffer_management import BufferManager
 from spinn_front_end_common.interface.config_setup import unittest_setup
-from spinn_front_end_common.interface.ds import DsSqlliteDatabase
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from spinn_front_end_common.utilities.notification_protocol import (
     NotificationProtocol)

--- a/unittests/data/test_simulator_data.py
+++ b/unittests/data/test_simulator_data.py
@@ -573,17 +573,6 @@ class TestSimulatorData(unittest.TestCase):
         with self.assertRaises(TypeError):
             writer.set_executable_targets([])
 
-    def test_ds_database(self):
-        writer = FecDataWriter.mock()
-        set_config("Machine", "version", 5)
-        with self.assertRaises(DataNotYetAvialable):
-            FecDataView.get_ds_database()
-        targets = DsSqlliteDatabase()
-        writer.set_ds_database(targets)
-        self.assertEqual(targets, FecDataView.get_ds_database())
-        with self.assertRaises(TypeError):
-            writer.set_ds_database(dict())
-
     def test_gatherer_map(self):
         writer = FecDataWriter.mock()
         with self.assertRaises(DataNotYetAvialable):

--- a/unittests/interface/ds/test_ds.py
+++ b/unittests/interface/ds/test_ds.py
@@ -55,270 +55,270 @@ class TestDataSpecification(unittest.TestCase):
         set_config("Machine", "version", 5)
 
     def test_init(self):
-        db = DsSqlliteDatabase()
         vertex1 = _TestVertexWithBinary(
             "off_board__system", ExecutableType.SYSTEM)
-        DataSpecificationGenerator(0, 1, 2, vertex1, db)
-        DataSpecificationReloader(0, 1, 2, db)
+        with DsSqlliteDatabase() as db:
+            DataSpecificationGenerator(0, 1, 2, vertex1, db)
+            DataSpecificationReloader(0, 1, 2, db)
 
     def test_none_ds_vertex(self):
-        db = DsSqlliteDatabase()
         vertex = SimpleMachineVertex(0)
-        with self.assertRaises(AttributeError):
-            DataSpecificationGenerator(0, 1, 2, vertex, db)
+        with DsSqlliteDatabase() as db:
+            with self.assertRaises(AttributeError):
+                DataSpecificationGenerator(0, 1, 2, vertex, db)
 
     def test_bad_x_y_ds_vertex(self):
-        db = DsSqlliteDatabase()
         vertex = _TestVertexWithBinary(
             "off_board__system", ExecutableType.SYSTEM)
-        with self.assertRaises(KeyError):
-            DataSpecificationGenerator(10, 10, 2, vertex, db)
+        with DsSqlliteDatabase() as db:
+            with self.assertRaises(KeyError):
+                DataSpecificationGenerator(10, 10, 2, vertex, db)
 
     def test_repeat_x_y_ds_vertex(self):
-        db = DsSqlliteDatabase()
         vertex1 = _TestVertexWithBinary(
             "v1", ExecutableType.SYSTEM)
         vertex2 = _TestVertexWithBinary(
             "v2", ExecutableType.SYSTEM)
-        DataSpecificationGenerator(0, 1, 2, vertex1, db)
-        with self.assertRaises(IntegrityError):
-            DataSpecificationGenerator(0, 1, 2, vertex2, db)
+        with DsSqlliteDatabase() as db:
+            DataSpecificationGenerator(0, 1, 2, vertex1, db)
+            with self.assertRaises(IntegrityError):
+                DataSpecificationGenerator(0, 1, 2, vertex2, db)
 
     def test_core_infos(self):
         FecDataWriter.mock().set_machine(virtual_machine(16, 16))
-        db = DsSqlliteDatabase()
-        self.assertEqual([], db.get_core_infos(True))
-        s1 = _TestVertexWithBinary("S1", ExecutableType.SYSTEM)
-        DataSpecificationGenerator(0, 0, 2, s1, db)
-        s2 = _TestVertexWithBinary("S2", ExecutableType.SYSTEM)
-        DataSpecificationGenerator(5, 9, 2, s2, db)
-        s3 = _TestVertexWithBinary("S3", ExecutableType.SYSTEM)
-        DataSpecificationGenerator(9, 5, 2, s3, db)
-        a1 = _TestVertexWithBinary(
-            "A1", ExecutableType.USES_SIMULATION_INTERFACE)
-        DataSpecificationGenerator(0, 0, 3, a1, db)
-        a2 = _TestVertexWithBinary(
-            "A2", ExecutableType.USES_SIMULATION_INTERFACE)
-        DataSpecificationGenerator(0, 0, 4, a2, db)
-        sys_infos = [(0, 0, 2, 0, 0), (5, 9, 2, 4, 8),
-                     (9, 5, 2, 8, 4)]
-        self.assertEqual(sys_infos, db.get_core_infos(True))
-        app_infos = [(0, 0, 3, 0, 0), (0, 0, 4, 0, 0)]
-        self.assertEqual(app_infos, db.get_core_infos(False))
+        with DsSqlliteDatabase() as db:
+            self.assertEqual([], db.get_core_infos(True))
+            s1 = _TestVertexWithBinary("S1", ExecutableType.SYSTEM)
+            DataSpecificationGenerator(0, 0, 2, s1, db)
+            s2 = _TestVertexWithBinary("S2", ExecutableType.SYSTEM)
+            DataSpecificationGenerator(5, 9, 2, s2, db)
+            s3 = _TestVertexWithBinary("S3", ExecutableType.SYSTEM)
+            DataSpecificationGenerator(9, 5, 2, s3, db)
+            a1 = _TestVertexWithBinary(
+                "A1", ExecutableType.USES_SIMULATION_INTERFACE)
+            DataSpecificationGenerator(0, 0, 3, a1, db)
+            a2 = _TestVertexWithBinary(
+                "A2", ExecutableType.USES_SIMULATION_INTERFACE)
+            DataSpecificationGenerator(0, 0, 4, a2, db)
+            sys_infos = [(0, 0, 2, 0, 0), (5, 9, 2, 4, 8),
+                         (9, 5, 2, 8, 4)]
+            self.assertEqual(sys_infos, db.get_core_infos(True))
+            app_infos = [(0, 0, 3, 0, 0), (0, 0, 4, 0, 0)]
+            self.assertEqual(app_infos, db.get_core_infos(False))
 
     def test_bad_ethernet(self):
         router = Router([], 123)
         bad = Chip(10, 10, 15, router, 100, 8, 8)
         FecDataView.get_machine().add_chip(bad)
-        db = DsSqlliteDatabase()
         vertex = _TestVertexWithBinary(
             "bad", ExecutableType.SYSTEM)
-        with self.assertRaises(IntegrityError):
-            DataSpecificationGenerator(10, 10, 2, vertex, db)
+        with DsSqlliteDatabase() as db:
+            with self.assertRaises(IntegrityError):
+                DataSpecificationGenerator(10, 10, 2, vertex, db)
 
     def test_reserve_memory_region(self):
-        db = DsSqlliteDatabase()
         vertex = _TestVertexWithBinary(
             "binary", ExecutableType.SYSTEM)
-        dsg = DataSpecificationGenerator(0, 1, 2, vertex, db)
-        dsg.reserve_memory_region(10, 123456, "test_region")
-        size = db.get_region_size(0, 1, 2, 10)
-        self.assertEqual(123456, size)
-        # May not repeat a location
-        with self.assertRaises(IntegrityError):
-            dsg.reserve_memory_region(10, 24, "repeat_region")
+        with DsSqlliteDatabase() as db:
+            dsg = DataSpecificationGenerator(0, 1, 2, vertex, db)
+            dsg.reserve_memory_region(10, 123456, "test_region")
+            size = db.get_region_size(0, 1, 2, 10)
+            self.assertEqual(123456, size)
+            # May not repeat a location
+            with self.assertRaises(IntegrityError):
+                dsg.reserve_memory_region(10, 24, "repeat_region")
 
-        # check reloading
-        dsr = DataSpecificationReloader(0, 1, 2, db)
-        # ok to repeat serve as long as the size is the same
-        dsr.reserve_memory_region(10, 123456, "different_name")
-        # But the wrong size foes BOOM!
-        with self.assertRaises(DataSpecException):
-            dsr.reserve_memory_region(10, 12345, "different_name")
-        with self.assertRaises(DataSpecException):
-            dsr.reserve_memory_region(10, 212345, "different_name")
+            # check reloading
+            dsr = DataSpecificationReloader(0, 1, 2, db)
+            # ok to repeat serve as long as the size is the same
+            dsr.reserve_memory_region(10, 123456, "different_name")
+            # But the wrong size foes BOOM!
+            with self.assertRaises(DataSpecException):
+                dsr.reserve_memory_region(10, 12345, "different_name")
+            with self.assertRaises(DataSpecException):
+                dsr.reserve_memory_region(10, 212345, "different_name")
 
-        # test round up
-        dsg.reserve_memory_region(12, 1234, "test_region")
-        # the 1234 is rounded up to next 4
-        size = db.get_region_size(0, 1, 2, 12)
-        self.assertEqual(1236, size)
+            # test round up
+            dsg.reserve_memory_region(12, 1234, "test_region")
+            # the 1234 is rounded up to next 4
+            size = db.get_region_size(0, 1, 2, 12)
+            self.assertEqual(1236, size)
 
-        # dict will have all regions set for this core
-        sizes = db.get_region_sizes(0, 1, 2)
-        self.assertEqual(2, len(sizes))
-        self.assertEqual(sizes[10], 123456)
-        self.assertEqual(sizes[12], 1236)
+            # dict will have all regions set for this core
+            sizes = db.get_region_sizes(0, 1, 2)
+            self.assertEqual(2, len(sizes))
+            self.assertEqual(sizes[10], 123456)
+            self.assertEqual(sizes[12], 1236)
 
-        # total sizes
-        self.assertEqual(123456 + 1236, db.get_total_regions_size(0, 1, 2))
+            # total sizes
+            self.assertEqual(123456 + 1236, db.get_total_regions_size(0, 1, 2))
 
-        # If core unknown dict empty and size 0
-        self.assertEqual({}, db.get_region_sizes(0, 1, 3))
-        self.assertEqual(0, db.get_total_regions_size(0, 1, 3))
+            # If core unknown dict empty and size 0
+            self.assertEqual({}, db.get_region_sizes(0, 1, 3))
+            self.assertEqual(0, db.get_total_regions_size(0, 1, 3))
 
     def test_switch_write_focus(self):
-        db = DsSqlliteDatabase()
         vertex = _TestVertexWithBinary(
             "binary", ExecutableType.SYSTEM)
-        dsg = DataSpecificationGenerator(0, 1, 2, vertex, db)
-        dsg.reserve_memory_region(10, 123456, "test_region")
-        dsg.switch_write_focus(10)
-        # check internal fields used later are correct
-        self.assertEqual(123456, dsg._size)
-        # Error is switching into a region not reserved
-        with self.assertRaises(DsDatabaseException):
-            dsg.switch_write_focus(8)
+        with DsSqlliteDatabase() as db:
+            dsg = DataSpecificationGenerator(0, 1, 2, vertex, db)
+            dsg.reserve_memory_region(10, 123456, "test_region")
+            dsg.switch_write_focus(10)
+            # check internal fields used later are correct
+            self.assertEqual(123456, dsg._size)
+            # Error is switching into a region not reserved
+            with self.assertRaises(DsDatabaseException):
+                dsg.switch_write_focus(8)
 
     def test_pointers(self):
-        db = DsSqlliteDatabase()
-
         # You can use a reference before defining it
         vertex = _TestVertexWithBinary(
             "binary1", ExecutableType.SYSTEM)
-        dsg1 = DataSpecificationGenerator(1, 1, 1, vertex, db)
-        dsg1.reference_memory_region(6, 2)
+        with DsSqlliteDatabase() as db:
+            dsg1 = DataSpecificationGenerator(1, 1, 1, vertex, db)
+            dsg1.reference_memory_region(6, 2)
 
-        # You can use a reference before defining it
-        dsg2 = DataSpecificationGenerator(1, 1, 2, vertex, db)
-        dsg2.reserve_memory_region(2, 100)
-        dsg2.reserve_memory_region(6, 200, reference=1)
-        dsg2.reserve_memory_region(4, 400, reference=2)
-        db.set_start_address(1, 1, 2, 1000)
-        self.assertEqual(1000, db.get_start_address(1, 1, 2))
+            # You can use a reference before defining it
+            dsg2 = DataSpecificationGenerator(1, 1, 2, vertex, db)
+            dsg2.reserve_memory_region(2, 100)
+            dsg2.reserve_memory_region(6, 200, reference=1)
+            dsg2.reserve_memory_region(4, 400, reference=2)
+            db.set_start_address(1, 1, 2, 1000)
+            self.assertEqual(1000, db.get_start_address(1, 1, 2))
 
-        dsg3 = DataSpecificationGenerator(1, 1, 3, vertex, db)
-        dsg3.reference_memory_region(11, 1)
-        # And also use a reference more than once
-        dsg3.reference_memory_region(9, 2)
+            dsg3 = DataSpecificationGenerator(1, 1, 3, vertex, db)
+            dsg3.reference_memory_region(11, 1)
+            # And also use a reference more than once
+            dsg3.reference_memory_region(9, 2)
 
-        # You can use a reference before defining it
-        # So you can reference a bad region
-        dsg4 = DataSpecificationGenerator(1, 1, 4, vertex, db)
-        dsg4.reference_memory_region(8, 3, "oops")
+            # You can use a reference before defining it
+            # So you can reference a bad region
+            dsg4 = DataSpecificationGenerator(1, 1, 4, vertex, db)
+            dsg4.reference_memory_region(8, 3, "oops")
 
-        with self.assertRaises(DsDatabaseException):
-            db.set_start_address(1, 3, 4, 123)
+        with DsSqlliteDatabase() as db:
+            with self.assertRaises(DsDatabaseException):
+                db.set_start_address(1, 3, 4, 123)
 
-        with self.assertRaises(DsDatabaseException):
-            db.get_start_address(1, 3, 4)
+            with self.assertRaises(DsDatabaseException):
+                db.get_start_address(1, 3, 4)
 
-        p2 = 1000 + APP_PTR_TABLE_BYTE_SIZE
-        p4 = p2 + 100
-        p6 = p4 + 400
-        db.set_region_pointer(1, 1, 2, 2, p2)
-        db.set_region_pointer(1, 1, 2, 4, p4)
-        db.set_region_pointer(1, 1, 2, 6, p6)
+            p2 = 1000 + APP_PTR_TABLE_BYTE_SIZE
+            p4 = p2 + 100
+            p6 = p4 + 400
+            db.set_region_pointer(1, 1, 2, 2, p2)
+            db.set_region_pointer(1, 1, 2, 4, p4)
+            db.set_region_pointer(1, 1, 2, 6, p6)
 
-        self.assertEqual(p2, db.get_region_pointer(1, 1, 2, 2))
-        self.assertEqual(p4, db.get_region_pointer(1, 1, 2, 4))
-        self.assertEqual(p6, db.get_region_pointer(1, 1, 2, 6))
+            self.assertEqual(p2, db.get_region_pointer(1, 1, 2, 2))
+            self.assertEqual(p4, db.get_region_pointer(1, 1, 2, 4))
+            self.assertEqual(p6, db.get_region_pointer(1, 1, 2, 6))
 
-        region_infos = list(db.get_region_pointers_and_content(1, 1, 2))
-        self.assertEqual(3, len(region_infos))
-        self.assertIn((2, p2, None), region_infos)
-        self.assertIn((4, p4, None), region_infos)
-        self.assertIn((6, p6, None), region_infos)
+            region_infos = list(db.get_region_pointers_and_content(1, 1, 2))
+            self.assertEqual(3, len(region_infos))
+            self.assertIn((2, p2, None), region_infos)
+            self.assertIn((4, p4, None), region_infos)
+            self.assertIn((6, p6, None), region_infos)
 
-        region_infos = list(db.get_region_pointers_and_content(1, 1, 1))
-        self.assertEqual(1, len(region_infos))
-        self.assertIn((6, p4, None), region_infos)
+            region_infos = list(db.get_region_pointers_and_content(1, 1, 1))
+            self.assertEqual(1, len(region_infos))
+            self.assertIn((6, p4, None), region_infos)
 
-        region_infos = list(db.get_region_pointers_and_content(1, 1, 3))
-        self.assertEqual(2, len(region_infos))
-        self.assertIn((11, p6, None), region_infos)
-        self.assertIn((9, p4, None), region_infos)
+            region_infos = list(db.get_region_pointers_and_content(1, 1, 3))
+            self.assertEqual(2, len(region_infos))
+            self.assertIn((11, p6, None), region_infos)
+            self.assertIn((9, p4, None), region_infos)
 
-        # region_num, pointer, content
+            # region_num, pointer, content
 
-        with self.assertRaises(DsDatabaseException):
-            db.set_region_pointer(1, 2, 3, 9, 1400)
-        with self.assertRaises(DsDatabaseException):
-            db.get_region_pointer(1, 2, 3, 9)
+            with self.assertRaises(DsDatabaseException):
+                db.set_region_pointer(1, 2, 3, 9, 1400)
+            with self.assertRaises(DsDatabaseException):
+                db.get_region_pointer(1, 2, 3, 9)
 
     def test_write(self):
-        db = DsSqlliteDatabase()
         vertex = _TestVertexWithBinary(
             "binary", ExecutableType.SYSTEM)
 
-        # Emtpy if no cores set
-        self.assertEqual([], list(db.get_info_for_cores()))
+        with DsSqlliteDatabase() as db:
+            # Emtpy if no cores set
+            self.assertEqual([], list(db.get_info_for_cores()))
 
-        # You can use a reference before defining it
-        dsg = DataSpecificationGenerator(0, 1, 2, vertex, db)
-        dsg.reserve_memory_region(5, 100, "unused")
-        dsg.reserve_memory_region(10, 123456, "test_region")
-        dsg.switch_write_focus(10)
-        dsg.write_value(12)
-        dsg.write_array([34, 56])
-        dsg.end_specification()
+            # You can use a reference before defining it
+            dsg = DataSpecificationGenerator(0, 1, 2, vertex, db)
+            dsg.reserve_memory_region(5, 100, "unused")
+            dsg.reserve_memory_region(10, 123456, "test_region")
+            dsg.switch_write_focus(10)
+            dsg.write_value(12)
+            dsg.write_array([34, 56])
+            dsg.end_specification()
 
-        dsg = DataSpecificationGenerator(0, 1, 3, vertex, db)
-        dsg.reserve_memory_region(7, 444, "unused2")
+            dsg = DataSpecificationGenerator(0, 1, 3, vertex, db)
+            dsg.reserve_memory_region(7, 444, "unused2")
 
-        self.assertEqual(123456, db.get_region_size(0, 1, 2, 10))
+            self.assertEqual(123456, db.get_region_size(0, 1, 2, 10))
 
-        pcs = list(db.get_region_pointers_and_content(0, 1, 2))
-        self.assertEqual(2, len(pcs))
+            pcs = list(db.get_region_pointers_and_content(0, 1, 2))
+            self.assertEqual(2, len(pcs))
 
-        region, pointer, content = pcs[0]
-        self.assertEqual(5, region)
-        self.assertIsNone(pointer)
-        self.assertIsNone(content)
+            region, pointer, content = pcs[0]
+            self.assertEqual(5, region)
+            self.assertIsNone(pointer)
+            self.assertIsNone(content)
 
-        region, pointer, content = pcs[1]
-        self.assertEqual(10, region)
-        self.assertIsNone(pointer)
-        self.assertEqual(3 * 4, len(content))
-        self.assertEqual(
-            bytearray(b'\x0c\x00\x00\x00"\x00\x00\x008\x00\x00\x00'), content)
+            region, pointer, content = pcs[1]
+            self.assertEqual(10, region)
+            self.assertIsNone(pointer)
+            self.assertEqual(3 * 4, len(content))
+            self.assertEqual(
+                bytearray(b'\x0c\x00\x00\x00"\x00\x00\x008\x00\x00\x00'), content)
 
-        pcs = list(db.get_region_pointers_and_content(0, 1, 6))
-        self.assertEqual(0, len(pcs))
+            pcs = list(db.get_region_pointers_and_content(0, 1, 6))
+            self.assertEqual(0, len(pcs))
 
-        info = list(db.get_info_for_cores())
-        size2 = APP_PTR_TABLE_BYTE_SIZE + 100 + 123456
-        size3 = APP_PTR_TABLE_BYTE_SIZE + 444
-        self.assertIn(((0, 1, 2), None, size2, 404), info)
-        self.assertIn(((0, 1, 3), None, size3, APP_PTR_TABLE_BYTE_SIZE), info)
+            info = list(db.get_info_for_cores())
+            size2 = APP_PTR_TABLE_BYTE_SIZE + 100 + 123456
+            size3 = APP_PTR_TABLE_BYTE_SIZE + 444
+            self.assertIn(((0, 1, 2), None, size2, 404), info)
+            self.assertIn(((0, 1, 3), None, size3, APP_PTR_TABLE_BYTE_SIZE), info)
 
-        with self.assertRaises(DsDatabaseException):
-            db.set_region_content(
-                0, 1, 4, 5, bytearray(b'\x0c\x00\x00\x00'), "test")
+            with self.assertRaises(DsDatabaseException):
+                db.set_region_content(
+                    0, 1, 4, 5, bytearray(b'\x0c\x00\x00\x00'), "test")
 
     def test_ds_cores(self):
-        db = DsSqlliteDatabase()
         vertex = _TestVertexWithBinary(
             "binary", ExecutableType.SYSTEM)
-        self.assertEqual([], list(db.get_ds_cores()))
-        self.assertEqual(0, db.get_n_ds_cores())
+        with DsSqlliteDatabase() as db:
+            self.assertEqual([], list(db.get_ds_cores()))
+            self.assertEqual(0, db.get_n_ds_cores())
 
-        DataSpecificationGenerator(0, 1, 3, vertex, db)
-        DataSpecificationGenerator(0, 1, 4, vertex, db)
-        DataSpecificationGenerator(0, 2, 3, vertex, db)
-        self.assertEqual(3, db.get_n_ds_cores())
-        cores = list(db.get_ds_cores())
+            DataSpecificationGenerator(0, 1, 3, vertex, db)
+            DataSpecificationGenerator(0, 1, 4, vertex, db)
+            DataSpecificationGenerator(0, 2, 3, vertex, db)
+            self.assertEqual(3, db.get_n_ds_cores())
+            cores = list(db.get_ds_cores())
         self.assertEqual(3, len(cores))
         self.assertIn((0, 1, 3), cores)
         self.assertIn((0, 1, 4), cores)
         self.assertIn((0, 2, 3), cores)
 
     def test_memory_to_write(self):
-        db = DsSqlliteDatabase()
         vertex = _TestVertexWithBinary(
             "binary", ExecutableType.SYSTEM)
-        dsg = DataSpecificationGenerator(0, 1, 3, vertex, db)
-        dsg.reserve_memory_region(5, 200, "used")
-        dsg.switch_write_focus(5)
-        dsg.write_array([34, 56])
+        with DsSqlliteDatabase() as db:
+            dsg = DataSpecificationGenerator(0, 1, 3, vertex, db)
+            dsg.reserve_memory_region(5, 200, "used")
+            dsg.switch_write_focus(5)
+            dsg.write_array([34, 56])
 
-        dsg = DataSpecificationGenerator(0, 1, 4, vertex, db)
-        dsg = DataSpecificationGenerator(0, 1, 5, vertex, db)
-        dsg.reserve_memory_region(5, 100, "unused")
-        self.assertEqual(APP_PTR_TABLE_BYTE_SIZE,
-                         db.get_memory_to_write(0, 1, 4))
-        self.assertEqual(APP_PTR_TABLE_BYTE_SIZE,
-                         db.get_memory_to_write(0, 1, 3))
+            dsg = DataSpecificationGenerator(0, 1, 4, vertex, db)
+            dsg = DataSpecificationGenerator(0, 1, 5, vertex, db)
+            dsg.reserve_memory_region(5, 100, "unused")
+            self.assertEqual(APP_PTR_TABLE_BYTE_SIZE,
+                             db.get_memory_to_write(0, 1, 4))
+            self.assertEqual(APP_PTR_TABLE_BYTE_SIZE,
+                             db.get_memory_to_write(0, 1, 3))
 
 
 if __name__ == "__main__":

--- a/unittests/interface/ds/test_ds.py
+++ b/unittests/interface/ds/test_ds.py
@@ -196,7 +196,6 @@ class TestDataSpecification(unittest.TestCase):
             dsg4 = DataSpecificationGenerator(1, 1, 4, vertex, db)
             dsg4.reference_memory_region(8, 3, "oops")
 
-        with DsSqlliteDatabase() as db:
             with self.assertRaises(DsDatabaseException):
                 db.set_start_address(1, 3, 4, 123)
 

--- a/unittests/interface/ds/test_ds.py
+++ b/unittests/interface/ds/test_ds.py
@@ -270,7 +270,8 @@ class TestDataSpecification(unittest.TestCase):
             self.assertIsNone(pointer)
             self.assertEqual(3 * 4, len(content))
             self.assertEqual(
-                bytearray(b'\x0c\x00\x00\x00"\x00\x00\x008\x00\x00\x00'), content)
+                bytearray(b'\x0c\x00\x00\x00"\x00\x00\x008\x00\x00\x00'),
+                content)
 
             pcs = list(db.get_region_pointers_and_content(0, 1, 6))
             self.assertEqual(0, len(pcs))
@@ -279,7 +280,8 @@ class TestDataSpecification(unittest.TestCase):
             size2 = APP_PTR_TABLE_BYTE_SIZE + 100 + 123456
             size3 = APP_PTR_TABLE_BYTE_SIZE + 444
             self.assertIn(((0, 1, 2), None, size2, 404), info)
-            self.assertIn(((0, 1, 3), None, size3, APP_PTR_TABLE_BYTE_SIZE), info)
+            self.assertIn(
+                ((0, 1, 3), None, size3, APP_PTR_TABLE_BYTE_SIZE), info)
 
             with self.assertRaises(DsDatabaseException):
                 db.set_region_content(

--- a/unittests/interface/interface_functions/test_front_end_common_dsg_region_reloader.py
+++ b/unittests/interface/interface_functions/test_front_end_common_dsg_region_reloader.py
@@ -144,20 +144,19 @@ class TestFrontEndCommonDSGRegionReloader(unittest.TestCase):
 
         transceiver = _MockTransceiver()
         writer.set_transceiver(transceiver)
-        ds = DsSqlliteDatabase()
-        writer.set_ds_database(ds)
-        for placement in placements:
-            ds.set_core(
-                placement.x, placement.y, placement.p, placement.vertex)
-            base = placement.p * 1000
-            regions = reload_region_data[placement.p]
-            for (reg_num, size, _) in regions:
-                ds.set_memory_region(
-                    placement.x, placement.y, placement.p, reg_num, size,
-                    None, None)
-                ds.set_region_pointer(
-                    placement.x, placement.y, placement.p, reg_num, base)
-                base += size
+        with DsSqlliteDatabase() as ds:
+            for placement in placements:
+                ds.set_core(
+                    placement.x, placement.y, placement.p, placement.vertex)
+                base = placement.p * 1000
+                regions = reload_region_data[placement.p]
+                for (reg_num, size, _) in regions:
+                    ds.set_memory_region(
+                        placement.x, placement.y, placement.p, reg_num, size,
+                        None, None)
+                    ds.set_region_pointer(
+                        placement.x, placement.y, placement.p, reg_num, base)
+                    base += size
 
         reload_dsg_regions()
 
@@ -199,20 +198,19 @@ class TestFrontEndCommonDSGRegionReloader(unittest.TestCase):
 
         transceiver = _MockTransceiver()
         writer.set_transceiver(transceiver)
-        ds = DsSqlliteDatabase()
-        writer.set_ds_database(ds)
-        for placement in placements:
-            ds.set_core(
-                placement.x, placement.y, placement.p, placement.vertex)
-            base = placement.p * 1000
-            regions = reload_region_data[placement.p]
-            for (reg_num, size, _) in regions:
-                ds.set_memory_region(
-                    placement.x, placement.y, placement.p, reg_num, size-1,
-                    None, None)
-                ds.set_region_pointer(
-                    placement.x, placement.y, placement.p, reg_num, base)
-                base += size
+        with DsSqlliteDatabase() as ds:
+            for placement in placements:
+                ds.set_core(
+                    placement.x, placement.y, placement.p, placement.vertex)
+                base = placement.p * 1000
+                regions = reload_region_data[placement.p]
+                for (reg_num, size, _) in regions:
+                    ds.set_memory_region(
+                        placement.x, placement.y, placement.p, reg_num, size-1,
+                        None, None)
+                    ds.set_region_pointer(
+                        placement.x, placement.y, placement.p, reg_num, base)
+                    base += size
 
         with self.assertRaises(DataSpecException):
             reload_dsg_regions()

--- a/unittests/interface/provenance/test_provenance_database.py
+++ b/unittests/interface/provenance/test_provenance_database.py
@@ -14,6 +14,7 @@
 
 import logging
 import os
+from sqlite3 import OperationalError
 from spinn_utilities.log import FormatAdapter
 from datetime import timedelta
 from testfixtures.logcapture import LogCapture
@@ -212,3 +213,16 @@ class TestProvenanceDatabase(unittest.TestCase):
                 ["this works", "not locked", "this wis fine"],
                 ls.retreive_log_messages(20))
         logger.set_log_store(None)
+
+    def test_double_with(self):
+        # Confirm that using the database twice goes boom
+        with GlobalProvenance() as db1:
+            with GlobalProvenance() as db2:
+                # A read does not lock the database
+                db1.get_timer_provenance("test")
+                db2.get_timer_provenance("test")
+                # A write does
+                db1.insert_version("a", "foo")
+                with self.assertRaises(OperationalError):
+                    # So a write from a different transaction goes boom
+                    db2.insert_version("b", "bar")

--- a/unittests/interface/provenance/test_provenance_database.py
+++ b/unittests/interface/provenance/test_provenance_database.py
@@ -204,7 +204,7 @@ class TestProvenanceDatabase(unittest.TestCase):
         logger.warning("this works")
         with GlobalProvenance() as db:
             db._test_log_locked("locked")
-            logger.warning("not locked")
+        logger.warning("not locked")
         logger.warning("this wis fine")
         # the use of class variables and tests run in parallel dont work.
         if "JENKINS_URL" not in os.environ:

--- a/unittests/utilities/test_fec_timer.py
+++ b/unittests/utilities/test_fec_timer.py
@@ -108,7 +108,8 @@ class TestFecTimer(unittest.TestCase):
             total = db.get_category_timer_sum(
                 TimerCategory.SHUTTING_DOWN)
             self.assertEqual(total, 0)
-            FecTimer.stop_category_timing()
+        FecTimer.stop_category_timing()
+        with GlobalProvenance() as db:
             total = db.get_category_timer_sum(
                 TimerCategory.SHUTTING_DOWN)
             self.assertGreater(total, 0)
@@ -136,10 +137,11 @@ class TestFecTimer(unittest.TestCase):
         FecTimer.start_category(TimerCategory.RUN_OTHER)
         with GlobalProvenance() as db:
             before = db.get_category_timer_sum(TimerCategory.WAITING)
-            FecTimer.start_category(TimerCategory.MAPPING)
-            FecTimer.end_category(TimerCategory.MAPPING)
-            FecTimer.end_category(TimerCategory.RUN_OTHER)
-            FecTimer.stop_category_timing()
+        FecTimer.start_category(TimerCategory.MAPPING)
+        FecTimer.end_category(TimerCategory.MAPPING)
+        FecTimer.end_category(TimerCategory.RUN_OTHER)
+        FecTimer.stop_category_timing()
+        with GlobalProvenance() as db:
             total = db.get_category_timer_sum(TimerCategory.WAITING)
             self.assertGreater(total, before)
             other = db.get_category_timer_sum(TimerCategory.RUN_OTHER)
@@ -150,10 +152,11 @@ class TestFecTimer(unittest.TestCase):
         FecTimer.start_category(TimerCategory.RUN_OTHER)
         with GlobalProvenance() as db:
             before = db.get_category_timer_sum(TimerCategory.WAITING)
-            FecTimer.start_category(TimerCategory.MAPPING)
-            FecTimer.start_category(TimerCategory.SHUTTING_DOWN)
-            FecTimer.end_category(TimerCategory.SHUTTING_DOWN)
-            FecTimer.stop_category_timing()
+        FecTimer.start_category(TimerCategory.MAPPING)
+        FecTimer.start_category(TimerCategory.SHUTTING_DOWN)
+        FecTimer.end_category(TimerCategory.SHUTTING_DOWN)
+        FecTimer.stop_category_timing()
+        with GlobalProvenance() as db:
             mapping = db.get_category_timer_sum(TimerCategory.MAPPING)
             self.assertGreater(mapping, 0)
             total = db.get_category_timer_sum(TimerCategory.WAITING)


### PR DESCRIPTION
This Pr is based on ideas from https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1062

The purpose is to reduce the number of database transaction.

The basic idea is that all database patterns follow the pattern
with xyzDatabase() as db:
- The enter starts a transaction and caches a cursor
- SQLiteDB has a few pass through methods which check the cursor/transaction exists and uses that
- Exit commits the transaction and nukes the cached cursor so it can not be reused.

Most changes are just tabbing after the removal of the
with self.transaction() as cursor:

While NOT recommended it is possible to have two xyzDatabase Objects open on the same file
BUT if you write to both it goes BOOM!
see test_double_with

The pattern
with DsSqlliteDatabase() as db:
            dsg = DataSpecificationGenerator(0, 1, 3, vertex, db)
looks strange in tests but was used so that
_GraphDataSpecificationWriter runs the whole generation in a single transaction


A few code changes includes:
- The View now holds the path of the DsSqlliteDatabase
- Database queries moved from SpinnMan to Fec

Must be Done at the same time as:
https://github.com/SpiNNakerManchester/SpiNNMan/pull/361
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1385


