### PR TITLE
recording data fixes

### DIFF
--- a/spinn_front_end_common/data/fec_data_view.py
+++ b/spinn_front_end_common/data/fec_data_view.py
@@ -94,6 +94,7 @@ class _FecDataModel(object):
         "_live_packet_recorder_params",
         "_live_output_vertices",
         "_live_output_devices",
+        "_n_run_steps",
         "_next_sync_signal",
         "_next_ds_reference",
         "_none_labelled_edge_count",
@@ -187,6 +188,7 @@ class _FecDataModel(object):
         self._current_run_timesteps: Optional[int] = 0
         self._first_machine_time_step = 0
         self._run_step: Optional[int] = None
+        self._n_run_steps: Optional[int] = None
 
     def _clear_notification_protocol(self) -> None:
         if self._notification_protocol:
@@ -569,6 +571,23 @@ class FecDataView(PacmanDataView, SpiNNManDataView):
         :rtype: None or int
         """
         return cls.__fec_data._run_step
+
+    @classmethod
+    def is_last_step(cls) -> bool:
+        """
+        Detects if this is the last or only step of this run.
+
+        When not using auto pause resume steps this always returns True
+
+        When running forever with steps this always returns False.
+
+        For auto pause steps of a fixed run time this returns True
+        only on the last of these steps.
+        """
+        if cls.__fec_data._n_run_steps is None:
+            return cls.__fec_data._run_step is None
+        else:
+            return cls.__fec_data._run_step == cls.__fec_data._n_run_steps
 
     # Report directories
     # There are NO has or get methods for directories

--- a/spinn_front_end_common/data/fec_data_writer.py
+++ b/spinn_front_end_common/data/fec_data_writer.py
@@ -540,6 +540,16 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
         # Avoid the safety check in FecDataView
         PacmanDataWriter.add_vertex(vertex)
 
+    def set_n_run_steps(self, n_run_steps: int):
+        """
+        Sets the number of expected run-steps
+
+        Only used for auto pause resume and not running forever
+
+        :param n_run_steps:
+        """
+        self.__fec_data._n_run_steps = n_run_steps
+
     def next_run_step(self) -> int:
         """
         Starts or increases the run step count.
@@ -564,3 +574,4 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
         next_run_step will restart at 1
         """
         self.__fec_data._run_step = None
+        self.__fec_data._n_run_steps = None

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -598,6 +598,7 @@ class AbstractSpinnakerBase(ConfigHandler):
             assert steps is not None
             logger.info("Running for {} steps for a total of {}ms",
                         len(steps), run_time)
+            self._data_writer.set_n_run_steps(len(steps))
             for step in steps:
                 run_step = self._data_writer.next_run_step()
                 logger.info(f"Run {run_step} of {len(steps)}")

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
@@ -207,7 +207,8 @@ class BufferDatabase(BaseDatabase):
                 """, (x, y, p, region)):
             return row["region_id"], row["is_recording"]
         if is_recording is None:
-            raise LookupError(f"There is no region for {x=} {y=} {p=} {region=}")
+            raise LookupError(
+                f"There is no region for {x=} {y=} {p=} {region=}")
 
         core_id = self._get_core_id(x, y, p)
         self.execute(

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
@@ -190,7 +190,8 @@ class BufferDatabase(BaseDatabase):
         return memoryview(c_buffer), missing_data
 
     def _get_region_id(self, x: int, y: int, p: int, region: int,
-                       is_recording: Optional[bool] = None) -> int:
+                       is_recording: Optional[bool] = None) -> Tuple[
+                       int, bool]:
         """
         :param int x:
         :param int y:

--- a/spinn_front_end_common/utilities/db.sql
+++ b/spinn_front_end_common/utilities/db.sql
@@ -52,17 +52,13 @@ CREATE TABLE IF NOT EXISTS region(
 	core_id INTEGER NOT NULL
 		REFERENCES core(core_id) ON DELETE RESTRICT,
 	local_region_index INTEGER NOT NULL,
-	address INTEGER,
-	content BLOB NOT NULL DEFAULT '',
-	content_len INTEGER DEFAULT 0,
-	fetches INTEGER NOT NULL DEFAULT 0,
-	append_time INTEGER);
+    is_recording INTEGER NOT NULL);
 -- Every recording region has a unique vertex and index
 CREATE UNIQUE INDEX IF NOT EXISTS regionSanity ON region(
 	core_id ASC, local_region_index ASC);
 
 CREATE VIEW IF NOT EXISTS region_view AS
-	SELECT core_id, region_id, x, y, processor, local_region_index
+	SELECT core_id, region_id, x, y, processor, local_region_index, is_recording
 FROM core NATURAL JOIN region;
 
 CREATE TABLE IF NOT EXISTS region_data(
@@ -80,12 +76,12 @@ CREATE UNIQUE INDEX IF NOT EXISTS region_data_sanity ON region_data(
 
 CREATE VIEW IF NOT EXISTS region_data_view AS
 	SELECT core_id, region_id, extraction_id, x, y, processor, local_region_index,
-		content, content_len
+		content, content_len, is_recording
 FROM region_view NATURAL JOIN region_data;
 
 CREATE VIEW IF NOT EXISTS region_data_plus_view AS
 	SELECT core_id, region_id, extraction_id, x, y, processor, local_region_index,
-		content, content_len, run_timestep, run_time_ms, n_run, n_loop, extraction_time
+		content, content_len, is_recording, run_timestep, run_time_ms, n_run, n_loop, extraction_time
 FROM region_data_view NATURAL JOIN extraction_view;
 
 -- Information about how to access the connection proxying

--- a/unittests/data/test_simulator_data.py
+++ b/unittests/data/test_simulator_data.py
@@ -649,17 +649,27 @@ class TestSimulatorData(unittest.TestCase):
 
     def test_run_step(self):
         self.assertIsNone(FecDataView.get_run_step())
+        FecDataView.is_last_step()
         writer = FecDataWriter.setup()
+        self.assertTrue(FecDataView.is_last_step())
+        writer.set_n_run_steps(3)
+        self.assertFalse(FecDataView.is_last_step())
         self.assertEqual(1, writer.next_run_step())
         self.assertEqual(1, FecDataView.get_run_step())
+        self.assertFalse(FecDataView.is_last_step())
         self.assertEqual(2, writer.next_run_step())
+        self.assertFalse(FecDataView.is_last_step())
         self.assertEqual(3, writer.next_run_step())
         self.assertEqual(3, FecDataView.get_run_step())
         self.assertEqual(3, FecDataView.get_run_step())
+        self.assertTrue(FecDataView.is_last_step())
         writer.clear_run_steps()
+        self.assertTrue(FecDataView.is_last_step())
         self.assertIsNone(FecDataView.get_run_step())
         self.assertEqual(1, writer.next_run_step())
         self.assertEqual(1, FecDataView.get_run_step())
+        # this time there is no n_time_Step so assuming run forever
+        self.assertFalse(FecDataView.is_last_step())
 
     def test_ds_references(self):
         refs1 = FecDataView.get_next_ds_references(7)

--- a/unittests/interface/buffer_management/test_buffered_manager.py
+++ b/unittests/interface/buffer_management/test_buffered_manager.py
@@ -94,7 +94,7 @@ class TestBufferedDatabase(unittest.TestCase):
 
         with BufferDatabase() as brd:
             brd.start_new_extraction()
-            brd.store_data_in_region_buffer(1, 2, 3, 0, False, b"abc")
+            brd.store_data_in_region_buffer(1, 2, 3, 0, False, b"abc", True)
             data, missing = brd.get_region_data(1, 2, 3, 0)
             self.assertFalse(missing, "data shouldn't be 'missing'")
             self.assertEqual(bytes(data), b"abc")
@@ -105,13 +105,13 @@ class TestBufferedDatabase(unittest.TestCase):
 
         with BufferDatabase() as brd:
             brd.start_new_extraction()
-            brd.store_data_in_region_buffer(1, 2, 3, 0, False, b"def")
+            brd.store_data_in_region_buffer(1, 2, 3, 0, False, b"def", True)
             data, missing = brd.get_region_data(1, 2, 3, 0)
             self.assertFalse(missing, "data shouldn't be 'missing'")
             self.assertEqual(bytes(data), b"abcdef")
 
             brd.start_new_extraction()
-            brd.store_data_in_region_buffer(1, 2, 3, 0, True, b"g")
+            brd.store_data_in_region_buffer(1, 2, 3, 0, True, b"g", True)
             data, missing = brd.get_region_data(1, 2, 3, 0)
             self.assertTrue(missing, "data should be 'missing'")
             self.assertEqual(bytes(data), b"abcdefg")

--- a/unittests/interface/buffer_management/test_buffered_manager.py
+++ b/unittests/interface/buffer_management/test_buffered_manager.py
@@ -145,9 +145,9 @@ class TestBufferedDatabase(unittest.TestCase):
         bm = BufferManager()
         with BufferDatabase() as brd:
             brd.start_new_extraction()
-            brd.store_data_in_region_buffer(1, 2, 3, 0, False, b"abc")
+            brd.store_data_in_region_buffer(1, 2, 3, 0, False, b"abc", True)
             brd.start_new_extraction()
-            brd.store_data_in_region_buffer(1, 2, 3, 0, False, b"def")
+            brd.store_data_in_region_buffer(1, 2, 3, 0, False, b"def", True)
 
         data, missing = bm.get_data_by_placement(p1, 0)
         self.assertFalse(missing, "data shouldn't be 'missing'")


### PR DESCRIPTION
Followup to https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1207 and https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1202

- Add a method to FecData say if this is the last/or only auto pause loop of a run
- Only extract from AbstractReceiveRegionsToHost on the last/only loop
- Change BufferManager.get_placement_data so that for AbstractReceiveRegionsToHost regions it returns ONLY the last data extracted
- Removed the BufferManager.get_last_placement_data method as it is no longer needed.

To do this the database now tracks if the regions is_recording
- True for regions where the data is appended on each loop
- False for regions where the data is just the state at the end of the run
- Cleaned up some columns that should have been removed in https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1207 

The Python tells the Java which placements to extract on each loop!

Must be done at the same time as:
https://github.com/SpiNNakerManchester/JavaSpiNNaker/pull/1189
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1483

Tested by:
https://github.com/SpiNNakerManchester/IntegrationTests/pull/290




