### PR TITLE
No time callbacks

### DIFF
--- a/spinn_front_end_common/utilities/connections/live_event_connection.py
+++ b/spinn_front_end_common/utilities/connections/live_event_connection.py
@@ -194,7 +194,7 @@ class LiveEventConnection(DatabaseConnection):
         """
         self.__init_callbacks[label].append(init_callback)
 
-    def add_receive_callback(self, label, time_event_callback,
+    def add_receive_callback(self, label, live_event_callback,
                              translate_key=True):
         """
         Add a callback for the reception of time events from a vertex.
@@ -209,20 +209,20 @@ class LiveEventConnection(DatabaseConnection):
 
         :param str label: The label of the vertex to be notified about.
             Must be one of the vertices listed in the constructor
-        :param time_event_callback: A function to be called when events are
+        :param live_event_callback: A function to be called when events are
             received. This should take as parameters the label of the vertex,
             the simulation timestep when the event occurred, and an
             array-like of atom IDs or keys.
-        :type time_event_callback: callable(str, int, list(int)) -> None
+        :type live_event_callback: callable(str, int, list(int)) -> None
         :param bool translate_key:
             True if the key is to be converted to an atom ID, False if the
             key should stay a key
         """
         label_id = self.__receive_labels.index(label)
         logger.info("Receive callback {} registered to label {}",
-                    time_event_callback, label)
+                    live_event_callback, label)
         self.__time_event_callbacks[label_id].append(
-            (time_event_callback, translate_key))
+            (live_event_callback, translate_key))
 
     def add_receive_no_time_callback(
             self, label, live_event_callback, translate_key=True):

--- a/spinn_front_end_common/utilities/connections/live_event_connection.py
+++ b/spinn_front_end_common/utilities/connections/live_event_connection.py
@@ -528,7 +528,7 @@ class LiveEventConnection(DatabaseConnection):
             if key in self.__key_to_atom_id_and_label:
                 atom_id, label_id = self.__key_to_atom_id_and_label[key]
                 label = self.__receive_labels[label_id]
-                callbacks = self.__no_event_callbacks[label_id]
+                callbacks = self.__no_time_event_callbacks[label_id]
                 if len(callbacks) == 0:
                     msg = f"LiveEventConnection received a packet " \
                           f"without time for {label} but has no callback." \

--- a/spinn_front_end_common/utilities/connections/live_event_connection.py
+++ b/spinn_front_end_common/utilities/connections/live_event_connection.py
@@ -225,7 +225,7 @@ class LiveEventConnection(DatabaseConnection):
             (live_event_callback, translate_key))
 
     def add_receive_time_callback(self, label, time_event_callback,
-                             translate_key=True):
+                                  translate_key=True):
         """
         Add a callback for the reception of time events from a vertex.
 

--- a/spinn_front_end_common/utilities/connections/live_event_connection.py
+++ b/spinn_front_end_common/utilities/connections/live_event_connection.py
@@ -229,6 +229,8 @@ class LiveEventConnection(DatabaseConnection):
         """
         Add a callback for the reception of time events from a vertex.
 
+        These are typically used to receive keys or atoms ids that spiked.
+
         :param str label: The label of the vertex to be notified about.
             Must be one of the vertices listed in the constructor
         :param time_event_callback: A function to be called when events are


### PR DESCRIPTION
Simpler alternative to https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1114 et al

The LiveEventConnection has two different even callback methods.

They take different parameters and without this PR this works by usage not by implementation

Based on idea from https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1062

Only the rarer used callback where the data has no time has been changed.

Safety is added by logging if a handler has no callback.

Must be done at the same time as:
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1389

tested by:
https://github.com/SpiNNakerManchester/IntegrationTests/pull/239
