### PR TITLE
CSV reports (for master)

### DIFF
--- a/spinn_front_end_common/data/fec_data_view.py
+++ b/spinn_front_end_common/data/fec_data_view.py
@@ -1209,3 +1209,11 @@ class FecDataView(PacmanDataView, SpiNNManDataView):
                            cls.__fec_data._next_ds_reference+number)
         cls.__fec_data._next_ds_reference += number
         return list(references)
+
+    @classmethod
+    def get_run_dir_file_name(cls, *names: str) -> str:
+        """
+        Construct the name of a file in the directory that holds all the
+        reports for a run. For convenience of reporting.
+        """
+        return os.path.join(cls.get_run_dir_path(), *names)

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -874,9 +874,9 @@ class AbstractSpinnakerBase(ConfigHandler):
                 return
             board_chip_report()
             if FecDataView.has_allocation_controller():
-                filename = os.path.join(
-                    FecDataView.get_run_dir_path(), "machine_allocation.rpt")
-                FecDataView.get_allocation_controller().make_report(filename)
+                FecDataView.get_allocation_controller().make_report(
+                    FecDataView.get_run_dir_file_name(
+                        "machine_allocation.rpt"))
 
     def _execute_splitter_reset(self):
         """

--- a/spinn_front_end_common/interface/ds/ds_sqllite_database.py
+++ b/spinn_front_end_common/interface/ds/ds_sqllite_database.py
@@ -55,6 +55,17 @@ class DsSqlliteDatabase(SQLiteDB):
             self.__init_ethernets()
             self._init_file = False
 
+    @classmethod
+    def default_database_file(cls) -> str:
+        """
+        Gets the path to the default/ current database file
+
+        :rtype: str
+        :return: Path where the database is or should be written
+        """
+        return FecDataView.get_run_dir_file_name(
+            f"ds{FecDataView.get_reset_str()}.sqlite3")
+
     def __init_ethernets(self):
         """
         Set up the database contents from the machine.

--- a/spinn_front_end_common/interface/interface_functions/host_bit_field_router_compressor.py
+++ b/spinn_front_end_common/interface/interface_functions/host_bit_field_router_compressor.py
@@ -91,8 +91,7 @@ def generate_report_path():
     """
     :rtype: str
     """
-    report_folder_path = os.path.join(
-        FecDataView.get_run_dir_path(), _REPORT_FOLDER_NAME)
+    report_folder_path = FecDataView.get_run_dir_file_name(_REPORT_FOLDER_NAME)
     if not os.path.exists(report_folder_path):
         os.mkdir(report_folder_path)
     return report_folder_path

--- a/spinn_front_end_common/interface/java_caller.py
+++ b/spinn_front_end_common/interface/java_caller.py
@@ -363,11 +363,10 @@ class JavaCaller(object):
                 BufferDatabase.default_database_file(),
                 FecDataView.get_run_dir_path())
         if result != 0:
-            log_file = os.path.join(
-                FecDataView.get_run_dir_path(), "jspin.log")
+            log_file = FecDataView.get_run_dir_file_name("jspin.log")
             raise PacmanExternalAlgorithmFailedToCompleteException(
-                "Java call exited with value " + str(result) + " see "
-                + str(log_file) + " for logged info")
+                f"Java call exited with value {result}; "
+                f"see {log_file} for logged info")
 
     def load_system_data_specification(self):
         """
@@ -382,11 +381,10 @@ class JavaCaller(object):
             FecDataView.get_ds_database_path(),
             FecDataView.get_run_dir_path())
         if result != 0:
-            log_file = os.path.join(
-                FecDataView.get_run_dir_path(), "jspin.log")
+            log_file = FecDataView.get_run_dir_file_name("jspin.log")
             raise PacmanExternalAlgorithmFailedToCompleteException(
-                "Java call exited with value " + str(result) + " see "
-                + str(log_file) + " for logged info")
+                f"Java call exited with value {result}; "
+                f"see {log_file} for logged info")
 
     def load_app_data_specification(self, use_monitors):
         """
@@ -412,8 +410,7 @@ class JavaCaller(object):
                 FecDataView.get_ds_database_path(),
                 FecDataView.get_run_dir_path())
         if result != 0:
-            log_file = os.path.join(
-                FecDataView.get_run_dir_path(), "jspin.log")
+            log_file = FecDataView.get_run_dir_file_name("jspin.log")
             raise PacmanExternalAlgorithmFailedToCompleteException(
-                "Java call exited with value " + str(result) + " see "
-                + str(log_file) + " for logged info")
+                f"Java call exited with value {result}; "
+                f"see {log_file} for logged info")

--- a/spinn_front_end_common/interface/provenance/fec_timer.py
+++ b/spinn_front_end_common/interface/provenance/fec_timer.py
@@ -12,43 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-import os
-import sys
 import time
 from datetime import timedelta
 from spinn_utilities.config_holder import (get_config_bool)
 from spinn_utilities.log import FormatAdapter
 from spinn_front_end_common.data import FecDataView
 from .global_provenance import GlobalProvenance
+from spinn_front_end_common.utilities.report_functions.utils import csvopen
 
 logger = FormatAdapter(logging.getLogger(__name__))
 
-if sys.version_info >= (3, 7):
-    # acquire the most accurate measurement available (perf_counter_ns)
-    _now = time.perf_counter_ns  # pylint: disable=no-member
-    # conversion factor
-    _NANO_TO_MICRO = 1000.0
+# conversion factor
+_NANO_TO_MICRO = 1000.0
 
-    def _convert_to_timedelta(time_diff):
-        """
-        Have to convert to a timedelta for rest of code to read.
 
-        As perf_counter_ns is nano seconds, and time delta lowest is micro,
-        need to convert.
-        """
-        return timedelta(microseconds=time_diff / _NANO_TO_MICRO)
+def _convert_to_timedelta(time_diff):
+    """
+    Have to convert to a timedelta for rest of code to read.
 
-else:
-    # acquire the most accurate measurement available (perf_counter)
-    _now = time.perf_counter  # pylint: disable=no-member
-
-    def _convert_to_timedelta(time_diff):
-        """
-        Have to convert to a timedelta for rest of code to read.
-
-        As perf_counter is fractional seconds, put into correct time delta.
-        """
-        return timedelta(seconds=time_diff)
+    As perf_counter_ns is nano seconds, and time delta lowest is micro,
+    need to convert.
+    """
+    return timedelta(microseconds=time_diff / _NANO_TO_MICRO)
 
 
 class FecTimer(object):
@@ -61,8 +46,7 @@ class FecTimer(object):
     _category_time = None
     _machine_on = False
     _previous = []
-    __slots__ = [
-
+    __slots__ = (
         # The start time when the timer was set off
         "_start_time",
 
@@ -70,20 +54,22 @@ class FecTimer(object):
         "_algorithm",
 
         # Type of work being done
-        "_work"
-        ]
+        "_work")
 
     # Algorithm Names used elsewhere
     APPLICATION_RUNNER = "Application runner"
+
+    _CSV_HEADER = "Category,Algorithm,Action,Time Taken,Detail"
 
     @classmethod
     def setup(cls, simulator):
         # pylint: disable=global-statement, protected-access
         cls._simulator = simulator
         if get_config_bool("Reports", "write_algorithm_timings"):
-            cls._provenance_path = os.path.join(
-                FecDataView.get_run_dir_path(),
+            cls._provenance_path = FecDataView.get_run_dir_file_name(
                 "algorithm_timings.rpt")
+            cls._provenance_csv = FecDataView.get_run_dir_file_name(
+                "algorithm_timings.csv")
         else:
             cls._provenance_path = None
         cls._print_timings = get_config_bool(
@@ -95,23 +81,33 @@ class FecTimer(object):
         self._work = work
 
     def __enter__(self):
-        self._start_time = _now()
+        self._start_time = time.perf_counter_ns()
         return self
 
-    def _report(self, message):
+    def _report(self, message, act, time_taken, detail):
         if self._provenance_path is not None:
             with open(self._provenance_path, "a", encoding="utf-8") as p_file:
                 p_file.write(f"{message}\n")
+        if self._provenance_csv:
+            with csvopen(self._provenance_csv, self._CSV_HEADER,
+                         mode="a") as c_file:
+                c_file.writerow([
+                    self._category, self._algorithm, act, time_taken, detail])
         if self._print_timings:
             logger.info(message)
+
+    def _insert_timing(self, time_taken, skip_reason):
+        if self._category_id is not None:
+            with GlobalProvenance() as db:
+                db.insert_timing(
+                    self._category_id, self._algorithm, self._work,
+                    time_taken, skip_reason)
 
     def skip(self, reason):
         message = f"{self._algorithm} skipped as {reason}"
         time_taken = self._stop_timer()
-        with GlobalProvenance() as db:
-            db.insert_timing(self._category_id, self._algorithm, self._work,
-                             time_taken, reason)
-        self._report(message)
+        self._insert_timing(time_taken, reason)
+        self._report(message, "skip", "", reason)
 
     def skip_if_has_not_run(self):
         if self._simulator.has_ran:
@@ -156,11 +152,9 @@ class FecTimer(object):
 
     def error(self, reason):
         time_taken = self._stop_timer()
-        message = f"{self._algorithm} failed after {timedelta} as {reason}"
-        with GlobalProvenance() as db:
-            db.insert_timing(self._category_id, self._algorithm,
-                             self._work, time_taken, reason)
-        self._report(message)
+        message = f"{self._algorithm} failed after {time_taken} as {reason}"
+        self._insert_timing(time_taken, reason)
+        self._report(message, "fail", time_taken, reason)
 
     def _stop_timer(self):
         """
@@ -169,7 +163,7 @@ class FecTimer(object):
 
         :rtype: datetime.timedelta
         """
-        time_now = _now()
+        time_now = time.perf_counter_ns()
         diff = time_now - self._start_time
         self._start_time = None
         return _convert_to_timedelta(diff)
@@ -180,8 +174,10 @@ class FecTimer(object):
         time_taken = self._stop_timer()
         if exc_type is None:
             message = f"{self._algorithm} took {time_taken} "
+            act = "run"
             skip = None
         else:
+            act = "exception"
             try:
                 message = (f"{self._algorithm} exited with "
                            f"{exc_type.__name__} after {time_taken}")
@@ -191,10 +187,8 @@ class FecTimer(object):
                            f"after {time_taken}")
                 skip = f"Exception {ex}"
 
-        with GlobalProvenance() as db:
-            db.insert_timing(self._category_id, self._algorithm, self._work,
-                             time_taken, skip)
-        self._report(message)
+        self._insert_timing(time_taken, skip)
+        self._report(message, act, time_taken, exc_value if exc_value else "")
         return False
 
     @classmethod
@@ -204,7 +198,7 @@ class FecTimer(object):
 
         :return: Time the stop happened
         """
-        time_now = _now()
+        time_now = time.perf_counter_ns()
         if cls._category_id:
             with GlobalProvenance() as db:
                 diff = _convert_to_timedelta(time_now - cls._category_time)

--- a/spinn_front_end_common/utilities/base_database.py
+++ b/spinn_front_end_common/utilities/base_database.py
@@ -65,8 +65,8 @@ class BaseDatabase(SQLiteDB, AbstractContextManager):
 
     @classmethod
     def default_database_file(cls):
-        return os.path.join(FecDataView.get_run_dir_path(),
-                            f"data{FecDataView.get_reset_str()}.sqlite3")
+        return FecDataView.get_run_dir_file_name(
+            f"data{FecDataView.get_reset_str()}.sqlite3")
 
     def _get_core_id(self, x, y, p):
         """

--- a/spinn_front_end_common/utilities/database/database_writer.py
+++ b/spinn_front_end_common/utilities/database/database_writer.py
@@ -54,8 +54,7 @@ class DatabaseWriter(SQLiteDB):
     ]
 
     def __init__(self):
-        self._database_path = os.path.join(FecDataView.get_run_dir_path(),
-                                           DB_NAME)
+        self._database_path = FecDataView.get_run_dir_file_name(DB_NAME)
         init_sql_path = os.path.join(os.path.dirname(__file__), INIT_SQL)
 
         # delete any old database

--- a/spinn_front_end_common/utilities/report_functions/bit_field_compressor_report.py
+++ b/spinn_front_end_common/utilities/report_functions/bit_field_compressor_report.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import logging
-import os
 import sys
 from collections import defaultdict
 from spinn_utilities.log import FormatAdapter
@@ -52,7 +51,7 @@ def bitfield_compressor_report():
     :return: a summary, or `None` if the report file can't be written
     :rtype: BitFieldSummary
     """
-    file_name = os.path.join(FecDataView.get_run_dir_path(), _FILE_NAME)
+    file_name = FecDataView.get_run_dir_file_name(_FILE_NAME)
     try:
         with open(file_name, "w", encoding="utf-8") as f:
             _write_report(f)

--- a/spinn_front_end_common/utilities/report_functions/board_chip_report.py
+++ b/spinn_front_end_common/utilities/report_functions/board_chip_report.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from spinn_utilities.progress_bar import ProgressBar
 from spinn_front_end_common.data import FecDataView
 from spinn_machine import Router
@@ -26,16 +25,14 @@ def board_chip_report():
     """
     machine = FecDataView.get_machine()
     # create file path
-    directory_name = os.path.join(
-        FecDataView.get_run_dir_path(), AREA_CODE_REPORT_NAME)
+    directory_name = FecDataView.get_run_dir_file_name(AREA_CODE_REPORT_NAME)
     # create the progress bar for end users
-    progress_bar = ProgressBar(
-        len(machine.ethernet_connected_chips),
-        "Writing the board chip report")
-
-    # iterate over ethernet chips and then the chips on that board
-    with open(directory_name, "w", encoding="utf-8") as writer:
-        _write_report(writer, machine, progress_bar)
+    with ProgressBar(
+            len(machine.ethernet_connected_chips),
+            "Writing the board chip report") as progress_bar:
+        # iterate over ethernet chips and then the chips on that board
+        with open(directory_name, "w", encoding="utf-8") as writer:
+            _write_report(writer, machine, progress_bar)
 
 
 def _write_report(writer, machine, progress_bar):

--- a/spinn_front_end_common/utilities/report_functions/drift_report.py
+++ b/spinn_front_end_common/utilities/report_functions/drift_report.py
@@ -17,6 +17,7 @@ from spinn_utilities.progress_bar import ProgressBar
 from spinn_utilities.config_holder import get_config_bool
 from spinn_utilities.log import FormatAdapter
 from spinn_front_end_common.data import FecDataView
+from .utils import csvopen
 
 # The fixed point position for drift readings
 CLOCK_DRIFT_REPORT = "clock_drift.csv"
@@ -28,54 +29,75 @@ def drift_report():
     """
     A report on the clock drift as reported by each chip
     """
-    ethernet_only = get_config_bool(
-            "Reports", "drift_report_ethernet_only")
+    if get_config_bool("Reports", "drift_report_ethernet_only"):
+        _ethernet_drift_report()
+    else:
+        _all_drift_report()
+
+
+def _ethernet_drift_report():
+    """
+    A report on the clock drift as reported by each ethernet chip
+    """
     machine = FecDataView.get_machine()
-    eth_chips = machine.ethernet_connected_chips
-    n_chips = machine.n_chips
-    if ethernet_only:
-        n_chips = len(eth_chips)
+    txrx = FecDataView.get_transceiver()
 
     # create file path
-    directory_name = os.path.join(
-        FecDataView.get_run_dir_path(), CLOCK_DRIFT_REPORT)
+    file_name = FecDataView.get_run_dir_file_name(CLOCK_DRIFT_REPORT)
 
     # If the file is new, write a header
-    if not os.path.exists(directory_name):
-        with open(directory_name, "w", encoding="utf-8") as writer:
-            for eth_chip in eth_chips:
-                if ethernet_only:
-                    writer.write(f'"{eth_chip.x} {eth_chip.y}",')
-                else:
-                    for chip in machine.get_chips_by_ethernet(
-                            eth_chip.x, eth_chip.y):
-                        writer.write(f'"{chip.x} {chip.y}",')
-            writer.write("\n")
+    if not os.path.exists(file_name):
+        with csvopen(file_name, None) as writer:
+            writer.writerow(
+                f"{eth_chip.x} {eth_chip.y}"
+                for eth_chip in machine.ethernet_connected_chips)
 
     # create the progress bar for end users
-    progress = ProgressBar(n_chips, "Writing clock drift report")
+    progress = ProgressBar(
+        len(machine.ethernet_connected_chips), "Writing clock drift report")
 
     # iterate over ethernet chips and then the chips on that board
+    with csvopen(file_name, None, mode="a") as writer:
+        writer.writerow(
+            txrx.get_clock_drift(eth_chip.x, eth_chip.y)
+            for eth_chip in progress.over(machine.ethernet_connected_chips))
+
+
+def _all_drift_report():
+    """
+    A report on the clock drift as reported by all chips
+    """
+    machine = FecDataView.get_machine()
     txrx = FecDataView.get_transceiver()
-    with open(directory_name, "a", encoding="utf-8") as writer:
-        for eth_chip in eth_chips:
-            if ethernet_only:
-                drift = txrx.get_clock_drift(eth_chip.x, eth_chip.y)
-                writer.write(f'"{drift}",')
-                progress.update()
-            else:
-                last_drift = None
-                for chip in machine.get_chips_by_ethernet(
-                        eth_chip.x, eth_chip.y):
-                    drift = txrx.get_clock_drift(chip.x, chip.y)
-                    writer.write(f'"{drift}",')
-                    if last_drift is None:
-                        last_drift = drift
-                    elif last_drift != drift:
-                        logger.warning(
-                            "On board {}, chip {}, {} is not in sync"
-                            " ({} vs {})",
-                            eth_chip.ip_address, chip.x, chip.y,
-                            drift, last_drift)
-                    progress.update()
-        writer.write("\n")
+
+    # create file path
+    file_name = FecDataView.get_run_dir_file_name(CLOCK_DRIFT_REPORT)
+
+    # If the file is new, write a header
+    if not os.path.exists(file_name):
+        with csvopen(file_name, None) as writer:
+            writer.writerow(
+                f"{chip.x} {chip.y}"
+                for ec in machine.ethernet_connected_chips
+                for chip in machine.get_chips_by_ethernet(ec.x, ec.y))
+
+    # create the progress bar for end users
+    progress = ProgressBar(machine.n_chips, "Writing clock drift report")
+
+    # iterate over ethernet chips and then the chips on that board
+    with csvopen(file_name, None, mode="a") as writer:
+        for eth_chip in machine.ethernet_connected_chips:
+            drifts = []
+            last_drift = None
+            for chip in progress.over(machine.get_chips_by_ethernet(
+                    eth_chip.x, eth_chip.y), finish_at_end=False):
+                drift = txrx.get_clock_drift(chip.x, chip.y)
+                drifts.append(drift)
+                if last_drift is None:
+                    last_drift = drift
+                elif last_drift != drift:
+                    logger.warning(
+                        "On board {}, chip {}, {} is not in sync ({} vs {})",
+                        eth_chip.ip_address, chip.x, chip.y, drift, last_drift)
+            writer.writerow(drifts)
+        progress.end()

--- a/spinn_front_end_common/utilities/report_functions/energy_report.py
+++ b/spinn_front_end_common/utilities/report_functions/energy_report.py
@@ -14,7 +14,6 @@
 
 from collections import defaultdict
 import logging
-import os
 from spinn_utilities.config_holder import is_config_none
 from spinn_utilities.log import FormatAdapter
 from spinn_front_end_common.data import FecDataView
@@ -52,13 +51,13 @@ class EnergyReport(object):
         :param ~spinn_machine.Machine machine: the machine
         :param PowerUsed power_used:
         """
-        report_dir = FecDataView.get_run_dir_path()
-
         # detailed report path
-        detailed_report = os.path.join(report_dir, self._DETAILED_FILENAME)
+        detailed_report = FecDataView.get_run_dir_file_name(
+            self._DETAILED_FILENAME)
 
         # summary report path
-        summary_report = os.path.join(report_dir, self._SUMMARY_FILENAME)
+        summary_report = FecDataView.get_run_dir_file_name(
+            self._SUMMARY_FILENAME)
 
         # create detailed report
         with open(detailed_report, "w", encoding="utf-8") as f:

--- a/spinn_front_end_common/utilities/report_functions/fixed_route_from_machine_report.py
+++ b/spinn_front_end_common/utilities/report_functions/fixed_route_from_machine_report.py
@@ -12,66 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from spinn_utilities.progress_bar import ProgressBar
+from pacman.utilities.algorithm_utilities.routes_format import (
+    _reduce_route_value)
 from spinn_front_end_common.data import FecDataView
+from .utils import csvopen
 
 
 def fixed_route_from_machine_report():
     """
     Writes the fixed routes from the machine.
     """
-    file_name = os.path.join(
-        FecDataView.get_run_dir_path(), "fixed_route_routers")
+    file_name = FecDataView.get_run_dir_file_name("fixed_route_routers.csv")
     transceiver = FecDataView.get_transceiver()
     machine = FecDataView.get_machine()
+    link_labels = {0: 'E', 1: 'NE', 2: 'N', 3: 'W', 4: 'SW', 5: 'S'}
 
     progress = ProgressBar(machine.n_chips, "Writing fixed route report")
 
     app_id = FecDataView.get_app_id()
-    with open(file_name, "w", encoding="utf-8") as f:
-        f.write(" x    y       route         [cores][links]\n")
+    with csvopen(file_name, "X,Y,Route,Cores,Links") as f:
         for chip in progress.over(machine.chips):
             fixed_route = transceiver.read_fixed_route(
                 chip.x, chip.y, app_id)
-            f.write("{: <3s}:{: <3s} contains route {: <10s} {}\n".format(
-                str(chip.x), str(chip.y),
-                _reduce_route_value(
+            f.writerow([
+                chip.x, chip.y, _reduce_route_value(
                     fixed_route.processor_ids, fixed_route.link_ids),
-                _expand_route_value(
-                    fixed_route.processor_ids, fixed_route.link_ids)))
-
-
-def _reduce_route_value(processors_ids, link_ids):
-    value = 0
-    for link in link_ids:
-        value += 1 << link
-    for processor in processors_ids:
-        value += 1 << (processor + 6)
-    return str(value)
-
-
-def _expand_route_value(processors_ids, link_ids):
-    """
-    Convert a 32-bit route word into a string which lists the target
-    cores and links.
-    """
-
-    # Convert processor targets to readable values:
-    route_string = "["
-    separator = ""
-    for processor in processors_ids:
-        route_string += separator + str(processor)
-        separator = ", "
-
-    route_string += "] ["
-
-    # Convert link targets to readable values:
-    link_labels = {0: 'E', 1: 'NE', 2: 'N', 3: 'W', 4: 'SW', 5: 'S'}
-
-    separator = ""
-    for link in link_ids:
-        route_string += separator + link_labels[link]
-        separator = ", "
-    route_string += "]"
-    return route_string
+                ", ".join(
+                    str(processor)
+                    for processor in sorted(fixed_route.processor_ids)),
+                ", ".join(
+                    link_labels[link]
+                    for link in sorted(fixed_route.link_ids))])

--- a/spinn_front_end_common/utilities/report_functions/memory_map_on_host_chip_report.py
+++ b/spinn_front_end_common/utilities/report_functions/memory_map_on_host_chip_report.py
@@ -21,6 +21,7 @@ from spinn_front_end_common.data import FecDataView
 from spinn_front_end_common.interface.ds import DsSqlliteDatabase
 from spinn_front_end_common.utilities.constants import (
     BYTES_PER_WORD, MAX_MEM_REGIONS)
+from .utils import csvopen
 
 logger = FormatAdapter(logging.getLogger(__name__))
 _ONE_WORD = struct.Struct("<I")
@@ -32,8 +33,7 @@ def memory_map_on_host_chip_report():
     Report on memory usage. Creates a report that states where in SDRAM
     each region is (read from machine).
     """
-    directory_name = os.path.join(
-        FecDataView.get_run_dir_path(), "memory_map_reports")
+    directory_name = FecDataView.get_run_dir_file_name("memory_map_reports")
     if not os.path.exists(directory_name):
         os.makedirs(directory_name)
 
@@ -41,20 +41,23 @@ def memory_map_on_host_chip_report():
     with DsSqlliteDatabase() as ds_database:
         progress = ProgressBar(
             ds_database.get_n_ds_cores(), "Writing memory map reports")
-        for (x, y, p) in progress.over(ds_database.get_ds_cores()):
-            file_name = os.path.join(
-                directory_name, f"memory_map_from_processor_{x}_{y}_{p}.txt")
-            try:
-                with open(file_name, "w", encoding="utf-8") as f:
-                    _describe_mem_map(f, transceiver, x, y, p)
-            except IOError:
-                logger.exception(
-                    "Generate_placement_reports: "
-                    "Can't open file {} for writing.",
-                    file_name)
+        with csvopen(os.path.join(directory_name, "memory_map.csv"),
+                     "x,y,p,region,address") as csv:
+            for (x, y, p) in progress.over(ds_database.get_ds_cores()):
+                file_name = os.path.join(
+                    directory_name,
+                    f"memory_map_from_processor_{x}_{y}_{p}.txt")
+                try:
+                    with open(file_name, "w", encoding="utf-8") as f:
+                        _describe_mem_map(f, csv, transceiver, x, y, p)
+                except IOError:
+                    logger.exception(
+                        "Generate_placement_reports: "
+                        "Can't open file {} for writing.",
+                        file_name)
 
 
-def _describe_mem_map(f, txrx, x, y, p):
+def _describe_mem_map(f, csv, txrx, x, y, p):
     """
     :param ~spinnman.transceiver.Transceiver txrx:
     """
@@ -69,6 +72,7 @@ def _describe_mem_map(f, txrx, x, y, p):
         region_address, = _ONE_WORD.unpack_from(
             memmap_data, i * BYTES_PER_WORD)
         f.write(f"Region {i:d}:\n\t start address: 0x{region_address:x}\n\n")
+        csv.writerow([x, y, p, i, hex(region_address)])
 
 
 def _get_region_table_addr(txrx, x, y, p):

--- a/spinn_front_end_common/utilities/report_functions/memory_map_on_host_report.py
+++ b/spinn_front_end_common/utilities/report_functions/memory_map_on_host_report.py
@@ -13,31 +13,38 @@
 # limitations under the License.
 
 import logging
-import os
 from spinn_utilities.log import FormatAdapter
 from spinn_front_end_common.data import FecDataView
 from spinn_front_end_common.interface.ds import DsSqlliteDatabase
+from .utils import csvopen
 logger = FormatAdapter(logging.getLogger(__name__))
 
-_FOLDER_NAME = "memory_map_from_processor_to_address_space"
+_FILE_NAME = "memory_map_from_processor_to_address_space"
+_CSV_NAME = "memory_map.csv"
 
 
 def memory_map_on_host_report():
     """
     Report on memory usage.
     """
-    file_name = os.path.join(FecDataView.get_run_dir_path(), _FOLDER_NAME)
+    file_name = FecDataView.get_run_dir_file_name(_FILE_NAME)
+    csv_name = FecDataView.get_run_dir_file_name(_CSV_NAME)
     try:
-        with open(file_name, "w", encoding="utf-8") as f:
+        with open(file_name, "w", encoding="utf-8") as f, csvopen(
+                csv_name, "x,y,p,address,memory used,memory written") as csv:
             f.write("On host data specification executor\n")
             with DsSqlliteDatabase() as ds_database:
                 for xyp, start_address, memory_used, memory_written in \
-                        ds_database.get_info_for_cores():
+                        ds_database().get_info_for_cores():
                     f.write(
                         f"{xyp}: ('start_address': {start_address}, "
                         f"hex:{hex(start_address)}), "
                         f"'memory_used': {memory_used}, "
-                        f"'memory_written': {memory_written} \n")
+                        f"'memory_written': {memory_written}\n")
+                    x, y, p = xyp
+                    csv.writerow([
+                        x, y, p,
+                        hex(start_address), memory_used, memory_written])
     except IOError:
         logger.exception("Generate_placement_reports: Can't open file"
                          " {} for writing.", file_name)

--- a/spinn_front_end_common/utilities/report_functions/network_specification.py
+++ b/spinn_front_end_common/utilities/report_functions/network_specification.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import logging
-import os.path
 from spinn_utilities.log import FormatAdapter
 from pacman.model.graphs.application import ApplicationVertex
 from spinn_front_end_common.data import FecDataView
@@ -27,7 +26,7 @@ def network_specification():
     """
     Generate report on the user's network specification.
     """
-    filename = os.path.join(FecDataView.get_run_dir_path(), _FILENAME)
+    filename = FecDataView.get_run_dir_file_name(_FILENAME)
     try:
         with open(filename, "w", encoding="utf-8") as f:
             f.write("*** Vertices:\n")

--- a/spinn_front_end_common/utilities/report_functions/real_tags_report.py
+++ b/spinn_front_end_common/utilities/report_functions/real_tags_report.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from spinn_front_end_common.data import FecDataView
 
 _REPORT_FILENAME = "tags_on_machine.txt"
@@ -22,7 +21,7 @@ def tags_from_machine_report():
     """
     Describes what the tags actually present on the machine are.
     """
-    filename = os.path.join(FecDataView.get_run_dir_path(), _REPORT_FILENAME)
+    filename = FecDataView.get_run_dir_file_name(_REPORT_FILENAME)
     tags = _get_tags()
     with open(filename, "w", encoding="utf-8") as f:
         f.write("Tags actually read off the machine\n")

--- a/spinn_front_end_common/utilities/report_functions/reports.py
+++ b/spinn_front_end_common/utilities/report_functions/reports.py
@@ -11,10 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from __future__ import annotations
+from contextlib import contextmanager
+import csv
 import logging
 import os
 import time
+from spinn_utilities.ordered_set import OrderedSet
 from spinn_utilities.progress_bar import ProgressBar
 from spinn_utilities.log import FormatAdapter
 from spinn_machine import Router
@@ -32,20 +35,34 @@ _LINK_LABELS = {0: 'E', 1: 'NE', 2: 'N', 3: 'W', 4: 'SW', 5: 'S'}
 
 _C_ROUTING_TABLE_DIR = "compressed_routing_tables_generated"
 _COMPARED_FILENAME = "comparison_of_compressed_uncompressed_routing_tables.rpt"
+_COMPARED_CSV = "comparison_of_compressed_uncompressed_routing_tables.csv"
 _COMPRESSED_ROUTING_SUMMARY_FILENAME = "compressed_routing_summary.rpt"
+_COMPRESSED_ROUTING_SUMMARY_CSV = "compressed_routing_summary.csv"
 _PARTITIONING_FILENAME = "partitioned_by_vertex.rpt"
+_PARTITIONING_CSV = "partitioning.csv"
 _PLACEMENT_VTX_GRAPH_FILENAME = "placement_by_vertex_using_graph.rpt"
 _PLACEMENT_VTX_SIMPLE_FILENAME = "placement_by_vertex_without_graph.rpt"
 _PLACEMENT_CORE_GRAPH_FILENAME = "placement_by_core_using_graph.rpt"
+_PLACEMENTS_CSV = "placements.csv"
 _PLACEMENT_CORE_SIMPLE_FILENAME = "placement_by_core_without_graph.rpt"
 _ROUTING_FILENAME = "edge_routing_info.rpt"
 _ROUTING_SUMMARY_FILENAME = "routing_summary.rpt"
+_ROUTING_SUMMARY_CSV = "routing_summary.csv"
 _ROUTING_TABLE_DIR = "routing_tables_generated"
 _SDRAM_FILENAME = "chip_sdram_usage_by_core.rpt"
 _TAGS_FILENAME = "tags.rpt"
 _VIRTKEY_FILENAME = "virtual_key_space_information_report.rpt"
+_VIRTKEY_CSV = "virtual_key_space_information.csv"
 
 _LOWER_16_BITS = 0xFFFF
+
+
+@contextmanager
+def _csvopen(filename, header):
+    with open(filename, "w", encoding="utf-8", newline="") as f:
+        csv_writer = csv.writer(f)
+        csv_writer.writerow(header.split(","))
+        yield csv_writer
 
 
 def tag_allocator_report():
@@ -87,10 +104,13 @@ def router_summary_report():
     """
     file_name = os.path.join(
         FecDataView.get_run_dir_path(), _ROUTING_SUMMARY_FILENAME)
+    csv_name = os.path.join(
+        FecDataView.get_run_dir_path(), _ROUTING_SUMMARY_CSV)
     progress = ProgressBar(FecDataView.get_machine().n_chips,
                            "Generating Routing summary report")
     routing_tables = FecDataView.get_uncompressed()
-    return _do_router_summary_report(file_name, progress, routing_tables)
+    return _do_router_summary_report(
+        file_name, csv_name, progress, routing_tables)
 
 
 def router_compressed_summary_report(routing_tables):
@@ -103,12 +123,15 @@ def router_compressed_summary_report(routing_tables):
     """
     file_name = os.path.join(
         FecDataView.get_run_dir_path(), _COMPRESSED_ROUTING_SUMMARY_FILENAME)
+    csv_name = os.path.join(
+        FecDataView.get_run_dir_path(), _COMPRESSED_ROUTING_SUMMARY_CSV)
     progress = ProgressBar(FecDataView.get_machine().n_chips,
                            "Generating Routing summary report")
-    return _do_router_summary_report(file_name, progress, routing_tables)
+    return _do_router_summary_report(
+        file_name, csv_name, progress, routing_tables)
 
 
-def _do_router_summary_report(file_name, progress, routing_tables):
+def _do_router_summary_report(file_name, csv_name, progress, routing_tables):
     """
     :param str file_name:
     :param ~spinn_utilities.progress_bar.Progress progress:
@@ -119,7 +142,8 @@ def _do_router_summary_report(file_name, progress, routing_tables):
     time_date_string = time.strftime("%c")
     convert = Router.convert_routing_table_entry_to_spinnaker_route
     try:
-        with open(file_name, "w", encoding="utf-8") as f:
+        with open(file_name, "w", encoding="utf-8") as f, _csvopen(
+                csv_name, "X,Y,Entries,Defaultable,Unique Routes") as csvf:
             f.write("        Routing Summary Report\n")
             f.write("        ======================\n\n")
             f.write(f"Generated: {time_date_string} "
@@ -147,6 +171,9 @@ def _do_router_summary_report(file_name, progress, routing_tables):
                         f"{defaultable} are defaultable and {link_only} link "
                         f"only with {len(spinnaker_routes)} unique spinnaker "
                         "routes\n")
+                    csvf.writerow([
+                        x, y, entries, defaultable, link_only,
+                        len(spinnaker_routes)])
                     total_entries += entries
                     max_entries = max(max_entries, entries)
                     max_none_defaultable = max(
@@ -228,9 +255,11 @@ def partitioner_report():
     # For each vertex, describe its core mapping.
     file_name = os.path.join(
         FecDataView.get_run_dir_path(), _PARTITIONING_FILENAME)
+    csv_file = os.path.join(FecDataView.get_run_dir_path(), _PARTITIONING_CSV)
     time_date_string = time.strftime("%c")
     try:
-        with open(file_name, "w", encoding="utf-8") as f:
+        with open(file_name, "w", encoding="utf-8") as f, _csvopen(
+                csv_file, "Vertex,Model,N Atoms,Slice,Partition") as csvf:
             progress = ProgressBar(FecDataView.get_n_vertices(),
                                    "Generating partitioner report")
 
@@ -240,14 +269,14 @@ def partitioner_report():
                     f"'{FecDataView.get_ipaddress()}'\n\n")
 
             for vertex in progress.over(FecDataView.iterate_vertices()):
-                _write_one_vertex_partition(f, vertex)
+                _write_one_vertex_partition(f, csvf, vertex)
     except IOError:
         logger.exception(
             "Generate partitioning reports: Can't open file {} for writing.",
             file_name)
 
 
-def _write_one_vertex_partition(f, vertex):
+def _write_one_vertex_partition(f, csv_writer, vertex):
     """
     :param ~io.FileIO f:
     :param ~pacman.model.graphs.application.ApplicationVertex vertex:
@@ -267,6 +296,8 @@ def _write_one_vertex_partition(f, vertex):
                               key=lambda x: x.vertex_slice.lo_atom)
     for sv in machine_vertices:
         f.write(f"  Slice {sv.vertex_slice}    Vertex {sv.label}\n")
+        csv_writer.writerow([
+            vertex_name, vertex_model, num_atoms, sv.vertex_slice, sv.label])
     f.write("\n")
 
 
@@ -343,10 +374,14 @@ def placement_report_with_application_graph_by_core():
     # For each core, display what is held on it.
     file_name = os.path.join(
         FecDataView.get_run_dir_path(), _PLACEMENT_CORE_GRAPH_FILENAME)
+    csv_name = os.path.join(
+        FecDataView.get_run_dir_path(), _PLACEMENTS_CSV)
     time_date_string = time.strftime("%c")
     try:
         machine = FecDataView.get_machine()
-        with open(file_name, "w", encoding="utf-8") as f:
+        with open(file_name, "w", encoding="utf-8") as f, _csvopen(
+                csv_name, "X,Y,Processor,Kind,Label,Atoms,Slice,Model,"
+                "Fixed Memory,Per-Timestep Memory") as csvf:
             progress = ProgressBar(machine.n_chips,
                                    "Generating placement by core report")
 
@@ -356,18 +391,17 @@ def placement_report_with_application_graph_by_core():
                     f"for target machine '{FecDataView.get_ipaddress()}'\n\n")
 
             for chip in progress.over(machine.chips):
-                _write_one_chip_application_placement(f, chip)
+                _write_one_chip_application_placement(f, csvf, chip)
     except IOError:
         logger.exception(
             "Generate_placement_reports: Can't open file {} for writing.",
             file_name)
 
 
-def _write_one_chip_application_placement(f, chip):
+def _write_one_chip_application_placement(f, csv_writer, chip):
     """
     :param ~io.FileIO f:
     :param ~spinn_machine.Chip chip:
-    :param ~pacman.model.placements.Placements placements:
     """
     written_header = False
     total_sdram = None
@@ -379,6 +413,7 @@ def _write_one_chip_application_placement(f, chip):
         pro_id = placement.p
         vertex = placement.vertex
         app_vertex = vertex.app_vertex
+        sdram = vertex.sdram_required
         if app_vertex is not None:
             vertex_label = app_vertex.label
             vertex_model = app_vertex.__class__.__name__
@@ -388,13 +423,20 @@ def _write_one_chip_application_placement(f, chip):
             f.write(f"              Slice: {vertex.vertex_slice}")
             f.write(f"  {vertex.label}\n")
             f.write("              Model: {}\n".format(vertex_model))
+            csv_writer.writerow([
+                chip.x, chip.y, pro_id, "Application", vertex_label,
+                vertex_atoms, vertex.vertex_slice, vertex_model,
+                sdram.fixed, sdram.per_timestep])
         else:
             f.write("  Processor {}: System Vertex: '{}'\n".format(
                 pro_id, vertex.label))
             f.write("              Model: {}\n".format(
                 vertex.__class__.__name__))
+            csv_writer.writerow([
+                chip.x, chip.y, pro_id, "System", vertex.label,
+                "", "", vertex.__class__.__name__,
+                sdram.fixed, sdram.per_timestep])
 
-        sdram = vertex.sdram_required
         f.write("              SDRAM required: {}; {} per timestep\n\n"
                 .format(sdram.fixed, sdram.per_timestep))
         if total_sdram is None:
@@ -491,24 +533,28 @@ def routing_info_report(extra_allocations):
     vertex.
     """
     file_name = os.path.join(FecDataView.get_run_dir_path(), _VIRTKEY_FILENAME)
+    csv_name = os.path.join(FecDataView.get_run_dir_path(), _VIRTKEY_CSV)
     routing_infos = FecDataView.get_routing_infos()
     try:
-        with open(file_name, "w", encoding="utf-8") as f:
-            vertex_partitions = set(
+        with open(file_name, "w", encoding="utf-8") as f, _csvopen(
+                csv_name, "Vertex,Partition,Overall Routing Info,"
+                "Machine Vertex,Slice,Routing Info") as csvf:
+            vertex_partitions = OrderedSet(
                 (p.pre_vertex, p.identifier)
                 for p in FecDataView.iterate_partitions())
             vertex_partitions.update(extra_allocations)
-            progress = ProgressBar(len(vertex_partitions),
-                                   "Generating Routing info report")
-            for pre_vert, part_id in progress.over(vertex_partitions):
-                _write_vertex_virtual_keys(f, pre_vert, part_id, routing_infos)
-            progress.end()
+            with ProgressBar(len(vertex_partitions),
+                             "Generating Routing info report") as progress:
+                for pre_vert, part_id in progress.over(vertex_partitions):
+                    _write_vertex_virtual_keys(
+                        f, csvf, pre_vert, part_id, routing_infos)
     except IOError:
         logger.exception("generate virtual key space information report: "
                          "Can't open file {} for writing.", file_name)
 
 
-def _write_vertex_virtual_keys(f, pre_vertex, part_id, routing_infos):
+def _write_vertex_virtual_keys(
+        f, csv_writer, pre_vertex, part_id, routing_infos):
     """
     :param ~io.FileIO f:
     :param ~pacman.model.graphs.application.ApplicationVertex pre_vertex:
@@ -531,6 +577,9 @@ def _write_vertex_virtual_keys(f, pre_vertex, part_id, routing_infos):
                 f.write("    Machine Vertex: {}, Slice: {}, Routing Info: {}\n"
                         .format(m_vertex, m_vertex.vertex_slice,
                                 r_info.key_and_mask))
+                csv_writer.writerow([
+                    pre_vertex, part_id, rinfo.key_and_mask,
+                    m_vertex, m_vertex.vertex_slice, r_info.key_and_mask])
 
 
 def router_report_from_router_tables():
@@ -573,11 +622,13 @@ def generate_routing_table(routing_table, top_level_folder):
         ~pacman.model.routing_tables.AbstractMulticastRoutingTable
     :param str top_level_folder:
     """
-    file_name = "routing_table_{}_{}.rpt".format(
-        routing_table.x, routing_table.y)
+    file_name = f"routing_table_{routing_table.x}_{routing_table.y}.rpt"
+    csv_name = f"routing_table_{routing_table.x}_{routing_table.y}.csv"
     file_path = os.path.join(top_level_folder, file_name)
+    csv_path = os.path.join(top_level_folder, csv_name)
     try:
-        with open(file_path, "w", encoding="utf-8") as f:
+        with open(file_path, "w", encoding="utf-8") as f, _csvopen(
+                csv_path, "index,key,mask,route,default,cores,links") as csvf:
             f.write("Router contains {} entries\n".format(
                 routing_table.number_of_entries))
 
@@ -588,6 +639,8 @@ def generate_routing_table(routing_table, top_level_folder):
                     "", "", "", "", "", ""))
             line_format = "{: >5d} {}\n"
 
+            link_labels = {0: 'E', 1: 'NE', 2: 'N', 3: 'W', 4: 'SW', 5: 'S'}
+
             entry_count = 0
             n_defaultable = 0
             for entry in routing_table.multicast_routing_entries:
@@ -597,6 +650,12 @@ def generate_routing_table(routing_table, top_level_folder):
                 if entry.defaultable:
                     n_defaultable += 1
                 f.write(entry_str)
+
+                csvf.writerow([
+                    index, hex(entry.routing_entry_key), hex(entry.mask),
+                    hex(entry.spinnaker_route), str(entry.defaultable),
+                    [str(pid) for pid in sorted(entry.processor_ids)],
+                    [link_labels[link] for link in sorted(entry.link_ids)]])
             f.write(f"{n_defaultable} Defaultable entries\n")
     except IOError:
         logger.exception("Generate_placement_reports: Can't open file"
@@ -628,8 +687,10 @@ def generate_comparison_router_report(compressed_routing_tables):
     routing_tables = FecDataView.get_uncompressed().routing_tables
     file_name = os.path.join(
         FecDataView.get_run_dir_path(), _COMPARED_FILENAME)
+    csv_file = os.path.join(FecDataView.get_run_dir_path(), _COMPARED_CSV)
     try:
-        with open(file_name, "w", encoding="utf-8") as f:
+        with open(file_name, "w", encoding="utf-8") as f, _csvopen(
+                csv_file, "x,y,uncompressed,compressed,ratio") as csvf:
             progress = ProgressBar(
                 routing_tables,
                 "Generating comparison of router table report")
@@ -642,6 +703,10 @@ def generate_comparison_router_report(compressed_routing_tables):
                 y = table.y
                 compressed_table = compressed_routing_tables.\
                     get_routing_table_for_chip(x, y)
+                if compressed_table is None:
+                    f.write(f"No compressed table at {x}:{y}; not compared!\n")
+                    csvf.writerow([x, y, "", "", ""])
+                    continue
                 n_entries_uncompressed = table.number_of_entries
                 total_uncompressed += n_entries_uncompressed
                 n_entries_compressed = compressed_table.number_of_entries
@@ -653,9 +718,12 @@ def generate_comparison_router_report(compressed_routing_tables):
                     f"{n_entries_uncompressed} entries whereas compressed "
                     f"table has {n_entries_compressed} entries. This is a "
                     f"decrease of {ratio}%\n")
+                csvf.writerow([
+                    x, y, n_entries_uncompressed, n_entries_compressed, ratio])
                 if max_compressed < n_entries_compressed:
                     max_compressed = n_entries_compressed
                     uncompressed_for_max = n_entries_uncompressed
+
             if total_uncompressed > 0:
                 ratio = _compression_ratio(
                     total_uncompressed, total_compressed)

--- a/spinn_front_end_common/utilities/report_functions/reports.py
+++ b/spinn_front_end_common/utilities/report_functions/reports.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
-from contextlib import contextmanager
-import csv
+
 import logging
 import os
 import time
@@ -28,6 +26,7 @@ from pacman.utilities.algorithm_utilities.routing_algorithm_utilities import (
 from pacman.utilities.algorithm_utilities.routes_format import format_route
 from spinn_front_end_common.data import FecDataView
 from .router_summary import RouterSummary
+from .utils import csvopen
 
 logger = FormatAdapter(logging.getLogger(__name__))
 
@@ -51,18 +50,11 @@ _ROUTING_SUMMARY_CSV = "routing_summary.csv"
 _ROUTING_TABLE_DIR = "routing_tables_generated"
 _SDRAM_FILENAME = "chip_sdram_usage_by_core.rpt"
 _TAGS_FILENAME = "tags.rpt"
+_TAGS_CSV = "tags.csv"
 _VIRTKEY_FILENAME = "virtual_key_space_information_report.rpt"
 _VIRTKEY_CSV = "virtual_key_space_information.csv"
 
 _LOWER_16_BITS = 0xFFFF
-
-
-@contextmanager
-def _csvopen(filename, header):
-    with open(filename, "w", encoding="utf-8", newline="") as f:
-        csv_writer = csv.writer(f)
-        csv_writer.writerow(header.split(","))
-        yield csv_writer
 
 
 def tag_allocator_report():
@@ -71,17 +63,31 @@ def tag_allocator_report():
     simulation.
     """
     tag_infos = FecDataView.get_tags()
-    file_name = os.path.join(FecDataView.get_run_dir_path(), _TAGS_FILENAME)
+    file_name = FecDataView.get_run_dir_file_name(_TAGS_FILENAME)
+    csv_file = FecDataView.get_run_dir_file_name(_TAGS_CSV)
     try:
-        with open(file_name, "w", encoding="utf-8") as f:
+        with open(file_name, "w", encoding="utf-8") as f, csvopen(
+                csv_file, "Type,Board Address,X,Y,P,Tag ID,UDP Port,"
+                "Outbound IP Address,Strip SDP Header,Traffic ID,"
+                "Target SDP Port") as csvf:
             progress = ProgressBar(
                 len(list(tag_infos.ip_tags)) +
                 len(list(tag_infos.reverse_ip_tags)),
                 "Reporting Tags")
             for ip_tag in progress.over(tag_infos.ip_tags, False):
                 f.write(str(ip_tag) + "\n")
+                csvf.writerow([
+                    "Forward", ip_tag.board_address,
+                    ip_tag.destination_x, ip_tag.destination_y, "",
+                    ip_tag.tag, ip_tag.port, ip_tag.ip_address,
+                    ip_tag.strip_sdp, ip_tag.traffic_identifier, ""])
             for reverse_ip_tag in progress.over(tag_infos.reverse_ip_tags):
                 f.write(str(reverse_ip_tag) + "\n")
+                csvf.writerow([
+                    "Reverse", reverse_ip_tag.board_address,
+                    reverse_ip_tag.destination_x, reverse_ip_tag.destination_y,
+                    reverse_ip_tag.destination_p, reverse_ip_tag.tag,
+                    reverse_ip_tag.port, "", "", "", reverse_ip_tag.sdp_port])
     except IOError:
         logger.error(
             "Generate tag report: Can't open file {} for writing.", file_name)
@@ -102,10 +108,8 @@ def router_summary_report():
 
     :rtype: RouterSummary
     """
-    file_name = os.path.join(
-        FecDataView.get_run_dir_path(), _ROUTING_SUMMARY_FILENAME)
-    csv_name = os.path.join(
-        FecDataView.get_run_dir_path(), _ROUTING_SUMMARY_CSV)
+    file_name = FecDataView.get_run_dir_file_name(_ROUTING_SUMMARY_FILENAME)
+    csv_name = FecDataView.get_run_dir_file_name(_ROUTING_SUMMARY_CSV)
     progress = ProgressBar(FecDataView.get_machine().n_chips,
                            "Generating Routing summary report")
     routing_tables = FecDataView.get_uncompressed()
@@ -121,10 +125,10 @@ def router_compressed_summary_report(routing_tables):
         The in-operation COMPRESSED routing tables.
     :rtype: RouterSummary
     """
-    file_name = os.path.join(
-        FecDataView.get_run_dir_path(), _COMPRESSED_ROUTING_SUMMARY_FILENAME)
-    csv_name = os.path.join(
-        FecDataView.get_run_dir_path(), _COMPRESSED_ROUTING_SUMMARY_CSV)
+    file_name = FecDataView.get_run_dir_file_name(
+        _COMPRESSED_ROUTING_SUMMARY_FILENAME)
+    csv_name = FecDataView.get_run_dir_file_name(
+        _COMPRESSED_ROUTING_SUMMARY_CSV)
     progress = ProgressBar(FecDataView.get_machine().n_chips,
                            "Generating Routing summary report")
     return _do_router_summary_report(
@@ -142,7 +146,7 @@ def _do_router_summary_report(file_name, csv_name, progress, routing_tables):
     time_date_string = time.strftime("%c")
     convert = Router.convert_routing_table_entry_to_spinnaker_route
     try:
-        with open(file_name, "w", encoding="utf-8") as f, _csvopen(
+        with open(file_name, "w", encoding="utf-8") as f, csvopen(
                 csv_name, "X,Y,Entries,Defaultable,Unique Routes") as csvf:
             f.write("        Routing Summary Report\n")
             f.write("        ======================\n\n")
@@ -201,7 +205,7 @@ def router_report_from_paths():
     """
     Generates a text file of routing paths.
     """
-    file_name = os.path.join(FecDataView.get_run_dir_path(), _ROUTING_FILENAME)
+    file_name = FecDataView.get_run_dir_file_name(_ROUTING_FILENAME)
     time_date_string = time.strftime("%c")
     partitions = get_app_partitions()
     try:
@@ -253,12 +257,11 @@ def partitioner_report():
     """
     # Cycle through all vertices, and for each cycle through its vertices.
     # For each vertex, describe its core mapping.
-    file_name = os.path.join(
-        FecDataView.get_run_dir_path(), _PARTITIONING_FILENAME)
-    csv_file = os.path.join(FecDataView.get_run_dir_path(), _PARTITIONING_CSV)
+    file_name = FecDataView.get_run_dir_file_name(_PARTITIONING_FILENAME)
+    csv_file = FecDataView.get_run_dir_file_name(_PARTITIONING_CSV)
     time_date_string = time.strftime("%c")
     try:
-        with open(file_name, "w", encoding="utf-8") as f, _csvopen(
+        with open(file_name, "w", encoding="utf-8") as f, csvopen(
                 csv_file, "Vertex,Model,N Atoms,Slice,Partition") as csvf:
             progress = ProgressBar(FecDataView.get_n_vertices(),
                                    "Generating partitioner report")
@@ -307,8 +310,8 @@ def placement_report_with_application_graph_by_vertex():
     """
     # Cycle through all vertices, and for each cycle through its vertices.
     # For each vertex, describe its core mapping.
-    file_name = os.path.join(
-        FecDataView.get_run_dir_path(), _PLACEMENT_VTX_GRAPH_FILENAME)
+    file_name = FecDataView.get_run_dir_file_name(
+        _PLACEMENT_VTX_GRAPH_FILENAME)
     time_date_string = time.strftime("%c")
     try:
         with open(file_name, "w", encoding="utf-8") as f:
@@ -372,14 +375,13 @@ def placement_report_with_application_graph_by_core():
     # File 2: Placement by core.
     # Cycle through all chips and by all cores within each chip.
     # For each core, display what is held on it.
-    file_name = os.path.join(
-        FecDataView.get_run_dir_path(), _PLACEMENT_CORE_GRAPH_FILENAME)
-    csv_name = os.path.join(
-        FecDataView.get_run_dir_path(), _PLACEMENTS_CSV)
+    file_name = FecDataView.get_run_dir_file_name(
+        _PLACEMENT_CORE_GRAPH_FILENAME)
+    csv_name = FecDataView.get_run_dir_file_name(_PLACEMENTS_CSV)
     time_date_string = time.strftime("%c")
     try:
         machine = FecDataView.get_machine()
-        with open(file_name, "w", encoding="utf-8") as f, _csvopen(
+        with open(file_name, "w", encoding="utf-8") as f, csvopen(
                 csv_name, "X,Y,Processor,Kind,Label,Atoms,Slice,Model,"
                 "Fixed Memory,Per-Timestep Memory") as csvf:
             progress = ProgressBar(machine.n_chips,
@@ -454,7 +456,7 @@ def sdram_usage_report_per_chip():
     """
     Reports the SDRAM used per chip.
     """
-    file_name = os.path.join(FecDataView.get_run_dir_path(), _SDRAM_FILENAME)
+    file_name = FecDataView.get_run_dir_file_name(_SDRAM_FILENAME)
     n_placements = FecDataView.get_n_placements()
     time_date_string = time.strftime("%c")
     progress = ProgressBar(
@@ -532,11 +534,11 @@ def routing_info_report(extra_allocations):
     Generates a report which says which keys is being allocated to each
     vertex.
     """
-    file_name = os.path.join(FecDataView.get_run_dir_path(), _VIRTKEY_FILENAME)
-    csv_name = os.path.join(FecDataView.get_run_dir_path(), _VIRTKEY_CSV)
+    file_name = FecDataView.get_run_dir_file_name(_VIRTKEY_FILENAME)
+    csv_name = FecDataView.get_run_dir_file_name(_VIRTKEY_CSV)
     routing_infos = FecDataView.get_routing_infos()
     try:
-        with open(file_name, "w", encoding="utf-8") as f, _csvopen(
+        with open(file_name, "w", encoding="utf-8") as f, csvopen(
                 csv_name, "Vertex,Partition,Overall Routing Info,"
                 "Machine Vertex,Slice,Routing Info") as csvf:
             vertex_partitions = OrderedSet(
@@ -586,8 +588,7 @@ def router_report_from_router_tables():
     """
     Report the uncompressed routing tables.
     """
-    top_level_folder = os.path.join(
-        FecDataView.get_run_dir_path(), _ROUTING_TABLE_DIR)
+    top_level_folder = FecDataView.get_run_dir_file_name(_ROUTING_TABLE_DIR)
     routing_tables = FecDataView.get_uncompressed().routing_tables
     if not os.path.exists(top_level_folder):
         os.mkdir(top_level_folder)
@@ -604,8 +605,7 @@ def router_report_from_compressed_router_tables(routing_tables):
     :param ~pacman.model.routing_tables.MulticastRoutingTables routing_tables:
         the compressed routing tables
     """
-    top_level_folder = os.path.join(
-        FecDataView.get_run_dir_path(), _C_ROUTING_TABLE_DIR)
+    top_level_folder = FecDataView.get_run_dir_file_name(_C_ROUTING_TABLE_DIR)
     if not os.path.exists(top_level_folder):
         os.mkdir(top_level_folder)
     progress = ProgressBar(routing_tables.routing_tables,
@@ -627,7 +627,7 @@ def generate_routing_table(routing_table, top_level_folder):
     file_path = os.path.join(top_level_folder, file_name)
     csv_path = os.path.join(top_level_folder, csv_name)
     try:
-        with open(file_path, "w", encoding="utf-8") as f, _csvopen(
+        with open(file_path, "w", encoding="utf-8") as f, csvopen(
                 csv_path, "index,key,mask,route,default,cores,links") as csvf:
             f.write("Router contains {} entries\n".format(
                 routing_table.number_of_entries))
@@ -685,11 +685,10 @@ def generate_comparison_router_report(compressed_routing_tables):
         ~pacman.model.routing_tables.MulticastRoutingTables
     """
     routing_tables = FecDataView.get_uncompressed().routing_tables
-    file_name = os.path.join(
-        FecDataView.get_run_dir_path(), _COMPARED_FILENAME)
-    csv_file = os.path.join(FecDataView.get_run_dir_path(), _COMPARED_CSV)
+    file_name = FecDataView.get_run_dir_file_name(_COMPARED_FILENAME)
+    csv_file = FecDataView.get_run_dir_file_name(_COMPARED_CSV)
     try:
-        with open(file_name, "w", encoding="utf-8") as f, _csvopen(
+        with open(file_name, "w", encoding="utf-8") as f, csvopen(
                 csv_file, "x,y,uncompressed,compressed,ratio") as csvf:
             progress = ProgressBar(
                 routing_tables,

--- a/spinn_front_end_common/utilities/report_functions/routing_compression_report.py
+++ b/spinn_front_end_common/utilities/report_functions/routing_compression_report.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import logging
-import os
 from spinn_utilities.log import FormatAdapter
 from spinn_utilities.progress_bar import ProgressBar
 from pacman.operations.router_compressors.routing_compression_checker import (
@@ -36,8 +35,7 @@ def generate_routing_compression_checker_report(
     :type compressed_routing_tables:
         ~pacman.model.routing_tables.MulticastRoutingTables
     """
-    file_name = os.path.join(
-        FecDataView.get_run_dir_path(),
+    file_name = FecDataView.get_run_dir_file_name(
         "routing_compression_checker_report.rpt")
 
     try:

--- a/spinn_front_end_common/utilities/report_functions/routing_table_from_machine_report.py
+++ b/spinn_front_end_common/utilities/report_functions/routing_table_from_machine_report.py
@@ -35,7 +35,7 @@ def routing_table_from_machine_report(routing_tables):
     tables = list(routing_tables.routing_tables)
     progress = ProgressBar(tables, "Reading Routing Tables from Machine")
 
-    folder_name = os.path.join(FecDataView.get_run_dir_path(), _FOLDER_NAME)
+    folder_name = FecDataView.get_run_dir_file_name(_FOLDER_NAME)
     os.mkdir(folder_name)
 
     # generate a file for every multicast entry

--- a/spinn_front_end_common/utilities/report_functions/utils.py
+++ b/spinn_front_end_common/utilities/report_functions/utils.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2023 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import contextmanager
+import csv
+
+
+@contextmanager
+def csvopen(filename, header, *, mode="w"):
+    """
+    Open a CSV file for writing, write a header row (comma-separated string),
+    and yield a writer for the CSV rows.
+
+    Intended to be used like this::
+
+        with csvopen("abc.csv", "A,B,C") as csv:
+            csv.writerow([1,2,3])
+
+    .. note::
+        This handles all the complexities of quoting so you can ignore them.
+    """
+    with open(filename, mode, encoding="utf-8", newline="") as f:
+        at_start = f.tell() == 0
+        csv_writer = csv.writer(f)
+        if header is not None and at_start:
+            csv_writer.writerow(header.split(","))
+        yield csv_writer

--- a/spinn_front_end_common/utilities/utility_calls.py
+++ b/spinn_front_end_common/utilities/utility_calls.py
@@ -93,8 +93,7 @@ def get_report_writer(processor_chip_x, processor_chip_y, processor_id,
     dir_name = _RPT_DIR
     if use_run_number:
         dir_name += str(FecDataView.get_run_number())
-    new_report_directory = os.path.join(
-        FecDataView.get_run_dir_path(), dir_name)
+    new_report_directory = FecDataView.get_run_dir_file_name(dir_name)
     _mkdir(new_report_directory)
     name = os.path.join(new_report_directory, _RPT_TMPL.format(
         processor_chip_x, processor_chip_y, processor_id))

--- a/spinn_front_end_common/utility_models/data_speed_up_packet_gatherer_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/data_speed_up_packet_gatherer_machine_vertex.py
@@ -304,9 +304,10 @@ class DataSpeedUpPacketGatherMachineVertex(
 
         # create report if it doesn't already exist
 
-        dir_path = FecDataView.get_run_dir_path()
-        self._out_report_path = os.path.join(dir_path, self.OUT_REPORT_NAME)
-        self._in_report_path = os.path.join(dir_path, self.IN_REPORT_NAME)
+        self._out_report_path = FecDataView.get_run_dir_file_name(
+            self.OUT_REPORT_NAME)
+        self._in_report_path = FecDataView.get_run_dir_file_name(
+            self.IN_REPORT_NAME)
 
         # Stored reinjection status for resetting timeouts
         self._last_status = None

--- a/spinn_front_end_common/utility_models/data_speed_up_packet_gatherer_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/data_speed_up_packet_gatherer_machine_vertex.py
@@ -43,6 +43,7 @@ from spinn_front_end_common.utilities.exceptions import SpinnFrontEndException
 from spinn_front_end_common.utilities.utility_objs.\
     extra_monitor_scp_processes import (
         SetRouterTimeoutProcess, ClearQueueProcess)
+from spinn_front_end_common.utilities.report_functions.utils import csvopen
 
 log = FormatAdapter(logging.getLogger(__name__))
 
@@ -240,9 +241,9 @@ class DataSpeedUpPacketGatherMachineVertex(
     _TRANSMISSION_THROTTLE_TIME = 0.000001
 
     #: report name for tracking used routers
-    OUT_REPORT_NAME = "routers_used_in_speed_up_process.rpt"
+    OUT_REPORT_NAME = "routers_used_in_speed_up_process.csv"
     #: report name for tracking performance gains
-    IN_REPORT_NAME = "speeds_gained_in_speed_up_process.rpt"
+    IN_REPORT_NAME = "speeds_gained_in_speed_up_process.csv"
 
     # the end flag is set when the high bit of the sequence number word is set
     _LAST_MESSAGE_FLAG_BIT_MASK = 0x80000000
@@ -481,14 +482,11 @@ class DataSpeedUpPacketGatherMachineVertex(
             the set of missing sequence numbers per data transmission attempt
         """
         if not os.path.isfile(self._in_report_path):
-            with open(self._in_report_path, "w", encoding="utf-8") as writer:
-                writer.write(
-                    "x\t\t y\t\t SDRAM address\t\t size in bytes\t\t\t"
-                    " time took \t\t\t Mb/s \t\t\t missing sequence numbers\n")
-                writer.write(
-                    "------------------------------------------------"
-                    "------------------------------------------------"
-                    "-------------------------------------------------\n")
+            COLUMNS = (
+                "x,y,SDRAM address,size (bytes),time,data rate (Mb/s),"
+                "missing sequence numbers")
+            with csvopen(self._in_report_path, COLUMNS):
+                pass
 
         time_took_ms = float(time_diff.microseconds +
                              time_diff.total_seconds() * 1000000)
@@ -498,10 +496,10 @@ class DataSpeedUpPacketGatherMachineVertex(
         else:
             mbs = megabits / (float(time_took_ms) / 100000.0)
 
-        with open(self._in_report_path, "a", encoding="utf-8") as writer:
-            writer.write(
-                f"{x}\t\t {y}\t\t {address_written_to}\t\t {data_size}\t\t"
-                f"\t\t {time_took_ms}\t\t\t {mbs}\t\t {missing_seq_nums}\n")
+        with csvopen(self._in_report_path, None, mode="a") as writer:
+            writer.writerow([
+                x, y, hex(address_written_to), data_size, time_took_ms, mbs,
+                missing_seq_nums])
 
     def send_data_into_spinnaker(
             self, x, y, base_address, data, n_bytes=None, offset=0,
@@ -1025,10 +1023,7 @@ class DataSpeedUpPacketGatherMachineVertex(
         """
         # create report elements
         if get_config_bool("Reports", "write_data_speed_up_reports"):
-            routers_been_in_use = self._determine_which_routers_were_used(
-                placement)
-            self._write_routers_used_into_report(
-                routers_been_in_use, placement)
+            self._write_routers_used_into_report(placement)
 
         start = float(time.time())
         # if asked for no data, just return a empty byte array
@@ -1133,7 +1128,7 @@ class DataSpeedUpPacketGatherMachineVertex(
         return lost_seq_nums
 
     @staticmethod
-    def _determine_which_routers_were_used(placement):
+    def __describe_fixed_route_from(placement):
         """
         Traverse the fixed route paths from a given location to its
         destination. Used for determining which routers were used.
@@ -1159,19 +1154,16 @@ class DataSpeedUpPacketGatherMachineVertex(
             entry = fixed_routes[chip_x, chip_y]
         return routers
 
-    def _write_routers_used_into_report(self, routers_been_in_use, placement):
+    def _write_routers_used_into_report(self, placement):
         """
         Write the used routers into a report.
 
-        :param str report_path: the path to the report file
-        :param list(tuple(int,int)) routers_been_in_use:
-            the routers been in use
         :param ~.Placement placement: the first placement used
         """
-        with open(self._out_report_path, "a", encoding="utf-8") as writer:
-            writer.write(
-                f"[{placement.x}:{placement.y}:{placement.p}] "
-                f"= {routers_been_in_use}\n")
+        routers_used = self.__describe_fixed_route_from(placement)
+        with csvopen(
+                self._out_report_path, "x,y,p,routers used", mode="a") as f:
+            f.writerow([placement.x, placement.y, placement.p, routers_used])
 
     def _calculate_missing_seq_nums(self, seq_nums):
         """


### PR DESCRIPTION
A version of the `csv-reports` branch that isn't tangled up in #1062 (sorry about that! 😊)

This PR is mainly about making more extensive use of Python's CSV writing module. The _aim_ of that is to make more of our reported information easily readable from within Jupyter; that already renders CSV files much more nicely than plain text and many of our reports were distinctly tabular. The PR tames the Python code (which has some nasty internal aspects) using a context manager.

The old reports are _not_ removed. And some of our reports are very bad fits for tabular reporting as they're much more tree structured in the information they're presenting. (I looked at reports produced by other parts of the stack, but these seemed to be the most convertible ones anyway.)

Also:
* Nukes some pre-Python3.7 code in FecTimer
* Adds `FecDataView.get_run_dir_file_name()` which does a pretty common pattern in one place instead of scattering it all over. (I've left the type annotations on that one; they're trivial and harmless.)