### PR TITLE
Simplfy the data.sqlite3

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -2041,7 +2041,7 @@ class AbstractSpinnakerBase(ConfigHandler):
             if timer.skip_if_virtual_board():
                 return
             bm = self._data_writer.get_buffer_manager()
-            bm.get_placement_data()
+            bm.gather_placement_data()
 
     def _do_extract_from_machine(self) -> None:
         """

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -2041,7 +2041,7 @@ class AbstractSpinnakerBase(ConfigHandler):
             if timer.skip_if_virtual_board():
                 return
             bm = self._data_writer.get_buffer_manager()
-            bm.gather_placement_data()
+            bm.extract_data()
 
     def _do_extract_from_machine(self) -> None:
         """

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -427,7 +427,8 @@ class BufferManager(object):
                     placement.x, placement.y, placement.p,
                     recording_region_id)
         except LookupError as lookup_error:
-            self._raise_error(placement, recording_region_id, lookup_error)
+            return self._raise_error(
+                placement, recording_region_id, lookup_error)
 
     def get_last_data_by_placement(
             self, placement: Placement, recording_region_id: int) -> Tuple[
@@ -453,10 +454,14 @@ class BufferManager(object):
                     placement.x, placement.y, placement.p,
                     recording_region_id, -1)
         except LookupError as lookup_error:
-            self._raise_error(placement, recording_region_id, lookup_error)
+            return self._raise_error(
+                placement, recording_region_id, lookup_error)
 
     def _raise_error(self, placement: Placement, recording_region_id: int,
-                     lookup_error: LookupError):
+                     lookup_error: LookupError)-> Tuple[bytes, bool]:
+        """
+        Raises the correct exception-
+        """
         vertex = placement.vertex
         if isinstance(vertex, AbstractReceiveBuffersToHost):
             if recording_region_id not in vertex.get_recorded_region_ids():

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -419,7 +419,7 @@ class BufferManager(object):
         :raises BufferedRegionNotPresent:
             If no data is available nor marked missing.
         :raises NotImplementedError:
-            If the placment's vertex is not a type that records data
+            If the placement's vertex is not a type that records data
         """
         try:
             with BufferDatabase() as db:

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -349,7 +349,7 @@ class BufferManager(object):
         FecDataView.write_memory(
             placement.x, placement.y, region_base_address, all_data)
 
-    def get_placement_data(self) -> None:
+    def gather_placement_data(self) -> None:
         """
         Retrieve the data from placed vertices.
         """
@@ -361,14 +361,14 @@ class BufferManager(object):
         if self._java_caller is not None:
             logger.info("Starting buffer extraction using Java")
             self._java_caller.set_placements(recording_placements)
-            self._java_caller.get_all_data()
+            self._java_caller.gather_all_data()
         elif self.__enable_monitors:
-            self.__python_get_data_for_placements_with_monitors(
+            self.__python_gather_placements_data_with_monitors(
                 recording_placements)
         else:
-            self.__python_get_data_for_placements(recording_placements)
+            self.__python_gather_placements_data(recording_placements)
 
-    def __python_get_data_for_placements_with_monitors(
+    def __python_gather_placements_data_with_monitors(
             self, recording_placements: List[Placement]):
         """
         :param list(~pacman.model.placements.Placement) recording_placements:
@@ -385,9 +385,9 @@ class BufferManager(object):
 
         with StreamingContextManager(receivers):
             # get data
-            self.__python_get_data_for_placements(recording_placements)
+            self.__python_gather_placements_data(recording_placements)
 
-    def __python_get_data_for_placements(
+    def __python_gather_placements_data(
             self, recording_placements: List[Placement]):
         """
         :param list(~pacman.model.placements.Placement) recording_placements:

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -458,7 +458,7 @@ class BufferManager(object):
                 placement, recording_region_id, lookup_error)
 
     def _raise_error(self, placement: Placement, recording_region_id: int,
-                     lookup_error: LookupError)-> Tuple[bytes, bool]:
+                     lookup_error: LookupError) -> Tuple[bytes, bool]:
         """
         Raises the correct exception-
         """

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -370,7 +370,6 @@ class BufferManager(object):
         else:
             self.__python_extract_no_monitors(recording_placements)
 
-
     def __python_extract_with_monitors(
             self, recording_placements: List[Placement]):
         """
@@ -458,21 +457,21 @@ class BufferManager(object):
 
     def _raise_error(self, placement: Placement, recording_region_id: int,
                      lookup_error: LookupError):
-            vertex = placement.vertex
-            if isinstance(vertex, AbstractReceiveBuffersToHost):
-                if recording_region_id not in vertex.get_recorded_region_ids():
-                    raise BufferedRegionNotPresent(
-                        f"{vertex} not set to record region "
-                        f"{recording_region_id}") from lookup_error
-                else:
-                    raise BufferedRegionNotPresent(
-                        f"{vertex} should have record region "
-                        f"{recording_region_id} but there is no data"
-                    ) from lookup_error
+        vertex = placement.vertex
+        if isinstance(vertex, AbstractReceiveBuffersToHost):
+            if recording_region_id not in vertex.get_recorded_region_ids():
+                raise BufferedRegionNotPresent(
+                    f"{vertex} not set to record region "
+                    f"{recording_region_id}") from lookup_error
             else:
-                raise NotImplementedError(
-                    f"vertex {placement.vertex} does not implement "
-                    "AbstractReceiveBuffersToHost so no data read")
+                raise BufferedRegionNotPresent(
+                    f"{vertex} should have record region "
+                    f"{recording_region_id} but there is no data"
+                ) from lookup_error
+        else:
+            raise NotImplementedError(
+                f"vertex {placement.vertex} does not implement "
+                "AbstractReceiveBuffersToHost so no data read")
 
     def _retreive_by_placement(self, placement: Placement):
         """

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -349,7 +349,7 @@ class BufferManager(object):
         FecDataView.write_memory(
             placement.x, placement.y, region_base_address, all_data)
 
-    def gather_placement_data(self) -> None:
+    def extract_data(self) -> None:
         """
         Retrieve the data from placed vertices.
         """
@@ -361,14 +361,14 @@ class BufferManager(object):
         if self._java_caller is not None:
             logger.info("Starting buffer extraction using Java")
             self._java_caller.set_placements(recording_placements)
-            self._java_caller.gather_all_data()
+            self._java_caller.extract_all_data()
         elif self.__enable_monitors:
-            self.__python_gather_placements_data_with_monitors(
-                recording_placements)
+            self.__python_extract_with_monitors(recording_placements)
         else:
-            self.__python_gather_placements_data(recording_placements)
+            self.__python_extract_no_monitors(recording_placements)
 
-    def __python_gather_placements_data_with_monitors(
+
+    def __python_extract_with_monitors(
             self, recording_placements: List[Placement]):
         """
         :param list(~pacman.model.placements.Placement) recording_placements:
@@ -385,9 +385,9 @@ class BufferManager(object):
 
         with StreamingContextManager(receivers):
             # get data
-            self.__python_gather_placements_data(recording_placements)
+            self.__python_extract_no_monitors(recording_placements)
 
-    def __python_gather_placements_data(
+    def __python_extract_no_monitors(
             self, recording_placements: List[Placement]):
         """
         :param list(~pacman.model.placements.Placement) recording_placements:

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -125,6 +125,9 @@ class BufferManager(object):
             if vertex.buffering_input():
                 self._sender_vertices.add(vertex)
 
+        with BufferDatabase() as db:
+            db.store_setup_data()
+
     def _request_data(
             self, placement_x: int, placement_y: int, address: int,
             length: int) -> bytes:

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -419,7 +419,7 @@ class BufferManager(object):
         :raises BufferedRegionNotPresent:
             If no data is available nor marked missing.
         :raises NotImplementedError:
-            If the plcamenets vertex is not a type that records data
+            If the placment's vertex is not a type that records data
         """
         try:
             with BufferDatabase() as db:
@@ -445,7 +445,7 @@ class BufferManager(object):
         :raises BufferedRegionNotPresent:
             If no data is available nor marked missing.
         :raises NotImplementedError:
-            If the plcamenets vertex is not a type that records data
+            If the placement's vertex is not a type that records data
         """
         try:
             with BufferDatabase() as db:

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -351,6 +351,8 @@ class BufferManager(object):
         """
         Retrieve the data from placed vertices.
         """
+        with BufferDatabase() as db:
+            db.start_new_extraction()
         recording_placements = list(
             FecDataView.iterate_placements_by_vertex_type(
                 AbstractReceiveBuffersToHost))

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
@@ -267,12 +267,10 @@ class BufferDatabase(BaseDatabase):
                 necessarily shorter than 1GB.
 
         :rtype: tuple(memoryview, bool)
+        :raises LookupErrror: If no data is available nor marked missing.
         """
-        try:
-            region_id = self._get_region_id(x, y, p, region)
-            return self._read_contents_with_missing(region_id)
-        except LookupError:
-            return memoryview(b''), True
+        region_id = self._get_region_id(x, y, p, region)
+        return self._read_contents_with_missing(region_id)
 
     def get_region_data_by_extraction_id(
             self, x: int, y: int, p: int, region: int,

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
@@ -194,17 +194,31 @@ class BufferDatabase(BaseDatabase):
         assert region_id is not None
         return region_id
 
+    def store_setup_data(self):
+        for row in self.execute(
+                """
+                SELECT hardware_time_step_ms
+                FROM setup
+                """):
+            return
+        self.execute(
+            """
+            INSERT INTO setup(
+                setup_id, hardware_time_step_ms, time_scale_factor)
+            VALUES(0, ?, ?)
+            """, (
+                FecDataView.get_hardware_time_step_ms(),
+                FecDataView.get_time_scale_factor()))
+
     def start_new_extraction(self):
         run_timesteps = FecDataView.get_current_run_timesteps() or 0
         self.execute(
             """
-            INSERT INTO extraction(
-                run_timestep, hardware_time_step_ms, n_run, n_loop, extract_time)
-            VALUES(?, ?, ?, ?, ?)
+            INSERT INTO extraction(run_timestep, n_run, n_loop, extract_time)
+            VALUES(?, ?, ?, ?)
             """, (
-                run_timesteps, FecDataView.get_hardware_time_step_ms(),
-                FecDataView.get_run_number(), FecDataView.get_run_step(),
-                _timestamp()))
+                run_timesteps, FecDataView.get_run_number(),
+                FecDataView.get_run_step(), _timestamp()))
         extraction_id = self.lastrowid
         assert extraction_id is not None
         return extraction_id

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
@@ -66,7 +66,7 @@ class BufferDatabase(BaseDatabase):
                     AND local_region_index = ?
                 LIMIT 1
                 """, (x, y, p, region)):
-            region_id = (row["region_id"], )
+            region_id = int(row["region_id"])
             break
         else:
             return False
@@ -85,7 +85,7 @@ class BufferDatabase(BaseDatabase):
             UPDATE region_data SET
             content = CAST('' AS BLOB), content_len = 0, missing_data = 2
             WHERE region_id = ?
-            """, region_id)
+            """, (region_id,))
         return True
 
     def _read_contents(self, region_id: int) -> memoryview:

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
@@ -91,7 +91,7 @@ class BufferDatabase(BaseDatabase):
         """
         for row in self.execute(
                 """
-                SELECT count(*) as n_extractions, 
+                SELECT count(*) as n_extractions,
                 SUM(content_len) as total_content_length
                 FROM region_data
                 WHERE region_id = ?
@@ -129,7 +129,7 @@ class BufferDatabase(BaseDatabase):
 
     def _read_contents_by_extraction_id(
             self, region_id: int,
-            extraction_id:int) -> Tuple[memoryview, bool]:
+            extraction_id: int) -> Tuple[memoryview, bool]:
         """
         Reads the content for a single block for this region
 
@@ -230,7 +230,7 @@ class BufferDatabase(BaseDatabase):
     def get_last_extraction_id(self):
         for row in self.execute(
                 """
-                SELECT max(extraction_id) as max_id 
+                SELECT max(extraction_id) as max_id
                 FROM extraction
                 LIMIT 1
                 """):
@@ -292,7 +292,7 @@ class BufferDatabase(BaseDatabase):
 
     def get_region_data_by_extraction_id(
             self, x: int, y: int, p: int, region: int,
-            extraction_id:int) -> Tuple[memoryview, bool]:
+            extraction_id: int) -> Tuple[memoryview, bool]:
         """
         Get the data stored for a given region of a given core.
 
@@ -317,7 +317,8 @@ class BufferDatabase(BaseDatabase):
             if extraction_id < 0:
                 last_extraction_id = self.get_last_extraction_id()
                 extraction_id = last_extraction_id + 1 + extraction_id
-            return self._read_contents_by_extraction_id(region_id, extraction_id)
+            return self._read_contents_by_extraction_id(
+                region_id, extraction_id)
         except LookupError:
             return memoryview(b''), True
 

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
@@ -63,16 +63,29 @@ class BufferDatabase(BaseDatabase):
                 """
                 SELECT region_id FROM region_view
                 WHERE x = ? AND y = ? AND processor = ?
-                    AND local_region_index = ? AND fetches > 0 LIMIT 1
+                    AND local_region_index = ?  
+                LIMIT 1
                 """, (x, y, p, region)):
-            locus = (row["region_id"], )
+            region_id = (row["region_id"], )
             break
         else:
             return False
+
+        return self._clear_region(region_id)
+
+    def _clear_region(self, region_id: int) -> bool:
+        """
+        Clears out a region leaveing empty data and a missing of 2
+
+        :param region_id: region to clear
+        :return:
+        """
         self.execute(
             """
-            DELETE FROM region_data WHERE region_id = ?
-            """, locus)
+            UPDATE region_data SET
+            content = CAST('' AS BLOB), content_len = 0, missing_data = 2
+            WHERE region_id = ?
+            """, region_id)
         return True
 
     def _read_contents(self, region_id: int) -> memoryview:

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
@@ -200,7 +200,7 @@ class BufferDatabase(BaseDatabase):
 
     def store_setup_data(self):
         """
-        Stores data passed into sim.setup
+        Stores data passed into simulator setup
 
         """
         for _ in self.execute(

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
@@ -150,6 +150,21 @@ class BufferDatabase(BaseDatabase):
         assert region_id is not None
         return region_id
 
+    def start_new_extraction(self):
+        run_timesteps = FecDataView.get_current_run_timesteps() or 0
+        self.execute(
+            """
+            INSERT INTO extraction(
+                run_timestep, hardware_time_step_ms, n_run, n_loop, extract_time)
+            VALUES(?, ?, ?, ?, ?)
+            """, (
+                run_timesteps, FecDataView.get_hardware_time_step_ms(),
+                FecDataView.get_run_number(), FecDataView.get_run_step(),
+                _timestamp()))
+        extraction_id = self.lastrowid
+        assert extraction_id is not None
+        return extraction_id
+
     def store_data_in_region_buffer(
             self, x: int, y: int, p: int, region: int, missing: bool,
             data: bytes):

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
@@ -236,7 +236,11 @@ class BufferDatabase(BaseDatabase):
         assert extraction_id is not None
         return extraction_id
 
-    def get_last_extraction_id(self):
+    def get_last_extraction_id(self) -> int:
+        """
+        Get the id of the current/ last extraction
+
+        """
         for row in self.execute(
                 """
                 SELECT max(extraction_id) as max_id

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
@@ -140,7 +140,7 @@ class BufferDatabase(BaseDatabase):
         for row in self.execute(
                 """
                 SELECT content, missing_data FROM region_data
-                WHERE region_id = ? ORDER BY extration_id ASC
+                WHERE region_id = ? ORDER BY extraction_id ASC
                 """, (region_id, )):
             item = row["content"]
             c_buffer[idx:idx + len(item)] = item
@@ -224,7 +224,7 @@ class BufferDatabase(BaseDatabase):
         self.execute(
             """
             INSERT INTO region_data(
-                region_id, extration_id, content, content_len, missing_data)
+                region_id, extraction_id, content, content_len, missing_data)
             VALUES (?, ?, CAST(? AS BLOB), ?, ?)
             """, (region_id, extraction_id, datablob, len(data), missing))
         assert self.rowcount == 1

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
@@ -15,6 +15,7 @@
 from sqlite3 import Binary, IntegrityError
 import time
 from typing import Optional, Tuple
+from spinn_utilities.config_holder import get_config_bool
 from spinn_front_end_common.data import FecDataView
 from spinn_front_end_common.utilities.base_database import BaseDatabase
 
@@ -121,7 +122,10 @@ class BufferDatabase(BaseDatabase):
                 """, (region_id,)):
             return memoryview(row["content"]), row['missing_data'] != 0
         else:
-            raise LookupError(f"no record for region {region_id}")
+            if get_config_bool("Machine", "virtual_board"):
+                return memoryview(bytearray()), True
+            else:
+                raise LookupError(f"no record for region {region_id}")
 
     def _read_contents_by_extraction_id(
             self, region_id: int,

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
@@ -75,7 +75,7 @@ class BufferDatabase(BaseDatabase):
 
     def _clear_region(self, region_id: int) -> bool:
         """
-        Clears out a region leaveing empty data and a missing of 2
+        Clears out a region leaving empty data and a missing of 2
 
         :param region_id: region to clear
         :return:

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
@@ -63,7 +63,7 @@ class BufferDatabase(BaseDatabase):
                 """
                 SELECT region_id FROM region_view
                 WHERE x = ? AND y = ? AND processor = ?
-                    AND local_region_index = ?  
+                    AND local_region_index = ?
                 LIMIT 1
                 """, (x, y, p, region)):
             region_id = (row["region_id"], )

--- a/spinn_front_end_common/interface/java_caller.py
+++ b/spinn_front_end_common/interface/java_caller.py
@@ -362,7 +362,7 @@ class JavaCaller(object):
         params.extend(args)
         return subprocess.call(params)
 
-    def gather_all_data(self) -> None:
+    def extract_all_data(self) -> None:
         """
         Gets all the data from the previously set placements
         and put these in the previously set database.

--- a/spinn_front_end_common/interface/java_caller.py
+++ b/spinn_front_end_common/interface/java_caller.py
@@ -362,7 +362,7 @@ class JavaCaller(object):
         params.extend(args)
         return subprocess.call(params)
 
-    def get_all_data(self) -> None:
+    def gather_all_data(self) -> None:
         """
         Gets all the data from the previously set placements
         and put these in the previously set database.

--- a/spinn_front_end_common/utilities/db.sql
+++ b/spinn_front_end_common/utilities/db.sql
@@ -27,11 +27,15 @@ CREATE TABLE IF NOT EXISTS core(
 CREATE UNIQUE INDEX IF NOT EXISTS coreSanity ON core(
 	x ASC, y ASC, processor ASC);
 
+CREATE TABLE IF NOT EXISTS setup(
+    setup_id INTEGER PRIMARY KEY CHECK (setup_id = 0),
+    hardware_time_step_ms FLOAT NOT NULL,
+    time_scale_factor INTEGER);
+
 -- A table containing the metadata for an extraction run
 CREATE TABLE IF NOT EXISTS extraction(
 	extraction_id INTEGER PRIMARY KEY ASC AUTOINCREMENT,
     run_timestep INTEGER NOT NULL,
-    hardware_time_step_ms FLOAT NOT NULL,
     n_run INTEGER NOT NULL,
     n_loop INTEGER,
     extract_time INTEGER
@@ -39,7 +43,7 @@ CREATE TABLE IF NOT EXISTS extraction(
 CREATE VIEW IF NOT EXISTS extraction_view AS
 	SELECT extraction_id, run_timestep, run_timestep * hardware_time_step_ms as run_time_ms,
 	       n_run, n_loop, datetime(extract_time/1000, 'unixepoch') AS extraction_time
-    from extraction;
+    from extraction join setup;
 
 -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -- A table describing recording regions.

--- a/spinn_front_end_common/utilities/db.sql
+++ b/spinn_front_end_common/utilities/db.sql
@@ -65,22 +65,22 @@ CREATE TABLE IF NOT EXISTS region_data(
     region_data_id INTEGER PRIMARY KEY AUTOINCREMENT,
 	region_id INTEGER NOT NULL
 		REFERENCES region(region_id) ON DELETE RESTRICT,
-    extration_id INTEGER NOT NULL
+    extraction_id INTEGER NOT NULL
 		REFERENCES extraction(extraction_id) ON DELETE RESTRICT,
 	content BLOB NOT NULL,
 	content_len INTEGER NOT NULL,
     missing_data INTEGER NOT NULL);
 -- Every recording region is extracted once per BefferExtractor run
 CREATE UNIQUE INDEX IF NOT EXISTS region_data_sanity ON region_data(
-	region_id ASC, extration_id ASC);
+	region_id ASC, extraction_id ASC);
 
 CREATE VIEW IF NOT EXISTS region_data_view AS
-	SELECT core_id, region_id, extration_id, x, y, processor, local_region_index,
+	SELECT core_id, region_id, extraction_id, x, y, processor, local_region_index,
 		content, content_len
 FROM region_view NATURAL JOIN region_data;
 
 CREATE VIEW IF NOT EXISTS region_data_plus_view AS
-	SELECT core_id, region_id, extration_id, x, y, processor, local_region_index,
+	SELECT core_id, region_id, extraction_id, x, y, processor, local_region_index,
 		content, content_len, run_timestep, run_time_ms, n_run, n_loop, extraction_time
 FROM region_data_view NATURAL JOIN extraction_view;
 

--- a/spinn_front_end_common/utilities/db.sql
+++ b/spinn_front_end_common/utilities/db.sql
@@ -27,6 +27,15 @@ CREATE TABLE IF NOT EXISTS core(
 CREATE UNIQUE INDEX IF NOT EXISTS coreSanity ON core(
 	x ASC, y ASC, processor ASC);
 
+-- A table containing the metadata for an extraction run
+CREATE TABLE IF NOT EXISTS extraction(
+	extraction_id INTEGER PRIMARY KEY ASC AUTOINCREMENT,
+    run_timestep INTEGER NOT NULL,
+    hardware_time_step_ms FLOAT NOT NULL,
+    n_run INTEGER NOT NULL,
+    n_loop INTEGER,
+    extract_time INTEGER
+    );
 
 -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -- A table describing recording regions.
@@ -43,6 +52,7 @@ CREATE TABLE IF NOT EXISTS region(
 -- Every recording region has a unique vertex and index
 CREATE UNIQUE INDEX IF NOT EXISTS regionSanity ON region(
 	core_id ASC, local_region_index ASC);
+
 
 -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -- A table containing the data which doesn't fit in the content column of the

--- a/spinn_front_end_common/utilities/db.sql
+++ b/spinn_front_end_common/utilities/db.sql
@@ -36,6 +36,10 @@ CREATE TABLE IF NOT EXISTS extraction(
     n_loop INTEGER,
     extract_time INTEGER
     );
+CREATE VIEW IF NOT EXISTS extraction_view AS
+	SELECT extraction_id, run_timestep, run_timestep * hardware_time_step_ms as run_time_ms,
+	       n_run, n_loop, datetime(extract_time/1000, 'unixepoch') AS extraction_time
+    from extraction;
 
 -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -- A table describing recording regions.

--- a/unittests/data/test_simulator_data.py
+++ b/unittests/data/test_simulator_data.py
@@ -73,6 +73,7 @@ class TestSimulatorData(unittest.TestCase):
 
     def test_buffer_manager(self):
         writer = FecDataWriter.setup()
+        writer.set_up_timings(1, 1)
         with self.assertRaises(DataNotYetAvialable):
             FecDataView.get_buffer_manager()
         self.assertFalse(FecDataView.has_buffer_manager())

--- a/unittests/interface/buffer_management/test_buffered_database.py
+++ b/unittests/interface/buffer_management/test_buffered_database.py
@@ -37,12 +37,15 @@ class TestBufferedDatabase(unittest.TestCase):
         with BufferDatabase() as brd:
             self.assertTrue(os.path.isfile(f), "DB now exists")
 
+
             # TODO missing
             # data, missing = brd.get_region_data(0, 0, 0, 0)
             # self.assertTrue(missing, "data should be 'missing'")
             # self.assertEqual(data, b"")
 
+            brd.start_new_extraction()
             brd.store_data_in_region_buffer(0, 0, 0, 0, False, b"abc")
+            brd.start_new_extraction()
             brd.store_data_in_region_buffer(0, 0, 0, 0, False, b"def")
             data, missing = brd.get_region_data(0, 0, 0, 0)
 
@@ -63,6 +66,7 @@ class TestBufferedDatabase(unittest.TestCase):
         info.add_placement(Placement(SimpleMachineVertex(None), 2, 2, 3))
         writer.set_placements(info)
         with BufferDatabase() as db:
+            db.start_new_extraction()
             db.store_data_in_region_buffer(1, 2, 3, 0, False, b"abc")
             db.store_vertex_labels()
             label = db.get_core_name(1, 2, 3)

--- a/unittests/interface/buffer_management/test_buffered_database.py
+++ b/unittests/interface/buffer_management/test_buffered_database.py
@@ -39,18 +39,27 @@ class TestBufferedDatabase(unittest.TestCase):
 
 
             # TODO missing
-            # data, missing = brd.get_region_data(0, 0, 0, 0)
-            # self.assertTrue(missing, "data should be 'missing'")
-            # self.assertEqual(data, b"")
+            data, missing = brd.get_region_data(0, 0, 0, 0)
+            self.assertTrue(missing, "data should be 'missing'")
+            self.assertEqual(data, b"")
 
             brd.start_new_extraction()
             brd.store_data_in_region_buffer(0, 0, 0, 0, False, b"abc")
+            data, missing = brd.get_region_data(0, 0, 0, 0)
+            self.assertFalse(missing, "data shouldn't be 'missing'")
+            self.assertEqual(bytes(data), b"abc")
+
             brd.start_new_extraction()
             brd.store_data_in_region_buffer(0, 0, 0, 0, False, b"def")
             data, missing = brd.get_region_data(0, 0, 0, 0)
-
             self.assertFalse(missing, "data shouldn't be 'missing'")
             self.assertEqual(bytes(data), b"abcdef")
+
+            brd.start_new_extraction()
+            brd.store_data_in_region_buffer(0, 0, 0, 0, True, b"g")
+            data, missing = brd.get_region_data(0, 0, 0, 0)
+            self.assertTrue(missing, "data should be 'missing'")
+            self.assertEqual(bytes(data), b"abcdefg")
 
             self.assertTrue(os.path.isfile(f), "DB still exists")
 

--- a/unittests/interface/buffer_management/test_buffered_manager.py
+++ b/unittests/interface/buffer_management/test_buffered_manager.py
@@ -34,15 +34,17 @@ from spinn_front_end_common.interface.config_setup import unittest_setup
 from spinn_front_end_common.utilities.exceptions import (
     BufferedRegionNotPresent)
 
+
 class MockAbstractReceiveBuffersToHost(SimpleMachineVertex,
                                        AbstractReceiveBuffersToHost):
     @overrides(AbstractReceiveBuffersToHost.get_recorded_region_ids)
     def get_recorded_region_ids(self) -> Sequence[int]:
-        return[0]
+        return [0]
 
     @overrides(AbstractReceiveBuffersToHost.get_recording_region_base_address)
     def get_recording_region_base_address(self, placement: Placement) -> int:
         raise NotImplementedError
+
 
 class TestBufferedDatabase(unittest.TestCase):
 
@@ -78,7 +80,7 @@ class TestBufferedDatabase(unittest.TestCase):
 
             with self.assertRaises(LookupError):
                 brd.get_region_data(1, 2, 3, 0)
-                
+
         with self.assertRaises(BufferedRegionNotPresent):
             bm.get_data_by_placement(p1, 0)
 
@@ -115,10 +117,9 @@ class TestBufferedDatabase(unittest.TestCase):
             self.assertFalse(missing, "data shouldn't be 'missing'")
             self.assertEqual(bytes(data), b"def")
 
-            data, missing = brd.get_region_data_by_extraction_id(1, 2, 3, 0, -1)
+            data, missing = brd.get_region_data_by_extraction_id(
+                1, 2, 3, 0, -1)
             self.assertTrue(missing, "data should be 'missing'")
             self.assertEqual(bytes(data), b"g")
 
             self.assertTrue(os.path.isfile(f), "DB still exists")
-
-

--- a/unittests/interface/buffer_management/test_buffered_manager.py
+++ b/unittests/interface/buffer_management/test_buffered_manager.py
@@ -75,8 +75,8 @@ class TestBufferedDatabase(unittest.TestCase):
             self.assertEqual("V1", label)
             label = brd.get_core_name(1, 2, 5)
             self.assertEqual("V2", label)
-            label = brd.get_core_name(4, 3, 0)
-            self.assertEqual("SCAMP(OS)_4:3", label)
+            label = brd.get_core_name(1, 1, 0)
+            self.assertEqual("SCAMP(OS)_1:1", label)
 
             with self.assertRaises(LookupError):
                 brd.get_region_data(1, 2, 3, 0)
@@ -134,7 +134,7 @@ class TestBufferedDatabase(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             bm.get_data_by_placement(p, 1)
 
-    def test_not_recording(self):
+    def test_not_data_recorded(self):
         writer = FecDataWriter.mock()
         v = MockAbstractReceiveBuffersToHost(None, label="V2")
         p = Placement(v, 1, 2, 5)
@@ -142,12 +142,12 @@ class TestBufferedDatabase(unittest.TestCase):
         writer.set_placements(info)
         bm = BufferManager()
         try:
-            bm.get_data_by_placement(p, 1)
-            raise Exception("SException should have been raised")
+            bm.get_data_by_placement(p, 0)
+            raise Exception("Exception should have been raised")
         except BufferedRegionNotPresent as ex:
             self.assertIn("should have record region", str(ex))
 
-    def test_no_data_recording(self):
+    def test_not_recording_region(self):
         writer = FecDataWriter.mock()
         v = MockAbstractReceiveBuffersToHost(None, label="V2")
         p = Placement(v, 1, 2, 5)
@@ -156,6 +156,6 @@ class TestBufferedDatabase(unittest.TestCase):
         bm = BufferManager()
         try:
             bm.get_data_by_placement(p, 1)
-            raise Exception("SException should have been raised")
+            raise Exception("Exception should have been raised")
         except BufferedRegionNotPresent as ex:
             self.assertIn("not set to record region 1", str(ex))

--- a/unittests/interface/buffer_management/test_buffered_manager.py
+++ b/unittests/interface/buffer_management/test_buffered_manager.py
@@ -123,3 +123,39 @@ class TestBufferedDatabase(unittest.TestCase):
             self.assertEqual(bytes(data), b"g")
 
             self.assertTrue(os.path.isfile(f), "DB still exists")
+
+    def test_not_recording_type(self):
+        writer = FecDataWriter.mock()
+        info = Placements([])
+        writer.set_placements(info)
+        bm = BufferManager()
+        v = SimpleMachineVertex(None, label="V2")
+        p = Placement(v, 1, 2, 5)
+        with self.assertRaises(NotImplementedError):
+            bm.get_data_by_placement(p, 1)
+
+    def test_not_recording(self):
+        writer = FecDataWriter.mock()
+        v = MockAbstractReceiveBuffersToHost(None, label="V2")
+        p = Placement(v, 1, 2, 5)
+        info = Placements([p])
+        writer.set_placements(info)
+        bm = BufferManager()
+        try:
+            bm.get_data_by_placement(p, 1)
+            raise Exception("SException should have been raised")
+        except BufferedRegionNotPresent as ex:
+            self.assertIn("should have record region", str(ex))
+
+    def test_no_data_recording(self):
+        writer = FecDataWriter.mock()
+        v = MockAbstractReceiveBuffersToHost(None, label="V2")
+        p = Placement(v, 1, 2, 5)
+        info = Placements([p])
+        writer.set_placements(info)
+        bm = BufferManager()
+        try:
+            bm.get_data_by_placement(p, 1)
+            raise Exception("SException should have been raised")
+        except BufferedRegionNotPresent as ex:
+            self.assertIn("not set to record region 1", str(ex))

--- a/unittests/interface/buffer_management/test_buffered_manager.py
+++ b/unittests/interface/buffer_management/test_buffered_manager.py
@@ -152,7 +152,7 @@ class TestBufferedDatabase(unittest.TestCase):
         data, missing = bm.get_data_by_placement(p1, 0)
         self.assertFalse(missing, "data shouldn't be 'missing'")
         self.assertEqual(bytes(data), b"abcdef")
-        bm.clear_recorded_data(1,2,3, 0)
+        bm.clear_recorded_data(1, 2, 3, 0)
         data, missing = bm.get_data_by_placement(p1, 0)
         self.assertTrue(missing, "data should be 'missing'")
         self.assertEqual(bytes(data), b"")

--- a/unittests/interface/buffer_management/test_buffered_manager.py
+++ b/unittests/interface/buffer_management/test_buffered_manager.py
@@ -14,16 +14,35 @@
 
 import unittest
 import os
+from typing import Sequence
+
 from spinn_utilities.config_holder import set_config
+from spinn_utilities.overrides import overrides
+
 from spinn_machine.version.version_strings import VersionStrings
+
 from pacman.model.graphs.machine import SimpleMachineVertex
 from pacman.model.placements import Placement, Placements
+
 from spinn_front_end_common.data.fec_data_writer import FecDataWriter
 from spinn_front_end_common.interface.buffer_management import BufferManager
+from spinn_front_end_common.interface.buffer_management.buffer_models import (
+    AbstractReceiveBuffersToHost)
 from spinn_front_end_common.interface.buffer_management.storage_objects \
     import BufferDatabase
 from spinn_front_end_common.interface.config_setup import unittest_setup
+from spinn_front_end_common.utilities.exceptions import (
+    BufferedRegionNotPresent)
 
+class MockAbstractReceiveBuffersToHost(SimpleMachineVertex,
+                                       AbstractReceiveBuffersToHost):
+    @overrides(AbstractReceiveBuffersToHost.get_recorded_region_ids)
+    def get_recorded_region_ids(self) -> Sequence[int]:
+        return[0]
+
+    @overrides(AbstractReceiveBuffersToHost.get_recording_region_base_address)
+    def get_recording_region_base_address(self, placement: Placement) -> int:
+        raise NotImplementedError
 
 class TestBufferedDatabase(unittest.TestCase):
 
@@ -32,66 +51,74 @@ class TestBufferedDatabase(unittest.TestCase):
 
     def test_use_database(self):
         set_config("Machine", "versions", VersionStrings.ANY.text)
+        writer = FecDataWriter.mock()
         f = BufferDatabase.default_database_file()
         self.assertFalse(os.path.isfile(f), "no existing DB at first")
 
-        with BufferDatabase() as brd:
-            self.assertTrue(os.path.isfile(f), "DB now exists")
-
-            with self.assertRaises(LookupError):
-                data, missing = brd.get_region_data(0, 0, 0, 0)
-
-            brd.start_new_extraction()
-            brd.store_data_in_region_buffer(0, 0, 0, 0, False, b"abc")
-            data, missing = brd.get_region_data(0, 0, 0, 0)
-            self.assertFalse(missing, "data shouldn't be 'missing'")
-            self.assertEqual(bytes(data), b"abc")
-
-            brd.start_new_extraction()
-            brd.store_data_in_region_buffer(0, 0, 0, 0, False, b"def")
-            data, missing = brd.get_region_data(0, 0, 0, 0)
-            self.assertFalse(missing, "data shouldn't be 'missing'")
-            self.assertEqual(bytes(data), b"abcdef")
-
-            brd.start_new_extraction()
-            brd.store_data_in_region_buffer(0, 0, 0, 0, True, b"g")
-            data, missing = brd.get_region_data(0, 0, 0, 0)
-            self.assertTrue(missing, "data should be 'missing'")
-            self.assertEqual(bytes(data), b"abcdefg")
-
-            data, missing = brd.get_region_data_by_extraction_id(0, 0, 0, 0, 2)
-            self.assertFalse(missing, "data shouldn't be 'missing'")
-            self.assertEqual(bytes(data), b"def")
-
-            data, missing = brd.get_region_data_by_extraction_id(0, 0, 0, 0, -1)
-            self.assertTrue(missing, "data should be 'missing'")
-            self.assertEqual(bytes(data), b"g")
-
-            self.assertTrue(os.path.isfile(f), "DB still exists")
-
-    def test_placements(self):
-        set_config("Machine", "versions", VersionStrings.BIG.text)
-        writer = FecDataWriter.mock()
         info = Placements([])
-        p1 = Placement(SimpleMachineVertex(None, label="V1"), 1, 2, 3)
+        p1 = Placement(
+            MockAbstractReceiveBuffersToHost(None, label="V1"), 1, 2, 3)
         info.add_placement(p1)
         v2 = SimpleMachineVertex(None, label="V2")
         p2 = Placement(v2, 1, 2, 5)
         info.add_placement(p2)
         info.add_placement(Placement(SimpleMachineVertex(None), 2, 2, 3))
         writer.set_placements(info)
-        with BufferDatabase() as db:
-            db.start_new_extraction()
-            db.store_data_in_region_buffer(1, 2, 3, 0, False, b"abc")
-            db.store_vertex_labels()
-            label = db.get_core_name(1, 2, 3)
+        bm = BufferManager()
+        with BufferDatabase() as brd:
+            self.assertTrue(os.path.isfile(f), "DB now exists")
+
+            brd.store_vertex_labels()
+            label = brd.get_core_name(1, 2, 3)
             self.assertEqual("V1", label)
-            label = db.get_core_name(1, 2, 5)
+            label = brd.get_core_name(1, 2, 5)
             self.assertEqual("V2", label)
-            label = db.get_core_name(4, 3, 0)
+            label = brd.get_core_name(4, 3, 0)
             self.assertEqual("SCAMP(OS)_4:3", label)
 
-        bm = BufferManager()
+            with self.assertRaises(LookupError):
+                brd.get_region_data(1, 2, 3, 0)
+                
+        with self.assertRaises(BufferedRegionNotPresent):
+            bm.get_data_by_placement(p1, 0)
+
+        with BufferDatabase() as brd:
+            brd.start_new_extraction()
+            brd.store_data_in_region_buffer(1, 2, 3, 0, False, b"abc")
+            data, missing = brd.get_region_data(1, 2, 3, 0)
+            self.assertFalse(missing, "data shouldn't be 'missing'")
+            self.assertEqual(bytes(data), b"abc")
+
         data, missing = bm.get_data_by_placement(p1, 0)
-        self.assertFalse(missing, "data should not be 'missing'")
+        self.assertFalse(missing, "data shouldn't be 'missing'")
         self.assertEqual(bytes(data), b"abc")
+
+        with BufferDatabase() as brd:
+            brd.start_new_extraction()
+            brd.store_data_in_region_buffer(1, 2, 3, 0, False, b"def")
+            data, missing = brd.get_region_data(1, 2, 3, 0)
+            self.assertFalse(missing, "data shouldn't be 'missing'")
+            self.assertEqual(bytes(data), b"abcdef")
+
+            brd.start_new_extraction()
+            brd.store_data_in_region_buffer(1, 2, 3, 0, True, b"g")
+            data, missing = brd.get_region_data(1, 2, 3, 0)
+            self.assertTrue(missing, "data should be 'missing'")
+            self.assertEqual(bytes(data), b"abcdefg")
+
+        data, missing = bm.get_data_by_placement(p1, 0)
+        self.assertTrue(missing, "data should be 'missing'")
+        self.assertEqual(bytes(data), b"abcdefg")
+
+        with BufferDatabase() as brd:
+            data, missing = brd.get_region_data_by_extraction_id(1, 2, 3, 0, 2)
+            self.assertFalse(missing, "data shouldn't be 'missing'")
+            self.assertEqual(bytes(data), b"def")
+
+            data, missing = brd.get_region_data_by_extraction_id(1, 2, 3, 0, -1)
+            self.assertTrue(missing, "data should be 'missing'")
+            self.assertEqual(bytes(data), b"g")
+
+            self.assertTrue(os.path.isfile(f), "DB still exists")
+
+

--- a/unittests/interface/buffer_management/test_buffered_manager.py
+++ b/unittests/interface/buffer_management/test_buffered_manager.py
@@ -19,6 +19,7 @@ from spinn_machine.version.version_strings import VersionStrings
 from pacman.model.graphs.machine import SimpleMachineVertex
 from pacman.model.placements import Placement, Placements
 from spinn_front_end_common.data.fec_data_writer import FecDataWriter
+from spinn_front_end_common.interface.buffer_management import BufferManager
 from spinn_front_end_common.interface.buffer_management.storage_objects \
     import BufferDatabase
 from spinn_front_end_common.interface.config_setup import unittest_setup
@@ -61,26 +62,12 @@ class TestBufferedDatabase(unittest.TestCase):
             self.assertTrue(missing, "data should be 'missing'")
             self.assertEqual(bytes(data), b"abcdefg")
 
-            self.assertTrue(os.path.isfile(f), "DB still exists")
+            data, missing = brd.get_region_data_by_extraction_id(0, 0, 0, 0, 2)
+            self.assertFalse(missing, "data shouldn't be 'missing'")
+            self.assertEqual(bytes(data), b"def")
 
-    def test_placements(self):
-        set_config("Machine", "versions", VersionStrings.BIG.text)
-        writer = FecDataWriter.mock()
-        info = Placements([])
-        p1 = Placement(SimpleMachineVertex(None, label="V1"), 1, 2, 3)
-        info.add_placement(p1)
-        v2 = SimpleMachineVertex(None, label="V2")
-        p2 = Placement(v2, 1, 2, 5)
-        info.add_placement(p2)
-        info.add_placement(Placement(SimpleMachineVertex(None), 2, 2, 3))
-        writer.set_placements(info)
-        with BufferDatabase() as db:
-            db.start_new_extraction()
-            db.store_data_in_region_buffer(1, 2, 3, 0, False, b"abc")
-            db.store_vertex_labels()
-            label = db.get_core_name(1, 2, 3)
-            self.assertEqual("V1", label)
-            label = db.get_core_name(1, 2, 5)
-            self.assertEqual("V2", label)
-            label = db.get_core_name(4, 3, 0)
-            self.assertEqual("SCAMP(OS)_4:3", label)
+            data, missing = brd.get_region_data_by_extraction_id(0, 0, 0, 0, -1)
+            self.assertTrue(missing, "data should be 'missing'")
+            self.assertEqual(bytes(data), b"g")
+
+            self.assertTrue(os.path.isfile(f), "DB still exists")

--- a/unittests/interface/buffer_management/test_buffered_manager.py
+++ b/unittests/interface/buffer_management/test_buffered_manager.py
@@ -75,8 +75,16 @@ class TestBufferedDatabase(unittest.TestCase):
             self.assertEqual("V1", label)
             label = brd.get_core_name(1, 2, 5)
             self.assertEqual("V2", label)
-            label = brd.get_core_name(1, 1, 0)
-            self.assertEqual("SCAMP(OS)_1:1", label)
+
+            label = brd.get_core_name(0, 0, 0)
+            self.assertEqual("SCAMP(OS)_0:0", label)
+            version = writer.get_machine_version()
+            if version.n_chips_per_board >= 4:
+                label = brd.get_core_name(1, 1, 0)
+                self.assertEqual("SCAMP(OS)_1:1", label)
+            if version.n_chips_per_board >= 40:
+                label = brd.get_core_name(4, 3, 0)
+                self.assertEqual("SCAMP(OS)_4:3", label)
 
             with self.assertRaises(LookupError):
                 brd.get_region_data(1, 2, 3, 0)


### PR DESCRIPTION
Must be done at the same time as:
https://github.com/SpiNNakerManchester/JavaSpiNNaker/pull/1172
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1479
tested by 
https://github.com/SpiNNakerManchester/IntegrationTests/pull/288

---
In master on a second run without reset data is split between region and region_extra
So two tables holding near the same data.

In this PR.
table region_data table replaces both tables

supported by
extraction and setup tables.

between the three tables for each core extraction the database holds
x, y, processor, local_region_index, content, content_len, run_timestep, run_time_ms, n_run, n_loop, extraction_time

---

This now writes a region data row for every recording region every extraction (run/auto pause loop) even if the data read is empty..  This allows distinguish between the correct data read but empty and the error of never reading the region.

Also on clear the record is not removed just changed to empty and the missing_data set to 2

---

Getting data raises clearer exceptions.
- If a virtual Machine is being used missing record records are allowed
- if missing and incorrect type NotImplementedError
- if missing and correct type BufferedRegionNotPresent saying either region not read or region not set to record

---
The BufferManager methods that Extract data from cores have been renamed with "extract" rather than get or retreive




