### PR TITLE
Convert our use of SQLite to use RETURNING clauses

### DIFF
--- a/spinn_front_end_common/utilities/base_database.py
+++ b/spinn_front_end_common/utilities/base_database.py
@@ -18,6 +18,7 @@ import time
 from spinn_utilities.abstract_context_manager import AbstractContextManager
 from spinn_front_end_common.data import FecDataView
 from spinn_front_end_common.utilities.sqlite_db import SQLiteDB
+from spinn_front_end_common.utilities.exceptions import SpinnFrontEndException
 
 _DDL_FILE = os.path.join(os.path.dirname(__file__),
                          "db.sql")
@@ -83,8 +84,11 @@ class BaseDatabase(SQLiteDB, AbstractContextManager):
                 LIMIT 1
                 """, (x, y, p)):
             return row["core_id"]
-        cursor.execute(
-            """
-            INSERT INTO core(x, y, processor) VALUES(?, ?, ?)
-            """, (x, y, p))
-        return cursor.lastrowid
+        for row in cursor.execute(
+                """
+                INSERT INTO core(x, y, processor)
+                VALUES(?, ?, ?)
+                RETURNING core_id
+                """, (x, y, p)):
+            return row["core_id"]
+        raise SpinnFrontEndException("database insert failed")


### PR DESCRIPTION
This changes our Python code to use a `RETURNING` clause instead of using the `lastrowid` property, mirroring a change already in the Java code.

Note that this requires that we are running against a new enough Python to support `RETURNING` clauses. I don't know if 3.8 is new enough.