### PR TITLE
Live vs time callback

### DIFF
--- a/spinn_front_end_common/utilities/connections/live_event_connection.py
+++ b/spinn_front_end_common/utilities/connections/live_event_connection.py
@@ -225,7 +225,7 @@ class LiveEventConnection(DatabaseConnection):
             (live_event_callback, translate_key))
 
     def add_receive_time_callback(self, label, time_event_callback,
-                             translate_key=True):
+                                  translate_key=True):
         """
         Add a callback for the reception of time events from a vertex.
 

--- a/spinn_front_end_common/utilities/connections/live_event_connection.py
+++ b/spinn_front_end_common/utilities/connections/live_event_connection.py
@@ -229,6 +229,8 @@ class LiveEventConnection(DatabaseConnection):
         """
         Add a callback for the reception of time events from a vertex.
 
+        These are typically used to receive keys or atoms ids that spiked.
+
         :param str label: The label of the vertex to be notified about.
             Must be one of the vertices listed in the constructor
         :param time_event_callback: A function to be called when events are


### PR DESCRIPTION
https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1116 is a simpler alternative

The LiveEventConnection has two different even callback methods.

They take different parameters and without this PR this works by usage not by implementation

Based on idea from https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1062

But not depending on the caller happening to know that an extra parameter has been added.

Must be done at the same time as:
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1388
https://github.com/SpiNNakerManchester/SpiNNGym/pull/83
https://github.com/SpiNNakerManchester/Visualiser/pull/26
https://github.com/SpiNNakerManchester/PyNN8Examples/pull/109
https://github.com/SpiNNakerManchester/sPyNNakerVisualisers/pull/40
https://github.com/SpiNNakerManchester/SpiNNakerGraphFrontEnd/pull/260

tested by:
https://github.com/SpiNNakerManchester/IntegrationTests/pull/238




