### PR TITLE
remove @UnresolvedImport and fix some tests

### DIFF
--- a/spinn_front_end_common/utilities/notification_protocol/notification_protocol.py
+++ b/spinn_front_end_common/utilities/notification_protocol/notification_protocol.py
@@ -15,7 +15,7 @@
 import logging
 from typing import List, Optional
 from concurrent.futures import Future
-from concurrent.futures import ThreadPoolExecutor, wait  # @UnresolvedImport
+from concurrent.futures import ThreadPoolExecutor, wait
 from spinn_utilities.config_holder import get_config_bool, get_config_int
 from spinn_utilities.log import FormatAdapter
 from spinnman.connections.udp_packet_connections import EIEIOConnection

--- a/spinn_front_end_common/utilities/notification_protocol/notification_protocol.py
+++ b/spinn_front_end_common/utilities/notification_protocol/notification_protocol.py
@@ -58,6 +58,7 @@ class NotificationProtocol(object):
             "Database", "wait_on_confirmation_timeout")
         self.__wait_pool: Optional[ThreadPoolExecutor] = \
             ThreadPoolExecutor(max_workers=1)
+        # pylint: disable=unsubscriptable-object
         self.__wait_futures: List[Future[None]] = list()
         self.__sent_visualisation_confirmation = False
         # These connections are not used to talk to SpiNNaker boards

--- a/unittests/interface/interface_functions/test_front_end_common_graph_binary_gatherer.py
+++ b/unittests/interface/interface_functions/test_front_end_common_graph_binary_gatherer.py
@@ -64,6 +64,11 @@ class _TestExecutableFinder(object):
     def get_executable_path(self, executable_name: str) -> str:
         return executable_name
 
+    @property
+    @overrides(ExecutableFinder.binary_paths)
+    def binary_paths(self) -> str:
+        return "Test so no paths"
+
 
 class TestFrontEndCommonGraphBinaryGatherer(unittest.TestCase):
 

--- a/unittests/interface/interface_functions/test_front_end_common_graph_binary_gatherer.py
+++ b/unittests/interface/interface_functions/test_front_end_common_graph_binary_gatherer.py
@@ -64,11 +64,6 @@ class _TestExecutableFinder(object):
     def get_executable_path(self, executable_name: str) -> str:
         return executable_name
 
-    @property
-    @overrides(ExecutableFinder.binary_paths)
-    def binary_paths(self) -> str:
-        return "Test so no paths"
-
 
 class TestFrontEndCommonGraphBinaryGatherer(unittest.TestCase):
 
@@ -107,6 +102,8 @@ class TestFrontEndCommonGraphBinaryGatherer(unittest.TestCase):
         self.assertIn((0, 0, 0), test_cores)
         self.assertIn((0, 0, 1), test_2_cores)
         self.assertIn((0, 0, 2), test_2_cores)
+
+        writer._set_executable_finder(ExecutableFinder())
 
     def test_mixed_binaries(self):
         """ Test calling the binary gatherer with mixed executable types

--- a/unittests/interface/provenance/test_provenance_database.py
+++ b/unittests/interface/provenance/test_provenance_database.py
@@ -204,14 +204,16 @@ class TestProvenanceDatabase(unittest.TestCase):
         logger.set_log_store(ls)
         logger.warning("this works")
         with GlobalProvenance() as db:
-            db._test_log_locked("locked")
+            db._test_log_locked("now locked")
         logger.warning("not locked")
         logger.warning("this wis fine")
         # the use of class variables and tests run in parallel dont work.
         if "JENKINS_URL" not in os.environ:
-            self.assertListEqual(
-                ["this works", "not locked", "this wis fine"],
-                ls.retreive_log_messages(20))
+            reported = ls.retreive_log_messages(20)
+            self.assertIn("this works", reported)
+            self.assertIn("not locked", reported)
+            self.assertIn("this wis fine". reported)
+            self.assertNotIn("now locked", reported)
         logger.set_log_store(None)
 
     def test_double_with(self):

--- a/unittests/interface/provenance/test_provenance_database.py
+++ b/unittests/interface/provenance/test_provenance_database.py
@@ -212,7 +212,7 @@ class TestProvenanceDatabase(unittest.TestCase):
             reported = ls.retreive_log_messages(20)
             self.assertIn("this works", reported)
             self.assertIn("not locked", reported)
-            self.assertIn("this wis fine". reported)
+            self.assertIn("this wis fine", reported)
             self.assertNotIn("now locked", reported)
         logger.set_log_store(None)
 


### PR DESCRIPTION
This pr started as a check if @UnresolvedImport is still needed.

Appears it is not.

While running tests noticed some unrelated issues with tests conflicting each other.

TestFrontEndCommonGraphBinaryGatherer set a _TestExecutableFinder
now other tests are being affected.
So it now sets it back at the end.

TestProvenanceDatabase cgecks log messages
These where being merged with logs from other tests
So now it just checks the expected logs are there and the ones that will not be logged are not
