### PR TITLE
No longer use AbstractContextManager

### DIFF
--- a/spinn_front_end_common/utilities/base_database.py
+++ b/spinn_front_end_common/utilities/base_database.py
@@ -15,7 +15,6 @@
 import os
 import sqlite3
 import time
-from spinn_utilities.abstract_context_manager import AbstractContextManager
 from spinn_front_end_common.data import FecDataView
 from spinn_front_end_common.utilities.sqlite_db import SQLiteDB
 
@@ -29,7 +28,7 @@ def _timestamp():
     return int(time.time() * _SECONDS_TO_MICRO_SECONDS_CONVERSION)
 
 
-class BaseDatabase(SQLiteDB, AbstractContextManager):
+class BaseDatabase(SQLiteDB):
     """
     Specific implementation of the Database for SQLite 3.
 

--- a/spinn_front_end_common/utilities/notification_protocol/notification_protocol.py
+++ b/spinn_front_end_common/utilities/notification_protocol/notification_protocol.py
@@ -14,7 +14,6 @@
 
 import logging
 from concurrent.futures import ThreadPoolExecutor, wait  # @UnresolvedImport
-from spinn_utilities.abstract_context_manager import AbstractContextManager
 from spinn_utilities.config_holder import get_config_bool, get_config_int
 from spinn_utilities.log import FormatAdapter
 from spinnman.connections.udp_packet_connections import EIEIOConnection
@@ -30,7 +29,7 @@ from spinn_front_end_common.utilities.exceptions import ConfigurationException
 logger = FormatAdapter(logging.getLogger(__name__))
 
 
-class NotificationProtocol(AbstractContextManager):
+class NotificationProtocol(object):
     """
     The protocol which hand shakes with external devices about the
     database and starting execution.


### PR DESCRIPTION
Must be done before https://github.com/SpiNNakerManchester/SpiNNUtils/pull/250

BaseDatabase inherits the methods from SQLiteDB

SQLiteDB has a different implementation for both enter and exit

NotificationProtocol is not used in context