### PR TITLE
Simplify data in

### DIFF
--- a/c_common/models/system_models/src/data_speed_up_packet_gatherer.c
+++ b/c_common/models/system_models/src/data_speed_up_packet_gatherer.c
@@ -797,6 +797,7 @@ static void send_data_over_multicast(sdp_msg_t *msg) {
         msg->cmd_rc = RC_OK;
         reflect_sdp_message(msg, 0);
         send_msg(msg);
+        return;
     }
 
     last_sequence = msg->seq;

--- a/c_common/models/system_models/src/data_speed_up_packet_gatherer.c
+++ b/c_common/models/system_models/src/data_speed_up_packet_gatherer.c
@@ -808,6 +808,14 @@ static void send_data_over_multicast(sdp_msg_t *msg) {
     uint chip_y = msg->arg2 & 0xFFFF;
     uint n_data_items = msg->arg3;
 
+    if (chip_x >= 8 || chip_y >= 8) {
+        log_error("Chip %u, %u is not valid!", chip_x, chip_y);
+        msg->cmd_rc = RC_ARG;
+        reflect_sdp_message(msg, 0);
+        send_msg(msg);
+        return;
+    }
+
     if (chip_x == 0 && chip_y == 0) {
         copy_data((address_t) address, msg->data, n_data_items);
     } else {

--- a/c_common/models/system_models/src/data_speed_up_packet_gatherer.c
+++ b/c_common/models/system_models/src/data_speed_up_packet_gatherer.c
@@ -403,8 +403,8 @@ static void send_data_over_multicast(sdp_msg_t *msg) {
             return;
         }
 
-        log_info("Writing using %u words to %u, %u: 0x%08x", n_data_items, chip_x,
-                chip_y, address);
+        log_debug("Writing using %u words to %u, %u: 0x%08x", n_data_items,
+                chip_x, chip_y, address);
         send_mc_message(WRITE_ADDR_KEY_OFFSET, address, chip_x, chip_y);
         process_sdp_message_into_mc_messages(data, n_data_items,
                     chip_x, chip_y);

--- a/c_common/models/system_models/src/extra_monitor_support.c
+++ b/c_common/models/system_models/src/extra_monitor_support.c
@@ -1200,7 +1200,7 @@ static inline void data_in_process_data(uint data) {
     uint data_addr = (uint) data_in_write_address;
     if (((data_addr < SDRAM_BASE_BUF) || (data_addr >= SDRAM_TOP_BUF))
             && ((data_addr < SDRAM_BASE_UNBUF) || (data_addr >= SDRAM_TOP_UNBUF))) {
-        io_printf(IO_BUF, "[ERROR] Write address 0x%08x is outside SDRAM", data_addr);
+        io_printf(IO_BUF, "[ERROR] Write address 0x%08x is outside SDRAM\n", data_addr);
         rt_error(RTE_SWERR);
     }
     *data_in_write_address = data;

--- a/c_common/models/system_models/src/extra_monitor_support.c
+++ b/c_common/models/system_models/src/extra_monitor_support.c
@@ -1185,6 +1185,9 @@ static inline void data_in_process_address(uint data) {
     data_in_first_write_address = data_in_write_address = (address_t) data;
 }
 
+static const uint SDRAM_TOP_UNBUF = SDRAM_BASE_UNBUF + SDRAM_SIZE;
+static const uint SDRAM_TOP_BUF = SDRAM_TOP_UNBUF + SDRAM_SIZE;
+
 //! \brief Writes a word in a stream and advances the write pointer.
 //! \param[in] data: The word to write
 static inline void data_in_process_data(uint data) {
@@ -1192,6 +1195,12 @@ static inline void data_in_process_data(uint data) {
 
     if (data_in_write_address == NULL) {
         io_printf(IO_BUF, "[ERROR] Write address not set when write data received!\n");
+        rt_error(RTE_SWERR);
+    }
+    uint data_addr = (uint) data_in_write_address;
+    if (((data_addr < SDRAM_BASE_BUF) || (data_addr >= SDRAM_TOP_BUF))
+            && ((data_addr < SDRAM_BASE_UNBUF) || (data_addr >= SDRAM_TOP_UNBUF))) {
+        io_printf(IO_BUF, "[ERROR] Write address 0x%08x is outside SDRAM", data_addr);
         rt_error(RTE_SWERR);
     }
     *data_in_write_address = data;

--- a/spinn_front_end_common/interface/interface_functions/load_data_specification.py
+++ b/spinn_front_end_common/interface/interface_functions/load_data_specification.py
@@ -28,6 +28,7 @@ from spinn_front_end_common.utilities.exceptions import DataSpecException
 from spinn_front_end_common.utilities.emergency_recovery import (
     emergency_recover_states_from_failure)
 from spinn_front_end_common.interface.ds import DsSqlliteDatabase
+from spinn_front_end_common.utilities.iobuf_extractor import IOBufExtractor
 
 logger = FormatAdapter(logging.getLogger(__name__))
 _Writer: TypeAlias = Callable[[int, int, int, bytes], Any]
@@ -114,6 +115,12 @@ class _LoadDataSpecification(object):
                     self.__java_app(uses_advanced_monitors)
             else:
                 self.__python_load(is_system, uses_advanced_monitors)
+            if uses_advanced_monitors and get_config_bool(
+                    "Reports", "write_advanced_monitor_iobuf"):
+                extractor = IOBufExtractor(
+                    None, recovery_mode=True,
+                    filename_template="system_iobuf_{}_{}_{}.txt")
+                extractor.extract_iobuf()
         except:  # noqa: E722
             if uses_advanced_monitors:
                 emergency_recover_states_from_failure()

--- a/spinn_front_end_common/interface/java_caller.py
+++ b/spinn_front_end_common/interface/java_caller.py
@@ -423,7 +423,7 @@ class JavaCaller(object):
         """
         if use_monitors:
             result = self._run_java(
-                'dse_app_mon', self._placement_json, self._machine_json(),
+                'dse_app_mon_mc', self._placement_json, self._machine_json(),
                 FecDataView.get_ds_database_path(),
                 FecDataView.get_run_dir_path())
         else:

--- a/spinn_front_end_common/interface/spinnaker.cfg
+++ b/spinn_front_end_common/interface/spinnaker.cfg
@@ -84,6 +84,7 @@ write_router_compression_with_bitfield_report = True
 write_drift_report_start = False
 write_drift_report_end = False
 write_text_specs = False
+write_advanced_monitor_iobuf = False
 
 max_reports_kept = 10
 max_application_binaries_kept = 10

--- a/spinn_front_end_common/utilities/scp/__init__.py
+++ b/spinn_front_end_common/utilities/scp/__init__.py
@@ -16,9 +16,12 @@ from .clear_iobuf_process import ClearIOBUFProcess
 from .load_mc_routes_process import LoadMCRoutesProcess
 from .reinjector_control_process import ReinjectorControlProcess
 from .update_runtime_process import UpdateRuntimeProcess
+from .write_memory_using_multicast_process import (
+    WriteMemoryUsingMulticastProcess)
 
 __all__ = (
     "ClearIOBUFProcess",
     "LoadMCRoutesProcess",
     "ReinjectorControlProcess",
-    "UpdateRuntimeProcess")
+    "UpdateRuntimeProcess",
+    "WriteMemoryUsingMulticastProcess")

--- a/spinn_front_end_common/utilities/scp/write_memory_using_multicast_process.py
+++ b/spinn_front_end_common/utilities/scp/write_memory_using_multicast_process.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2017 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy
+from numpy import uint8, uint32
+from spinnman.constants import UDP_MESSAGE_MAX_SIZE
+from spinnman.processes import AbstractMultiConnectionProcess
+from spinnman.messages.scp.impl import CheckOKResponse
+from spinn_front_end_common.utilities.utility_objs.\
+    extra_monitor_scp_messages import SendMCDataMessage
+
+_UNSIGNED_WORD = 0xFFFFFFFF
+
+
+class WriteMemoryUsingMulticastProcess(
+        AbstractMultiConnectionProcess[CheckOKResponse]):
+    """
+    How to send messages to write data using multicast
+    """
+    __slots__ = ()
+
+    def write_memory_from_bytearray(
+            self, x: int, y: int, p: int, target_x: int, target_y: int,
+            base_address: int, data: bytes, data_offset: int = 0,
+            n_bytes: int = None, get_sum: bool = False) -> int:
+        offset = 0
+        n_bytes_to_write = n_bytes
+        if n_bytes is None:
+            n_bytes_to_write = len(data)
+        with self._collect_responses():
+            while n_bytes_to_write > 0:
+                bytes_to_send = min(n_bytes_to_write, UDP_MESSAGE_MAX_SIZE)
+                data_array = data[data_offset:data_offset + bytes_to_send]
+
+                self._send_request(
+                    SendMCDataMessage(x, y, p, target_x, target_y,
+                                      base_address + offset, data_array))
+
+                n_bytes_to_write -= bytes_to_send
+                offset += bytes_to_send
+                data_offset += bytes_to_send
+        if not get_sum:
+            return 0
+        np_data = numpy.array(data, dtype=uint8)
+        np_sum = int(numpy.sum(np_data.view(uint32), dtype=uint32))
+        return np_sum & _UNSIGNED_WORD

--- a/spinn_front_end_common/utilities/utility_objs/extra_monitor_scp_messages/__init__.py
+++ b/spinn_front_end_common/utilities/utility_objs/extra_monitor_scp_messages/__init__.py
@@ -21,6 +21,7 @@ from .reset_counters_message import ResetCountersMessage
 from .set_reinjection_packet_types_message import (
     SetReinjectionPacketTypesMessage)
 from .set_router_timeout_message import SetRouterTimeoutMessage
+from .send_mc_data_message import SendMCDataMessage
 
 __all__ = (
     "ClearReinjectionQueueMessage",
@@ -30,4 +31,5 @@ __all__ = (
     "LoadSystemMCRoutesMessage",
     "ResetCountersMessage",
     "SetReinjectionPacketTypesMessage",
-    "SetRouterTimeoutMessage")
+    "SetRouterTimeoutMessage",
+    "SendMCDataMessage")

--- a/spinn_front_end_common/utilities/utility_objs/extra_monitor_scp_messages/send_mc_data_message.py
+++ b/spinn_front_end_common/utilities/utility_objs/extra_monitor_scp_messages/send_mc_data_message.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2017 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from spinn_utilities.overrides import overrides
+from spinnman.messages.scp import SCPRequestHeader
+from spinnman.messages.scp.abstract_messages import AbstractSCPRequest
+from spinnman.messages.sdp import SDPFlag, SDPHeader
+from spinnman.messages.scp.impl.check_ok_response import CheckOKResponse
+from spinnman.messages.scp.enums import SCPCommand
+from spinnman.model.enums import SDP_PORTS
+from spinn_front_end_common.utilities.constants import BYTES_PER_WORD
+
+X_SHIFT = 16
+
+
+class SendMCDataMessage(AbstractSCPRequest[CheckOKResponse]):
+    """
+    An SCP Request to write data using multicast.
+    """
+
+    __slots__ = ()
+
+    def __init__(self, x: int, y: int, p: int, target_x: int, target_y: int,
+                 target_address: int, data: bytes):
+        """
+        :param int x: The x-coordinate of a chip, between 0 and 255
+        :param int y: The y-coordinate of a chip, between 0 and 255
+        :param int p:
+            The processor running the extra monitor vertex, between 0 and 17
+        """
+        super().__init__(
+            SDPHeader(
+                flags=SDPFlag.REPLY_EXPECTED,
+                destination_port=(
+                    SDP_PORTS.EXTRA_MONITOR_CORE_COPY_DATA_IN.value),
+                destination_cpu=p, destination_chip_x=x,
+                destination_chip_y=y),
+            SCPRequestHeader(
+                command=SCPCommand.CMD_WRITE),
+            argument_1=target_address,
+            argument_2=target_x << X_SHIFT | target_y,
+            argument_3=len(data) // BYTES_PER_WORD,
+            data=data)
+
+    @overrides(AbstractSCPRequest.get_scp_response)
+    def get_scp_response(self) -> CheckOKResponse:
+        return CheckOKResponse(
+            "write_over_multicast",
+            SCPCommand.CMD_WRITE)

--- a/spinn_front_end_common/utility_models/data_speed_up_packet_gatherer_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/data_speed_up_packet_gatherer_machine_vertex.py
@@ -13,22 +13,20 @@
 # limitations under the License.
 from __future__ import annotations
 import os
-import datetime
 import logging
 import time
 import struct
 from enum import Enum, IntEnum
 from typing import (
-    Any, BinaryIO, Iterable, List, Optional, Set, Tuple, Union, TYPE_CHECKING)
+    Iterable, List, Optional, Set, Tuple, TYPE_CHECKING)
 from spinn_utilities.config_holder import get_config_bool
 from spinn_utilities.overrides import overrides
 from spinn_utilities.log import FormatAdapter
 from spinn_utilities.typing.coords import XY
-from spinn_machine import Chip
 from spinnman.exceptions import SpinnmanTimeoutException
 from spinnman.messages.sdp import SDPMessage, SDPHeader, SDPFlag
 from spinnman.model.enums import (
-    CPUState, ExecutableType, SDP_PORTS, UserRegister)
+    CPUState, ExecutableType, SDP_PORTS)
 from spinnman.connections.udp_packet_connections import SCAMPConnection
 from pacman.model.graphs.machine import MachineVertex
 from pacman.model.resources import ConstantSDRAM, IPtagResource
@@ -151,17 +149,6 @@ class DATA_OUT_COMMANDS(IntEnum):
     CLEAR = 2000
 
 
-class DATA_IN_COMMANDS(IntEnum):
-    """
-    Command IDs for the SDP packets for data in.
-    """
-    SEND_DATA_TO_LOCATION = 200
-    SEND_SEQ_DATA = 2000
-    SEND_TELL = 2001
-    RECEIVE_MISSING_SEQ_DATA = 2002
-    RECEIVE_FINISHED = 2003
-
-
 # precompiled structures
 _ONE_WORD = struct.Struct("<I")
 _TWO_WORDS = struct.Struct("<II")
@@ -228,8 +215,6 @@ class DataSpeedUpPacketGatherMachineVertex(
         "_missing_seq_nums_data_in",
         # holder of data from out
         "_output",
-        # my placement for future lookup
-        "__placement",
         # Count of the runs for provenance data
         "_run",
         "_remote_tag",
@@ -314,7 +299,6 @@ class DataSpeedUpPacketGatherMachineVertex(
 
         # local provenance storage
         self._run = 0
-        self.__placement: Optional[Placement] = None
 
         # create report if it doesn't already exist
 
@@ -324,19 +308,6 @@ class DataSpeedUpPacketGatherMachineVertex(
 
         # Stored reinjection status for resetting timeouts
         self._last_status: Optional[ReInjectionStatus] = None
-
-    def __throttled_send(
-            self, message: SDPMessage, connection: SCAMPConnection):
-        """
-        Slows down transmissions to allow SpiNNaker to keep up.
-
-        :param ~.SDPMessage message: message to send
-        :type connection:
-            ~spinnman.connections.udp_packet_connections.SCAMPConnection
-        """
-        # send first message
-        connection.send_sdp_message(message)
-        time.sleep(self._TRANSMISSION_THROTTLE_TIME)
 
     @property
     @overrides(MachineVertex.sdram_required)
@@ -352,15 +323,6 @@ class DataSpeedUpPacketGatherMachineVertex(
             port=self._TAG_INITIAL_PORT, strip_sdp=True,
             ip_address="localhost", traffic_identifier="DATA_SPEED_UP")]
 
-    def _read_transaction_id_from_machine(self) -> None:
-        """
-        Looks up from the machine what the current transaction ID is
-        and updates the data speed up gatherer.
-        """
-        self._transaction_id = FecDataView.get_transceiver().read_user(
-            self._placement.x, self._placement.y, self._placement.p,
-            UserRegister.USER_1)
-
     @overrides(AbstractHasAssociatedBinary.get_binary_start_type)
     def get_binary_start_type(self) -> ExecutableType:
         return ExecutableType.SYSTEM
@@ -369,8 +331,6 @@ class DataSpeedUpPacketGatherMachineVertex(
     def generate_data_specification(
             self, spec: DataSpecificationGenerator, placement: Placement):
         # pylint: disable=unsubscriptable-object
-        # update my placement for future knowledge
-        self.__placement = placement
 
         # Create the data regions for hello world
         self._reserve_memory_regions(spec)
@@ -427,12 +387,6 @@ class DataSpeedUpPacketGatherMachineVertex(
         # End-of-Spec:
         spec.end_specification()
 
-    @property
-    def _placement(self) -> Placement:
-        if self.__placement is None:
-            raise SpinnFrontEndException("placement not known")
-        return self.__placement
-
     def _reserve_memory_regions(self, spec: DataSpecificationGenerator):
         """
         Writes the DSG regions memory sizes. Static so that it can be used
@@ -455,133 +409,6 @@ class DataSpeedUpPacketGatherMachineVertex(
     @overrides(AbstractHasAssociatedBinary.get_binary_file_name)
     def get_binary_file_name(self) -> str:
         return "data_speed_up_packet_gatherer.aplx"
-
-    def _generate_data_in_report(
-            self, time_diff, data_size: int, x: int, y: int,
-            address_written_to: int, missing_seq_nums):
-        """
-        Writes the data in report for this stage.
-
-        :param ~datetime.timedelta time_diff:
-            the time taken to write the memory
-        :param int data_size: the size of data that was written in bytes
-        :param int x:
-            the location in machine where the data was written to X axis
-        :param int y:
-            the location in machine where the data was written to Y axis
-        :param int address_written_to: where in SDRAM it was written to
-        :param list(set(int)) missing_seq_nums:
-            the set of missing sequence numbers per data transmission attempt
-        """
-        if not os.path.isfile(self._in_report_path):
-            with open(self._in_report_path, "w", encoding="utf-8") as writer:
-                writer.write(
-                    "x\t\t y\t\t SDRAM address\t\t size in bytes\t\t\t"
-                    " time took \t\t\t Mb/s \t\t\t missing sequence numbers\n")
-                writer.write(
-                    "------------------------------------------------"
-                    "------------------------------------------------"
-                    "-------------------------------------------------\n")
-
-        time_took_ms = float(time_diff.microseconds +
-                             time_diff.total_seconds() * 1000000)
-        megabits = (data_size * 8.0) / (1024 * BYTES_PER_KB)
-        if time_took_ms == 0:
-            mbs: Any = "unknown, below threshold"
-        else:
-            mbs = megabits / (float(time_took_ms) / 100000.0)
-
-        with open(self._in_report_path, "a", encoding="utf-8") as writer:
-            writer.write(
-                f"{x}\t\t {y}\t\t {address_written_to}\t\t {data_size}\t\t"
-                f"\t\t {time_took_ms}\t\t\t {mbs}\t\t {missing_seq_nums}\n")
-
-    def send_data_into_spinnaker(
-            self, x: int, y: int, base_address: int,
-            data: Union[BinaryIO, bytes, str, int], *,
-            n_bytes: Optional[int] = None, offset: int = 0,
-            cpu: int = 0):  # pylint: disable=unused-argument
-        """
-        Sends a block of data into SpiNNaker to a given chip.
-
-        :param int x: chip x for data
-        :param int y: chip y for data
-        :param int base_address: the address in SDRAM to start writing memory
-        :param data:
-            the data to write or filename to load data from (if a string)
-        :type data: bytes or bytearray or memoryview or str
-        :param int n_bytes: how many bytes to read, or `None` if not set
-        :param int offset: where in the data to start from
-        :param int cpu: Ignored; can only target SDRAM so unimportant
-        """
-        # if file, read in and then process as normal
-        if isinstance(data, str):
-            if offset != 0:
-                raise ValueError(
-                    "when using a file, you can only have a offset of 0")
-
-            with open(data, "rb") as reader:
-                # n_bytes=None already means 'read everything'
-                data = reader.read(n_bytes)
-            # Number of bytes to write is now length of buffer we have
-            if n_bytes is None:
-                n_bytes = len(data)
-            else:
-                n_bytes = min(n_bytes, len(data))
-        elif not isinstance(data, (bytes, bytearray)):
-            raise ValueError("that type of data not supported")
-        if n_bytes is None:
-            n_bytes = len(data)
-        if n_bytes < 0:
-            raise ValueError("cannot write a negative amount of data")
-
-        destination = FecDataView.get_chip_at(x, y)
-        # start time recording
-        start = datetime.datetime.now()
-        # send data
-        self._send_data_via_extra_monitors(
-            destination, base_address, data[offset:n_bytes + offset])
-        # end time recording
-        end = datetime.datetime.now()
-
-        if VERIFY_SENT_DATA:
-            original_data = bytes(data[offset:n_bytes + offset])
-            transceiver = FecDataView.get_transceiver()
-            verified_data = bytes(transceiver.read_memory(
-                x, y, base_address, n_bytes))
-            self.__verify_sent_data(
-                original_data, verified_data, x, y, base_address, n_bytes)
-
-        # write report
-        if get_config_bool("Reports", "write_data_speed_up_reports"):
-            self._generate_data_in_report(
-                x=x, y=y, time_diff=end - start,
-                data_size=n_bytes, address_written_to=base_address,
-                missing_seq_nums=self._missing_seq_nums_data_in)
-
-    @staticmethod
-    def __verify_sent_data(
-            original_data: bytes, verified_data: bytes, x: int, y: int,
-            base_address: int, n_bytes: int):
-        if original_data != verified_data:
-            log.error("VARIANCE: chip:{},{} address:{} len:{}",
-                      x, y, base_address, n_bytes)
-            log.error("original:{}", original_data.hex())
-            log.error("verified:{}", verified_data.hex())
-            for i, (a, b) in enumerate(zip(original_data, verified_data)):
-                if a != b:
-                    raise ValueError(f"Mismatch found as position {i}")
-
-    def __make_data_in_message(self, payload: bytes) -> SDPMessage:
-        return SDPMessage(
-            sdp_header=SDPHeader(
-                destination_chip_x=self._placement.x,
-                destination_chip_y=self._placement.y,
-                destination_cpu=self._placement.p,
-                destination_port=(
-                    SDP_PORTS.EXTRA_MONITOR_CORE_DATA_IN_SPEED_UP.value),
-                flags=SDPFlag.REPLY_NOT_EXPECTED),
-            data=payload)
 
     @staticmethod
     def __make_data_out_message(
@@ -607,270 +434,6 @@ class DataSpeedUpPacketGatherMachineVertex(
         connection = open_scp_connection(self._x, self._y, self._ip_address)
         retarget_tag(connection, self._x, self._y, self._remote_tag)
         return connection
-
-    def _send_data_via_extra_monitors(
-            self, destination_chip: Chip, start_address: int,
-            data_to_write: bytes):
-        """
-        Sends data using the extra monitor cores.
-
-        :param Chip destination_chip: chip to send to
-        :param int start_address: start address in SDRAM to write data to
-        :param bytearray data_to_write: the data to write
-        """
-        # Set up the connection
-        with self.__open_connection() as connection:
-            # how many packets after first one we need to send
-            self._max_seq_num = ceildiv(
-                len(data_to_write), BYTES_IN_FULL_PACKET_WITH_KEY)
-
-            # determine board chip IDs, as the LPG does not know
-            # machine scope IDs
-            machine = FecDataView.get_machine()
-            dest_x, dest_y = machine.get_local_xy(destination_chip)
-            self._coord_word = (dest_x << DEST_X_SHIFT) | dest_y
-
-            # for safety, check the transaction id from the machine before
-            # updating
-            self._read_transaction_id_from_machine()
-            self._transaction_id = (
-                self._transaction_id + 1) & TRANSACTION_ID_CAP
-            time_out_count = 0
-
-            # verify completed
-            received_confirmation = False
-            while not received_confirmation:
-                # send initial attempt at sending all the data
-                self._send_all_data_based_packets(
-                    data_to_write, start_address, connection)
-
-                # Don't create a missing buffer until at least one packet has
-                # come back.
-                missing: Optional[Set[int]] = None
-
-                while not received_confirmation:
-                    try:
-                        # try to receive a confirmation of some sort from
-                        # spinnaker
-                        data = connection.receive(
-                            timeout=self._TIMEOUT_PER_RECEIVE_IN_SECONDS)
-                        time_out_count = 0
-
-                        # Read command and transaction id
-                        (cmd, transaction_id) = _TWO_WORDS.unpack_from(data, 0)
-
-                        # If wrong transaction id, ignore packet
-                        if self._transaction_id != transaction_id:
-                            continue
-
-                        # Decide what to do with the packet
-                        if cmd == DATA_IN_COMMANDS.RECEIVE_FINISHED:
-                            received_confirmation = True
-                            break
-
-                        if cmd != DATA_IN_COMMANDS.RECEIVE_MISSING_SEQ_DATA:
-                            raise ValueError(f"Unknown command {cmd} received")
-
-                        # The currently received packet has missing sequence
-                        # numbers. Accumulate and dispatch transactionId when
-                        # we've got them all.
-                        if missing is None:
-                            missing = set()
-                            self._missing_seq_nums_data_in.append(missing)
-                        seen_last, seen_all = self._read_in_missing_seq_nums(
-                            data,
-                            BYTES_FOR_RECEPTION_COMMAND_AND_ADDRESS_HEADER,
-                            missing)
-
-                        # Check that you've seen something that implies ready
-                        # to retransmit.
-                        if seen_all or seen_last:
-                            self._outgoing_retransmit_missing_seq_nums(
-                                data_to_write, missing, connection)
-                            missing.clear()
-
-                    except SpinnmanTimeoutException as e:
-                        # if the timeout has not occurred x times, keep trying
-                        time_out_count += 1
-                        if time_out_count > TIMEOUT_RETRY_LIMIT:
-                            emergency_recover_state_from_failure(
-                                self, self._placement)
-                            raise SpinnFrontEndException(
-                                "Failed to hear from the machine during "
-                                f"{time_out_count} attempts. "
-                                "Please try removing firewalls.") from e
-
-                        # If we never received a packet, we will never have
-                        # created the buffer, so send everything again
-                        if missing is None:
-                            break
-
-                        self._outgoing_retransmit_missing_seq_nums(
-                                data_to_write, missing, connection)
-                        missing.clear()
-
-    def _read_in_missing_seq_nums(
-            self, data: bytes, position: int,
-            seq_nums: Set[int]) -> Tuple[bool, bool]:
-        """
-        Handles a missing sequence number packet from SpiNNaker.
-
-        :param data: the data to translate into missing sequence numbers
-        :type data: bytearray or bytes
-        :param int position: the position in the data to write.
-        :param set(int) seq_nums: a set of sequence numbers to add to
-        :return: seen_last flag and seen_all flag
-        :rtype: tuple(bool, bool)
-        """
-        # find how many elements are in this packet
-        n_elements = (len(data) - position) // BYTES_PER_WORD
-
-        # store missing
-        new_seq_nums = n_word_struct(n_elements).unpack_from(
-            data, position)
-
-        # add missing seqs accordingly
-        seen_last = False
-        seen_all = False
-        if new_seq_nums[-1] == self._MISSING_SEQ_NUMS_END_FLAG:
-            new_seq_nums = new_seq_nums[:-1]
-            seen_last = True
-        if new_seq_nums[-1] == self.FLAG_FOR_MISSING_ALL_SEQUENCES:
-            for missing_seq in range(self._max_seq_num or 0):
-                seq_nums.add(missing_seq)
-            seen_all = True
-        else:
-            seq_nums.update(new_seq_nums)
-
-        return seen_last, seen_all
-
-    def _outgoing_retransmit_missing_seq_nums(
-            self, data_to_write: bytes, missing: Set[int],
-            connection: SCAMPConnection):
-        """
-        Transmits back into SpiNNaker the missing data based off missing
-        sequence numbers.
-
-        :param bytearray data_to_write: the data to write.
-        :param set(int) missing: a set of missing sequence numbers
-        :type connection:
-            ~spinnman.connections.udp_packet_connections.SCAMPConnection
-        """
-        missing_seqs_as_list = list(missing)
-        missing_seqs_as_list.sort()
-
-        # send seq data
-        for missing_seq_num in missing_seqs_as_list:
-            message, _length = self.__make_data_in_stream_message(
-                data_to_write, missing_seq_num, None)
-            self.__throttled_send(message, connection)
-
-        # request an update on what is missing
-        self.__send_tell_flag(connection)
-
-    @staticmethod
-    def __position_from_seq_number(seq_num: int) -> int:
-        """
-        Calculates where in the raw data to start reading from, given a
-        sequence number.
-
-        :param int seq_num: the sequence number to determine position from
-        :return: the position in the byte data
-        :rtype: int
-        """
-        return BYTES_IN_FULL_PACKET_WITH_KEY * seq_num
-
-    def __make_data_in_stream_message(
-            self, data_to_write: bytes, seq_num: int,
-            position: Optional[int]) -> Tuple[SDPMessage, int]:
-        """
-        Determine the data needed to be sent to the SpiNNaker machine
-        given a sequence number.
-
-        :param bytearray data_to_write:
-            the data to write to the SpiNNaker machine
-        :param int seq_num: the sequence number to get the data for
-        :param position:
-            the position in the data to write to SpiNNaker,
-            or None to infer from the sequence number
-        :type position: int or None
-        :return: SDP message and how much data has been written
-        :rtype: tuple(~.SDPMessage, int)
-        """
-        # check for last packet
-        packet_data_length = BYTES_IN_FULL_PACKET_WITH_KEY
-
-        # determine position in data if not given
-        if position is None:
-            position = self.__position_from_seq_number(seq_num)
-
-        # if less than a full packet worth of data, adjust length
-        if position + packet_data_length > len(data_to_write):
-            packet_data_length = len(data_to_write) - position
-
-        if packet_data_length < 0:
-            raise ValueError("weird packet data length")
-
-        # create message body
-        packet_data = _THREE_WORDS.pack(
-            DATA_IN_COMMANDS.SEND_SEQ_DATA, self._transaction_id,
-            seq_num) + data_to_write[position:position+packet_data_length]
-
-        # return message for sending, and the length in data sent
-        return self.__make_data_in_message(packet_data), packet_data_length
-
-    def __send_location(self, start_address: int, connection: SCAMPConnection):
-        """
-        Send location as separate message.
-
-        :param int start_address: SDRAM location
-        """
-        connection.send_sdp_message(self.__make_data_in_message(
-            _FIVE_WORDS.pack(
-                DATA_IN_COMMANDS.SEND_DATA_TO_LOCATION,
-                self._transaction_id, start_address, self._coord_word,
-                self._max_seq_num - 1)))
-        log.debug(
-            "start address for transaction {} is {}",
-            self._transaction_id, start_address)
-
-    def __send_tell_flag(self, connection: SCAMPConnection) -> None:
-        """
-        Send tell flag as separate message.
-        """
-        connection.send_sdp_message(self.__make_data_in_message(
-            _TWO_WORDS.pack(
-                DATA_IN_COMMANDS.SEND_TELL, self._transaction_id)))
-
-    def _send_all_data_based_packets(
-            self, data_to_write: bytes, start_address: int,
-            connection: SCAMPConnection):
-        """
-        Send all the data as one block.
-
-        :param bytearray data_to_write: the data to send
-        :param int start_address:
-        """
-        # Send the location
-        self.__send_location(start_address, connection)
-
-        # where in the data we are currently up to
-        position_in_data = 0
-
-        # send rest of data
-        for seq_num in range(self._max_seq_num or 0):
-            # put in command flag and seq num
-            message, length_to_send = self.__make_data_in_stream_message(
-                data_to_write, seq_num, position_in_data)
-            position_in_data += length_to_send
-
-            # send the message
-            self.__throttled_send(message, connection)
-            log.debug("sent seq {} of {} bytes", seq_num, length_to_send)
-
-        # check for end flag
-        self.__send_tell_flag(connection)
-        log.debug("sent end flag")
 
     def set_cores_for_data_streaming(self) -> None:
         """

--- a/unittests/interface/interface_functions/test_load_data_specification.py
+++ b/unittests/interface/interface_functions/test_load_data_specification.py
@@ -62,6 +62,10 @@ class _MockTransceiver(Version5Transceiver):
             data = struct.pack("<I", data)
         self._regions_written.append((base_address, data))
 
+    @overrides(Version5Transceiver.get_scamp_connection_selector)
+    def get_scamp_connection_selector(self):
+        return None
+
     @overrides(Version5Transceiver.close)
     def close(self):
         pass


### PR DESCRIPTION
Removes the complicated data in protocol and replaces it with a much simpler one!  This uses the same "multicast paths" on the machine, but instead of keeping track of packets and then retransmitting them in blocks, it instead uses normal SCP messages to send the data, which is then expanded to multicast on the machine as before.  This appears to run at the same speed as the other protocol, but without the complicated code...