### PR TITLE
split download and recording data tables and methods

### DIFF
--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -411,6 +411,32 @@ class BufferManager(object):
         for placement in progress.over(recording_placements):
             self._retreive_by_placement(placement)
 
+    def get_data_by_placement(self, placement: Placement,
+                              recording_region_id: int) -> Tuple[bytes, bool]:
+        """
+        Deprecated use get_recording or get_download
+
+        :param placement:
+        :param recording_region_id:
+        :return:
+        """
+        if isinstance(placement.vertex, AbstractReceiveBuffersToHost):
+            if isinstance(placement.vertex, AbstractReceiveRegionsToHost):
+                raise SpinnFrontEndException(
+                    f"The vertex {placement.vertex} could return "
+                    f"either recording or download data")
+            logger.warning(
+                "get_data_by_placement is deprecated use get_recording")
+            return self.get_recording(placement, recording_region_id)
+
+        elif isinstance(placement.vertex, AbstractReceiveRegionsToHost):
+            raise SpinnFrontEndException(
+                f"Use the get_download method")
+
+        else:
+            raise NotImplementedError(
+                f"Unable to get data for vertex {placement.vertex}")
+
     def get_recording(self, placement: Placement,
                       recording_region_id: int) -> Tuple[bytes, bool]:
         """

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -246,7 +246,7 @@ class BufferManager(object):
         :param int recording_region_id: the recording region ID
         """
         with BufferDatabase() as db:
-            db.clear_region(x, y, p, recording_region_id)
+            db.clear_recording_region(x, y, p, recording_region_id)
 
     def _create_message_to_send(
             self, size: int, vertex: AbstractSendsBuffersFromHost,

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -411,16 +411,13 @@ class BufferManager(object):
         for placement in progress.over(recording_placements):
             self._retreive_by_placement(placement)
 
-    def get_data_by_placement(
-            self, placement: Placement, recording_region_id: int) -> Tuple[
-                bytes, bool]:
+    def get_recording(self, placement: Placement,
+                      recording_region_id: int) -> Tuple[bytes, bool]:
         """
         Get the data container for the data retrieved
         during the simulation from a specific region area of a core.
 
-        If this is a recoding region the data for all extractions is combined.
-
-        For none recording regions only the last data extracted is returned.
+        Data for all extractions is combined.
 
         :param ~pacman.model.placements.Placement placement:
             the placement to get the data from
@@ -442,12 +439,13 @@ class BufferManager(object):
             return self._raise_error(
                 placement, recording_region_id, lookup_error)
 
-    def get_last_data_by_placement(
-            self, placement: Placement, recording_region_id: int) -> Tuple[
-                bytes, bool]:
+    def get_download(self, placement: Placement,
+                     recording_region_id: int) -> Tuple[bytes, bool]:
         """
-        Get the data container for all the data retrieved
+        Get the data container for the data retrieved
         during the simulation from a specific region area of a core.
+
+        Only the last data extracted is returned.
 
         :param ~pacman.model.placements.Placement placement:
             the placement to get the data from
@@ -462,9 +460,9 @@ class BufferManager(object):
         """
         try:
             with BufferDatabase() as db:
-                return db.get_region_data_by_extraction_id(
+                return db.get_region_data(
                     placement.x, placement.y, placement.p,
-                    recording_region_id, -1)
+                    recording_region_id)
         except LookupError as lookup_error:
             return self._raise_error(
                 placement, recording_region_id, lookup_error)

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -432,9 +432,8 @@ class BufferManager(object):
         """
         try:
             with BufferDatabase() as db:
-                return db.get_region_data(
-                    placement.x, placement.y, placement.p,
-                    recording_region_id)
+                return db.get_recording(placement.x, placement.y, placement.p,
+                                        recording_region_id)
         except LookupError as lookup_error:
             return self._raise_error(
                 placement, recording_region_id, lookup_error)
@@ -460,9 +459,9 @@ class BufferManager(object):
         """
         try:
             with BufferDatabase() as db:
-                return db.get_region_data(
+                return db.get_download_by_extraction_id(
                     placement.x, placement.y, placement.p,
-                    recording_region_id)
+                    recording_region_id, -1)
         except LookupError as lookup_error:
             return self._raise_error(
                 placement, recording_region_id, lookup_error)
@@ -522,17 +521,15 @@ class BufferManager(object):
                 data = self._request_data(
                     placement.x, placement.y, addr, size)
                 with BufferDatabase() as db:
-                    db.store_data_in_region_buffer(
-                        placement.x, placement.y, placement.p, region, missing,
-                        data, True)
+                    db.store_recording(placement.x, placement.y, placement.p,
+                                       region, missing, data)
         if isinstance(placement.vertex, AbstractReceiveRegionsToHost):
             dl_vtx = cast(AbstractReceiveRegionsToHost, placement.vertex)
             for region, addr, size in dl_vtx.get_download_regions(placement):
                 data = self._request_data(placement.x, placement.y, addr, size)
                 with BufferDatabase() as db:
-                    db.store_data_in_region_buffer(
-                        placement.x, placement.y, placement.p, region, False,
-                        data, False)
+                    db.store_download(placement.x, placement.y, placement.p,
+                                      region, False, data)
 
     def _get_region_information(
             self, address: int, x: int, y: int) -> List[Tuple[int, int, bool]]:

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -430,8 +430,7 @@ class BufferManager(object):
             return self.get_recording(placement, recording_region_id)
 
         elif isinstance(placement.vertex, AbstractReceiveRegionsToHost):
-            raise SpinnFrontEndException(
-                f"Use the get_download method")
+            raise SpinnFrontEndException("Use the get_download method")
 
         else:
             raise NotImplementedError(

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
@@ -45,7 +45,8 @@ class BufferDatabase(BaseDatabase):
 
     __slots__ = ()
 
-    def clear_region(self, x: int, y: int, p: int, region: int) -> bool:
+    def clear_recording_region(
+            self, x: int, y: int, p: int, region: int) -> bool:
         """
         Clears the data for a single region.
 
@@ -61,19 +62,19 @@ class BufferDatabase(BaseDatabase):
         """
         for row in self.execute(
                 """
-                SELECT region_id FROM region_view
+                SELECT recording_region_id FROM recording_region_view
                 WHERE x = ? AND y = ? AND processor = ?
                     AND local_region_index = ?
                 LIMIT 1
                 """, (x, y, p, region)):
-            region_id = int(row["region_id"])
+            region_id = int(row["recording_region_id"])
             break
         else:
             return False
 
-        return self._clear_region(region_id)
+        return self._clear_recording_region(region_id)
 
-    def _clear_region(self, region_id: int) -> bool:
+    def _clear_recording_region(self, region_id: int) -> bool:
         """
         Clears out a region leaving empty data and a missing of 2
 
@@ -82,23 +83,27 @@ class BufferDatabase(BaseDatabase):
         """
         self.execute(
             """
-            UPDATE region_data SET
+            UPDATE recording_data SET
             content = CAST('' AS BLOB), content_len = 0, missing_data = 2
-            WHERE region_id = ?
+            WHERE recording_region_id = ?
             """, (region_id,))
         return True
 
-    def _read_contents(self, region_id: int) -> memoryview:
+    def _read_recording(self, region_id: int) -> memoryview:
         """
+        Read a recording region
+
         :param int region_id:
         :rtype: memoryview
         """
-        content, _ = self._read_contents_with_missing(region_id)
+        content, _ = self._read_recording_with_missing(region_id)
         return content
 
-    def _read_contents_with_missing(self, region_id: int) -> Tuple[
+    def _read_recording_with_missing(self, region_id: int) -> Tuple[
             memoryview, bool]:
         """
+        Get the contents from a recording region
+
         :param int region_id:
         :rtype: memoryview, bool
         """
@@ -106,8 +111,8 @@ class BufferDatabase(BaseDatabase):
                 """
                 SELECT count(*) as n_extractions,
                 SUM(content_len) as total_content_length
-                FROM region_data
-                WHERE region_id = ?
+                FROM recording_data
+                WHERE recording_region_id = ?
                 LIMIT 1
                 """, (region_id, )):
             n_extractions = row["n_extractions"]
@@ -115,13 +120,13 @@ class BufferDatabase(BaseDatabase):
         if n_extractions <= 1:
             return self._read_contents_single(region_id)
         else:
-            return self._read_content_multiple(
+            return self._read_recording_multiple(
                 region_id, total_content_length)
 
     def _read_contents_single(self, region_id: int) -> Tuple[
             memoryview, bool]:
         """
-        Reads the content for a single block for this region
+        Reads the content for a single block for this recording region
 
         :param int region_id:
         :rtype: memoryview
@@ -129,8 +134,8 @@ class BufferDatabase(BaseDatabase):
         for row in self.execute(
                 """
                 SELECT content, missing_data
-                FROM region_data
-                WHERE region_id = ?
+                FROM recording_data
+                WHERE recording_region_id = ?
                 LIMIT 1
                 """, (region_id,)):
             return memoryview(row["content"]), row['missing_data'] != 0
@@ -140,7 +145,7 @@ class BufferDatabase(BaseDatabase):
         else:
             raise LookupError(f"no record for region {region_id}")
 
-    def _read_contents_by_extraction_id(
+    def _read_recording_by_extraction_id(
             self, region_id: int,
             extraction_id: int) -> Tuple[memoryview, bool]:
         """
@@ -156,8 +161,8 @@ class BufferDatabase(BaseDatabase):
         for row in self.execute(
                 """
                 SELECT content, missing_data
-                FROM region_data
-                WHERE region_id = ? AND extraction_id = ?
+                FROM recording_data
+                WHERE recording_region_id = ? AND extraction_id = ?
                 LIMIT 1
                 """, (region_id, extraction_id)):
             return memoryview(row["content"]), row['missing_data'] != 0
@@ -165,7 +170,32 @@ class BufferDatabase(BaseDatabase):
         raise LookupError(
             f"no record for {region_id=} and {extraction_id=}")
 
-    def _read_content_multiple(
+    def _read_download_by_extraction_id(
+            self, region_id: int,
+            extraction_id: int) -> Tuple[memoryview, bool]:
+        """
+        Reads the content for a single block for this region
+
+        :param int region_id:
+        :rtype: memoryview
+        """
+        if extraction_id < 0:
+            last_extraction_id = self.get_last_extraction_id()
+            extraction_id = last_extraction_id + 1 + extraction_id
+
+        for row in self.execute(
+                """
+                SELECT content, missing_data
+                FROM download_data
+                WHERE download_region_id = ? AND extraction_id = ?
+                LIMIT 1
+                """, (region_id, extraction_id)):
+            return memoryview(row["content"]), row['missing_data'] != 0
+
+        raise LookupError(
+            f"no record for {region_id=} and {extraction_id=}")
+
+    def _read_recording_multiple(
             self, region_id: int, total_content_length: int) -> Tuple[
             memoryview, bool]:
         """
@@ -180,8 +210,8 @@ class BufferDatabase(BaseDatabase):
         idx = 0
         for row in self.execute(
                 """
-                SELECT content, missing_data FROM region_data
-                WHERE region_id = ? ORDER BY extraction_id ASC
+                SELECT content, missing_data FROM recording_data
+                WHERE recording_region_id = ? ORDER BY extraction_id ASC
                 """, (region_id, )):
             item = row["content"]
             c_buffer[idx:idx + len(item)] = item
@@ -189,29 +219,34 @@ class BufferDatabase(BaseDatabase):
             missing_data = missing_data or row["missing_data"] != 0
         return memoryview(c_buffer), missing_data
 
-    def _find_existing_recording_region_id(self, x: int, y: int, p: int, region: int):
+    def _find_existing_recording_region_id(
+            self, x: int, y: int, p: int, region: int) -> Optional[int]:
         for row in self.execute(
                 """
-                SELECT region_id, is_recording FROM region_view
+                SELECT recording_region_id 
+                FROM recording_region_view
                 WHERE x = ? AND y = ? AND processor = ?
                     AND local_region_index = ?
                 LIMIT 1
                 """, (x, y, p, region)):
-            return row["region_id"], row["is_recording"]
+            return row["recording_region_id"]
         return None
 
-    def _find_existing_download_region_id(self, x: int, y: int, p: int, region: int):
+    def _find_existing_download_region_id(
+            self, x: int, y: int, p: int, region: int) -> Optional[int]:
         for row in self.execute(
                 """
-                SELECT region_id, is_recording FROM region_view
+                SELECT download_region_id 
+                FROM download_region_view
                 WHERE x = ? AND y = ? AND processor = ?
                     AND local_region_index = ?
                 LIMIT 1
                 """, (x, y, p, region)):
-            return row["region_id"], row["is_recording"]
+            return row["download_region_id"]
         return None
 
-    def _get_existing_recording_region_id(self, x: int, y: int, p: int, region: int):
+    def _get_existing_recording_region_id(
+            self, x: int, y: int, p: int, region: int) -> int:
         region_id = self._find_existing_recording_region_id(x, y, p, region)
         if region_id is None:
             raise LookupError(
@@ -220,7 +255,7 @@ class BufferDatabase(BaseDatabase):
             return region_id
 
     def _get_existing_download_region_id(
-            self, x: int, y: int, p: int, region: int):
+            self, x: int, y: int, p: int, region: int) -> int:
         region_id = self._find_existing_download_region_id(x, y, p, region)
         if region_id is None:
             raise LookupError(
@@ -228,7 +263,8 @@ class BufferDatabase(BaseDatabase):
         else:
             return region_id
 
-    def _get_recording_region_id(self, x: int, y: int, p: int, region: int) -> int:
+    def _get_recording_region_id(
+            self, x: int, y: int, p: int, region: int) -> int:
         """
         :param int x:
         :param int y:
@@ -238,20 +274,21 @@ class BufferDatabase(BaseDatabase):
         """
         region_info = self._find_existing_recording_region_id(x, y, p, region)
         if region_info is not None:
-            return region_info[0]
+            return region_info
 
         core_id = self._get_core_id(x, y, p)
         self.execute(
             """
-            INSERT INTO region(
-                core_id, local_region_index, is_recording)
-            VALUES(?, ?, ?)
-            """, (core_id, region, True))
+            INSERT INTO recording_region(
+                core_id, local_region_index)
+            VALUES(?, ?)
+            """, (core_id, region))
         region_id = self.lastrowid
         assert region_id is not None
         return region_id
 
-    def _get_download_region_id(self, x: int, y: int, p: int, region: int) -> int:
+    def _get_download_region_id(
+            self, x: int, y: int, p: int, region: int) -> int:
         """
         :param int x:
         :param int y:
@@ -261,15 +298,15 @@ class BufferDatabase(BaseDatabase):
         """
         region_info = self._find_existing_download_region_id(x, y, p, region)
         if region_info is not None:
-            return region_info[0]
+            return region_info
 
         core_id = self._get_core_id(x, y, p)
         self.execute(
             """
-            INSERT INTO region(
-                core_id, local_region_index, is_recording)
-            VALUES(?, ?, ?)
-            """, (core_id, region, False))
+            INSERT INTO download_region(
+                core_id, local_region_index)
+            VALUES(?, ?)
+            """, (core_id, region))
         region_id = self.lastrowid
         assert region_id is not None
         return region_id
@@ -349,8 +386,8 @@ class BufferDatabase(BaseDatabase):
         extraction_id = self.get_last_extraction_id()
         self.execute(
             """
-            INSERT INTO region_data(
-                region_id, extraction_id, content, content_len, missing_data)
+            INSERT INTO recording_data(
+                recording_region_id, extraction_id, content, content_len, missing_data)
             VALUES (?, ?, CAST(? AS BLOB), ?, ?)
             """, (region_id, extraction_id, datablob, len(data), missing))
         assert self.rowcount == 1
@@ -376,14 +413,16 @@ class BufferDatabase(BaseDatabase):
         # pylint: disable=too-many-arguments, unused-argument
         # TODO: Use missing
         datablob = Binary(data)
-        region_id = self._get_download_region_id(x, y, p, region)
+        download_region_id = self._get_download_region_id(x, y, p, region)
         extraction_id = self.get_last_extraction_id()
         self.execute(
             """
-            INSERT INTO region_data(
-                region_id, extraction_id, content, content_len, missing_data)
+            INSERT INTO download_data(
+                download_region_id, extraction_id, content, content_len,
+                missing_data)
             VALUES (?, ?, CAST(? AS BLOB), ?, ?)
-            """, (region_id, extraction_id, datablob, len(data), missing))
+            """, (download_region_id, extraction_id, datablob, len(data),
+                  missing))
         assert self.rowcount == 1
 
     def store_data_in_region_buffer(
@@ -415,9 +454,9 @@ class BufferDatabase(BaseDatabase):
         :rtype: tuple(memoryview, bool)
         :raises LookupErrror: If no data is available nor marked missing.
         """
-        region_id, is_recording = self._get_existing_recording_region_id(
+        region_id = self._get_existing_recording_region_id(
             x, y, p, region)
-        return self._read_contents_with_missing(region_id)
+        return self._read_recording_with_missing(region_id)
 
     def get_recording_by_extraction_id(
             self, x: int, y: int, p: int, region: int,
@@ -442,9 +481,9 @@ class BufferDatabase(BaseDatabase):
         :rtype: tuple(memoryview, bool)
         """
         try:
-            region_id, _ = self._get_existing_recording_region_id(
+            region_id = self._get_existing_recording_region_id(
                 x, y, p, region)
-            return self._read_contents_by_extraction_id(
+            return self._read_recording_by_extraction_id(
                 region_id, extraction_id)
         except LookupError:
             return memoryview(b''), True
@@ -471,9 +510,8 @@ class BufferDatabase(BaseDatabase):
 
         :rtype: tuple(memoryview, bool)
         """
-        region_id, _ = self._get_existing_download_region_id(
-            x, y, p, region)
-        return self._read_contents_by_extraction_id(
+        region_id = self._get_existing_download_region_id(x, y, p, region)
+        return self._read_download_by_extraction_id(
             region_id, extraction_id)
 
     def write_session_credentials_to_db(self) -> None:

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
@@ -427,11 +427,6 @@ class BufferDatabase(BaseDatabase):
                   missing))
         assert self.rowcount == 1
 
-    def store_data_in_region_buffer(
-            self, x: int, y: int, p: int, region: int, missing: bool,
-            data: bytes, is_recording: bool):
-        pass
-
     def get_recording(self, x: int, y: int, p: int, region: int) -> Tuple[
             memoryview, bool]:
         """

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
@@ -189,7 +189,7 @@ class BufferDatabase(BaseDatabase):
             missing_data = missing_data or row["missing_data"] != 0
         return memoryview(c_buffer), missing_data
 
-    def _find_existing_regiond_id(self, x: int, y: int, p: int, region: int):
+    def _find_existing_recording_region_id(self, x: int, y: int, p: int, region: int):
         for row in self.execute(
                 """
                 SELECT region_id, is_recording FROM region_view
@@ -200,16 +200,35 @@ class BufferDatabase(BaseDatabase):
             return row["region_id"], row["is_recording"]
         return None
 
-    def _get_existing_regiond_id(self, x: int, y: int, p: int, region: int):
-        region_id = self._find_existing_regiond_id(x, y, p, region)
+    def _find_existing_download_region_id(self, x: int, y: int, p: int, region: int):
+        for row in self.execute(
+                """
+                SELECT region_id, is_recording FROM region_view
+                WHERE x = ? AND y = ? AND processor = ?
+                    AND local_region_index = ?
+                LIMIT 1
+                """, (x, y, p, region)):
+            return row["region_id"], row["is_recording"]
+        return None
+
+    def _get_existing_recording_region_id(self, x: int, y: int, p: int, region: int):
+        region_id = self._find_existing_recording_region_id(x, y, p, region)
         if region_id is None:
             raise LookupError(
                 f"There is no region for {x=} {y=} {p=} {region=}")
         else:
             return region_id
 
-    def _get_region_id(self, x: int, y: int, p: int, region: int,
-                       is_recording: bool) -> int:
+    def _get_existing_download_region_id(
+            self, x: int, y: int, p: int, region: int):
+        region_id = self._find_existing_download_region_id(x, y, p, region)
+        if region_id is None:
+            raise LookupError(
+                f"There is no region for {x=} {y=} {p=} {region=}")
+        else:
+            return region_id
+
+    def _get_recording_region_id(self, x: int, y: int, p: int, region: int) -> int:
         """
         :param int x:
         :param int y:
@@ -217,7 +236,7 @@ class BufferDatabase(BaseDatabase):
         :param int region:
         :param is_recording: Flag to say if this is a recording regions.
         """
-        region_info = self._find_existing_regiond_id(x, y, p, region)
+        region_info = self._find_existing_recording_region_id(x, y, p, region)
         if region_info is not None:
             return region_info[0]
 
@@ -227,7 +246,30 @@ class BufferDatabase(BaseDatabase):
             INSERT INTO region(
                 core_id, local_region_index, is_recording)
             VALUES(?, ?, ?)
-            """, (core_id, region, is_recording))
+            """, (core_id, region, True))
+        region_id = self.lastrowid
+        assert region_id is not None
+        return region_id
+
+    def _get_download_region_id(self, x: int, y: int, p: int, region: int) -> int:
+        """
+        :param int x:
+        :param int y:
+        :param int p:
+        :param int region:
+        :param is_recording: Flag to say if this is a recording regions.
+        """
+        region_info = self._find_existing_download_region_id(x, y, p, region)
+        if region_info is not None:
+            return region_info[0]
+
+        core_id = self._get_core_id(x, y, p)
+        self.execute(
+            """
+            INSERT INTO region(
+                core_id, local_region_index, is_recording)
+            VALUES(?, ?, ?)
+            """, (core_id, region, False))
         region_id = self.lastrowid
         assert region_id is not None
         return region_id
@@ -284,9 +326,38 @@ class BufferDatabase(BaseDatabase):
             return row["max_id"]
         raise LookupError("No Extraction id found")
 
-    def store_data_in_region_buffer(
+    def store_recording(self, x: int, y: int, p: int, region: int,
+                        missing: bool, data: bytes):
+        """
+        Store some information in the corresponding buffer for a
+        specific chip, core and recording region.
+
+        :param int x: x coordinate of the chip
+        :param int y: y coordinate of the chip
+        :param int p: Core within the specified chip
+        :param int region: Region containing the data to be stored
+        :param bool missing: Whether any data is missing
+        :param bytearray data: data to be stored
+
+        .. note::
+                    Must be shorter than 1GB
+        """
+        # pylint: disable=too-many-arguments, unused-argument
+        # TODO: Use missing
+        datablob = Binary(data)
+        region_id = self._get_recording_region_id(x, y, p, region)
+        extraction_id = self.get_last_extraction_id()
+        self.execute(
+            """
+            INSERT INTO region_data(
+                region_id, extraction_id, content, content_len, missing_data)
+            VALUES (?, ?, CAST(? AS BLOB), ?, ?)
+            """, (region_id, extraction_id, datablob, len(data), missing))
+        assert self.rowcount == 1
+
+    def store_download(
             self, x: int, y: int, p: int, region: int, missing: bool,
-            data: bytes, is_recording: bool):
+            data: bytes):
         """
         Store some information in the corresponding buffer for a
         specific chip, core and recording region.
@@ -305,7 +376,7 @@ class BufferDatabase(BaseDatabase):
         # pylint: disable=too-many-arguments, unused-argument
         # TODO: Use missing
         datablob = Binary(data)
-        region_id = self._get_region_id(x, y, p, region, is_recording)
+        region_id = self._get_download_region_id(x, y, p, region)
         extraction_id = self.get_last_extraction_id()
         self.execute(
             """
@@ -315,7 +386,12 @@ class BufferDatabase(BaseDatabase):
             """, (region_id, extraction_id, datablob, len(data), missing))
         assert self.rowcount == 1
 
-    def get_region_data(self, x: int, y: int, p: int, region: int) -> Tuple[
+    def store_data_in_region_buffer(
+            self, x: int, y: int, p: int, region: int, missing: bool,
+            data: bytes, is_recording: bool):
+        pass
+
+    def get_recording(self, x: int, y: int, p: int, region: int) -> Tuple[
             memoryview, bool]:
         """
         Get the data stored for a given region of a given core.
@@ -339,14 +415,11 @@ class BufferDatabase(BaseDatabase):
         :rtype: tuple(memoryview, bool)
         :raises LookupErrror: If no data is available nor marked missing.
         """
-        region_id, is_recording = self._get_existing_regiond_id(
+        region_id, is_recording = self._get_existing_recording_region_id(
             x, y, p, region)
-        if is_recording:
-            return self._read_contents_with_missing(region_id)
-        else:
-            return self._read_contents_by_extraction_id(region_id, -1)
+        return self._read_contents_with_missing(region_id)
 
-    def get_region_data_by_extraction_id(
+    def get_recording_by_extraction_id(
             self, x: int, y: int, p: int, region: int,
             extraction_id: int) -> Tuple[memoryview, bool]:
         """
@@ -369,11 +442,39 @@ class BufferDatabase(BaseDatabase):
         :rtype: tuple(memoryview, bool)
         """
         try:
-            region_id, _ = self._get_existing_regiond_id(x, y, p, region)
+            region_id, _ = self._get_existing_recording_region_id(
+                x, y, p, region)
             return self._read_contents_by_extraction_id(
                 region_id, extraction_id)
         except LookupError:
             return memoryview(b''), True
+
+    def get_download_by_extraction_id(
+            self, x: int, y: int, p: int, region: int,
+            extraction_id: int) -> Tuple[memoryview, bool]:
+        """
+        Get the data stored for a given region of a given core.
+
+        :param int x: x coordinate of the chip
+        :param int y: y coordinate of the chip
+        :param int p: Core within the specified chip
+        :param int region: Region containing the data
+        :param int extraction_id: ID of the extraction top get data for.
+           Negative values will be counted from the end.
+        :return:
+            A buffer containing all the data received during the
+            simulation, and a flag indicating if any data was missing.
+
+            .. note::
+                Implementations should not assume that the total buffer is
+                necessarily shorter than 1GB.
+
+        :rtype: tuple(memoryview, bool)
+        """
+        region_id, _ = self._get_existing_download_region_id(
+            x, y, p, region)
+        return self._read_contents_by_extraction_id(
+            region_id, extraction_id)
 
     def write_session_credentials_to_db(self) -> None:
         """

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
@@ -223,7 +223,7 @@ class BufferDatabase(BaseDatabase):
             self, x: int, y: int, p: int, region: int) -> Optional[int]:
         for row in self.execute(
                 """
-                SELECT recording_region_id 
+                SELECT recording_region_id
                 FROM recording_region_view
                 WHERE x = ? AND y = ? AND processor = ?
                     AND local_region_index = ?
@@ -236,7 +236,7 @@ class BufferDatabase(BaseDatabase):
             self, x: int, y: int, p: int, region: int) -> Optional[int]:
         for row in self.execute(
                 """
-                SELECT download_region_id 
+                SELECT download_region_id
                 FROM download_region_view
                 WHERE x = ? AND y = ? AND processor = ?
                     AND local_region_index = ?
@@ -387,9 +387,11 @@ class BufferDatabase(BaseDatabase):
         self.execute(
             """
             INSERT INTO recording_data(
-                recording_region_id, extraction_id, content, content_len, missing_data)
+                recording_region_id, extraction_id, content, content_len,
+                missing_data)
             VALUES (?, ?, CAST(? AS BLOB), ?, ?)
-            """, (region_id, extraction_id, datablob, len(data), missing))
+            """,
+            (region_id, extraction_id, datablob, len(data), missing))
         assert self.rowcount == 1
 
     def store_download(

--- a/spinn_front_end_common/utilities/db.sql
+++ b/spinn_front_end_common/utilities/db.sql
@@ -112,12 +112,12 @@ CREATE UNIQUE INDEX IF NOT EXISTS download_data_sanity ON download_data(
 	download_region_id ASC, extraction_id ASC);
 
 CREATE VIEW IF NOT EXISTS download_data_view AS
-	SELECT core_id, region_id, extraction_id, x, y, processor, local_region_index,
+	SELECT core_id, download_region_id, extraction_id, x, y, processor, local_region_index,
 		content, content_len
-FROM recording_region_view NATURAL JOIN download_data;
+FROM download_region_view NATURAL JOIN download_data;
 
 CREATE VIEW IF NOT EXISTS download_data_plus_view AS
-	SELECT core_id, region_id, extraction_id, x, y, processor, local_region_index,
+	SELECT core_id, download_region_id, extraction_id, x, y, processor, local_region_index,
 		content, content_len, run_timestep, run_time_ms, n_run, n_loop, extraction_time
 FROM download_data_view NATURAL JOIN extraction_view;
 

--- a/spinn_front_end_common/utilities/db.sql
+++ b/spinn_front_end_common/utilities/db.sql
@@ -47,42 +47,79 @@ CREATE VIEW IF NOT EXISTS extraction_view AS
 
 -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -- A table describing recording regions.
-CREATE TABLE IF NOT EXISTS region(
-	region_id INTEGER PRIMARY KEY AUTOINCREMENT,
+CREATE TABLE IF NOT EXISTS recording_region(
+	recording_region_id INTEGER PRIMARY KEY AUTOINCREMENT,
 	core_id INTEGER NOT NULL
 		REFERENCES core(core_id) ON DELETE RESTRICT,
-	local_region_index INTEGER NOT NULL,
-    is_recording INTEGER NOT NULL);
+	local_region_index INTEGER NOT NULL);
 -- Every recording region has a unique vertex and index
-CREATE UNIQUE INDEX IF NOT EXISTS regionSanity ON region(
+CREATE UNIQUE INDEX IF NOT EXISTS recording_region_sanity ON recording_region(
 	core_id ASC, local_region_index ASC);
 
-CREATE VIEW IF NOT EXISTS region_view AS
-	SELECT core_id, region_id, x, y, processor, local_region_index, is_recording
-FROM core NATURAL JOIN region;
+CREATE VIEW IF NOT EXISTS recording_region_view AS
+	SELECT core_id, recording_region_id, x, y, processor, local_region_index
+FROM core NATURAL JOIN recording_region;
 
-CREATE TABLE IF NOT EXISTS region_data(
-    region_data_id INTEGER PRIMARY KEY AUTOINCREMENT,
-	region_id INTEGER NOT NULL
-		REFERENCES region(region_id) ON DELETE RESTRICT,
+CREATE TABLE IF NOT EXISTS recording_data(
+    recording_data_id INTEGER PRIMARY KEY AUTOINCREMENT,
+	recording_region_id INTEGER NOT NULL
+		REFERENCES recording_region(recording_region_id) ON DELETE RESTRICT,
     extraction_id INTEGER NOT NULL
 		REFERENCES extraction(extraction_id) ON DELETE RESTRICT,
 	content BLOB NOT NULL,
 	content_len INTEGER NOT NULL,
     missing_data INTEGER NOT NULL);
 -- Every recording region is extracted once per BefferExtractor run
-CREATE UNIQUE INDEX IF NOT EXISTS region_data_sanity ON region_data(
-	region_id ASC, extraction_id ASC);
+CREATE UNIQUE INDEX IF NOT EXISTS recording_data_sanity ON recording_data(
+	recording_region_id ASC, extraction_id ASC);
 
-CREATE VIEW IF NOT EXISTS region_data_view AS
-	SELECT core_id, region_id, extraction_id, x, y, processor, local_region_index,
-		content, content_len, is_recording
-FROM region_view NATURAL JOIN region_data;
+CREATE VIEW IF NOT EXISTS recording_data_view AS
+	SELECT core_id, recording_region_id, extraction_id, x, y, processor, local_region_index,
+		content, content_len
+FROM recording_region_view NATURAL JOIN recording_data;
 
-CREATE VIEW IF NOT EXISTS region_data_plus_view AS
+CREATE VIEW IF NOT EXISTS recording_data_plus_view AS
 	SELECT core_id, region_id, extraction_id, x, y, processor, local_region_index,
-		content, content_len, is_recording, run_timestep, run_time_ms, n_run, n_loop, extraction_time
-FROM region_data_view NATURAL JOIN extraction_view;
+		content, content_len, run_timestep, run_time_ms, n_run, n_loop, extraction_time
+FROM recording_data_view NATURAL JOIN extraction_view;
+
+-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+-- A table describing download regions.
+CREATE TABLE IF NOT EXISTS download_region(
+	download_region_id INTEGER PRIMARY KEY AUTOINCREMENT,
+	core_id INTEGER NOT NULL
+		REFERENCES core(core_id) ON DELETE RESTRICT,
+	local_region_index INTEGER NOT NULL);
+-- Every recording region has a unique vertex and index
+CREATE UNIQUE INDEX IF NOT EXISTS download_region_sanity ON download_region(
+	core_id ASC, local_region_index ASC);
+
+CREATE VIEW IF NOT EXISTS download_region_view AS
+	SELECT core_id, download_region_id, x, y, processor, local_region_index
+FROM core NATURAL JOIN download_region;
+
+CREATE TABLE IF NOT EXISTS download_data(
+    download_data_id INTEGER PRIMARY KEY AUTOINCREMENT,
+	download_region_id INTEGER NOT NULL
+		REFERENCES download_region(download_region_id) ON DELETE RESTRICT,
+    extraction_id INTEGER NOT NULL
+		REFERENCES extraction(extraction_id) ON DELETE RESTRICT,
+	content BLOB NOT NULL,
+	content_len INTEGER NOT NULL,
+    missing_data INTEGER NOT NULL);
+-- Every recording region is extracted once per BefferExtractor run
+CREATE UNIQUE INDEX IF NOT EXISTS download_data_sanity ON download_data(
+	download_region_id ASC, extraction_id ASC);
+
+CREATE VIEW IF NOT EXISTS download_data_view AS
+	SELECT core_id, region_id, extraction_id, x, y, processor, local_region_index,
+		content, content_len
+FROM recording_region_view NATURAL JOIN download_data;
+
+CREATE VIEW IF NOT EXISTS download_data_plus_view AS
+	SELECT core_id, region_id, extraction_id, x, y, processor, local_region_index,
+		content, content_len, run_timestep, run_time_ms, n_run, n_loop, extraction_time
+FROM download_data_view NATURAL JOIN extraction_view;
 
 -- Information about how to access the connection proxying
 -- WARNING! May include credentials

--- a/spinn_front_end_common/utility_models/chip_power_monitor_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/chip_power_monitor_machine_vertex.py
@@ -242,7 +242,7 @@ class ChipPowerMonitorMachineVertex(
         # for buffering output info is taken form the buffer manager
         # get raw data as a byte array
         buffer_manager = FecDataView.get_buffer_manager()
-        record_raw, data_missing = buffer_manager.get_data_by_placement(
+        record_raw, data_missing = buffer_manager.get_recording(
             placement, self._SAMPLE_RECORDING_CHANNEL)
         if data_missing:
             logger.warning(

--- a/unittests/interface/buffer_management/test_buffered_manager.py
+++ b/unittests/interface/buffer_management/test_buffered_manager.py
@@ -53,7 +53,7 @@ class MockAbstractReceiveRegionsToHost(
     @overrides(AbstractReceiveRegionsToHost.get_download_regions)
     def get_download_regions(self, placement: Placement) -> Sequence[
             Tuple[int, int, int]]:
-        return (0, 1235678, 90)
+        return [(0, 1235678, 90)]
 
 
 class TestBufferedDatabase(unittest.TestCase):

--- a/unittests/interface/buffer_management/test_buffered_manager.py
+++ b/unittests/interface/buffer_management/test_buffered_manager.py
@@ -53,7 +53,7 @@ class MockAbstractReceiveRegionsToHost(
     @overrides(AbstractReceiveRegionsToHost.get_download_regions)
     def get_download_regions(self, placement: Placement) -> Sequence[
             Tuple[int, int, int]]:
-        return [0, 1235678, 90]
+        return (0, 1235678, 90)
 
 
 class TestBufferedDatabase(unittest.TestCase):

--- a/unittests/interface/buffer_management/test_buffered_manager.py
+++ b/unittests/interface/buffer_management/test_buffered_manager.py
@@ -48,7 +48,7 @@ class MockAbstractReceiveBuffersToHost(
 
 
 class MockAbstractReceiveRegionsToHost(
-    SimpleMachineVertex, AbstractReceiveRegionsToHost):
+        SimpleMachineVertex, AbstractReceiveRegionsToHost):
 
     def get_download_regions(self, placement: Placement) -> Sequence[
             Tuple[int, int, int]]:

--- a/unittests/interface/buffer_management/test_buffered_manager.py
+++ b/unittests/interface/buffer_management/test_buffered_manager.py
@@ -14,7 +14,7 @@
 
 import unittest
 import os
-from typing import Sequence
+from typing import Sequence, Tuple
 
 from spinn_utilities.config_holder import set_config
 from spinn_utilities.overrides import overrides
@@ -27,7 +27,7 @@ from pacman.model.placements import Placement, Placements
 from spinn_front_end_common.data.fec_data_writer import FecDataWriter
 from spinn_front_end_common.interface.buffer_management import BufferManager
 from spinn_front_end_common.interface.buffer_management.buffer_models import (
-    AbstractReceiveBuffersToHost)
+    AbstractReceiveBuffersToHost, AbstractReceiveRegionsToHost)
 from spinn_front_end_common.interface.buffer_management.storage_objects \
     import BufferDatabase
 from spinn_front_end_common.interface.config_setup import unittest_setup
@@ -35,8 +35,9 @@ from spinn_front_end_common.utilities.exceptions import (
     BufferedRegionNotPresent)
 
 
-class MockAbstractReceiveBuffersToHost(SimpleMachineVertex,
-                                       AbstractReceiveBuffersToHost):
+class MockAbstractReceiveBuffersToHost(
+        SimpleMachineVertex, AbstractReceiveBuffersToHost):
+
     @overrides(AbstractReceiveBuffersToHost.get_recorded_region_ids)
     def get_recorded_region_ids(self) -> Sequence[int]:
         return [0]
@@ -46,12 +47,20 @@ class MockAbstractReceiveBuffersToHost(SimpleMachineVertex,
         raise NotImplementedError
 
 
+class MockAbstractReceiveRegionsToHost(
+    SimpleMachineVertex, AbstractReceiveRegionsToHost):
+
+    def get_download_regions(self, placement: Placement) -> Sequence[
+            Tuple[int, int, int]]:
+        return [0]
+
+
 class TestBufferedDatabase(unittest.TestCase):
 
     def setUp(self):
         unittest_setup()
 
-    def test_use_database(self):
+    def test_recording(self):
         set_config("Machine", "versions", VersionStrings.ANY.text)
         writer = FecDataWriter.mock()
         f = BufferDatabase.default_database_file()
@@ -87,15 +96,15 @@ class TestBufferedDatabase(unittest.TestCase):
                 self.assertEqual("SCAMP(OS)_4:3", label)
 
             with self.assertRaises(LookupError):
-                brd.get_region_data(1, 2, 3, 0)
+                brd.get_recording(1, 2, 3, 0)
 
         with self.assertRaises(BufferedRegionNotPresent):
             bm.get_recording(p1, 0)
 
         with BufferDatabase() as brd:
             brd.start_new_extraction()
-            brd.store_data_in_region_buffer(1, 2, 3, 0, False, b"abc", True)
-            data, missing = brd.get_region_data(1, 2, 3, 0)
+            brd.store_recording(1, 2, 3, 0, False, b"abc")
+            data, missing = brd.get_recording(1, 2, 3, 0)
             self.assertFalse(missing, "data shouldn't be 'missing'")
             self.assertEqual(bytes(data), b"abc")
 
@@ -105,14 +114,14 @@ class TestBufferedDatabase(unittest.TestCase):
 
         with BufferDatabase() as brd:
             brd.start_new_extraction()
-            brd.store_data_in_region_buffer(1, 2, 3, 0, False, b"def", True)
-            data, missing = brd.get_region_data(1, 2, 3, 0)
+            brd.store_recording(1, 2, 3, 0, False, b"def")
+            data, missing = brd.get_recording(1, 2, 3, 0)
             self.assertFalse(missing, "data shouldn't be 'missing'")
             self.assertEqual(bytes(data), b"abcdef")
 
             brd.start_new_extraction()
-            brd.store_data_in_region_buffer(1, 2, 3, 0, True, b"g", True)
-            data, missing = brd.get_region_data(1, 2, 3, 0)
+            brd.store_recording(1, 2, 3, 0, True, b"g")
+            data, missing = brd.get_recording(1, 2, 3, 0)
             self.assertTrue(missing, "data should be 'missing'")
             self.assertEqual(bytes(data), b"abcdefg")
 
@@ -121,16 +130,67 @@ class TestBufferedDatabase(unittest.TestCase):
         self.assertEqual(bytes(data), b"abcdefg")
 
         with BufferDatabase() as brd:
-            data, missing = brd.get_region_data_by_extraction_id(1, 2, 3, 0, 2)
+            data, missing = brd.get_recording_by_extraction_id(1, 2, 3, 0, 2)
             self.assertFalse(missing, "data shouldn't be 'missing'")
             self.assertEqual(bytes(data), b"def")
 
-            data, missing = brd.get_region_data_by_extraction_id(
+            data, missing = brd.get_recording_by_extraction_id(
                 1, 2, 3, 0, -1)
             self.assertTrue(missing, "data should be 'missing'")
             self.assertEqual(bytes(data), b"g")
 
             self.assertTrue(os.path.isfile(f), "DB still exists")
+
+    def test_download(self):
+        set_config("Machine", "versions", VersionStrings.ANY.text)
+        writer = FecDataWriter.mock()
+
+        info = Placements([])
+        p1 = Placement(
+            MockAbstractReceiveRegionsToHost(None, label="V1"), 1, 2, 3)
+        info.add_placement(p1)
+        writer.set_placements(info)
+        bm = BufferManager()
+        with BufferDatabase() as brd:
+            brd.store_vertex_labels()
+            with self.assertRaises(LookupError):
+                brd.get_download_by_extraction_id(1, 2, 3, 0, -1)
+
+        with self.assertRaises(BufferedRegionNotPresent):
+            bm.get_download(p1, 0)
+
+        with BufferDatabase() as brd:
+            brd.start_new_extraction()
+            brd.store_download(1, 2, 3, 0, False, b"abc")
+            data, missing = brd.get_download_by_extraction_id(1, 2, 3, 0, -1)
+            self.assertFalse(missing, "data should be 'missing'")
+            self.assertEqual(bytes(data), b"abc")
+
+        data, missing = bm.get_download(p1, 0)
+        self.assertFalse(missing, "data shouldn't be 'missing'")
+        self.assertEqual(bytes(data), b"abc")
+
+        with BufferDatabase() as brd:
+            brd.start_new_extraction()
+            brd.store_download(1, 2, 3, 0, False, b"def")
+            data, missing = brd.get_download_by_extraction_id(1, 2, 3, 0, -1)
+            self.assertFalse(missing, "data shouldn't be 'missing'")
+            self.assertEqual(bytes(data), b"def")
+
+        data, missing = bm.get_download(p1, 0)
+        self.assertFalse(missing, "data shouldn't be 'missing'")
+        self.assertEqual(bytes(data), b"def")
+
+        with BufferDatabase() as brd:
+            brd.start_new_extraction()
+            brd.store_download(1, 2, 3, 0, True, b"gh")
+            data, missing = brd.get_download_by_extraction_id(1, 2, 3, 0, -1)
+            self.assertTrue(missing, "data should be 'missing'")
+            self.assertEqual(bytes(data), b"gh")
+
+        data, missing = bm.get_download(p1, 0)
+        self.assertTrue(missing, "data should be 'missing'")
+        self.assertEqual(bytes(data), b"gh")
 
     def test_clear(self):
         set_config("Machine", "versions", VersionStrings.ANY.text)
@@ -145,9 +205,9 @@ class TestBufferedDatabase(unittest.TestCase):
         bm = BufferManager()
         with BufferDatabase() as brd:
             brd.start_new_extraction()
-            brd.store_data_in_region_buffer(1, 2, 3, 0, False, b"abc", True)
+            brd.store_recording(1, 2, 3, 0, False, b"abc")
             brd.start_new_extraction()
-            brd.store_data_in_region_buffer(1, 2, 3, 0, False, b"def", True)
+            brd.store_recording(1, 2, 3, 0, False, b"def")
 
         data, missing = bm.get_recording(p1, 0)
         self.assertFalse(missing, "data shouldn't be 'missing'")

--- a/unittests/interface/buffer_management/test_buffered_manager.py
+++ b/unittests/interface/buffer_management/test_buffered_manager.py
@@ -90,7 +90,7 @@ class TestBufferedDatabase(unittest.TestCase):
                 brd.get_region_data(1, 2, 3, 0)
 
         with self.assertRaises(BufferedRegionNotPresent):
-            bm.get_data_by_placement(p1, 0)
+            bm.get_recording(p1, 0)
 
         with BufferDatabase() as brd:
             brd.start_new_extraction()
@@ -99,7 +99,7 @@ class TestBufferedDatabase(unittest.TestCase):
             self.assertFalse(missing, "data shouldn't be 'missing'")
             self.assertEqual(bytes(data), b"abc")
 
-        data, missing = bm.get_data_by_placement(p1, 0)
+        data, missing = bm.get_recording(p1, 0)
         self.assertFalse(missing, "data shouldn't be 'missing'")
         self.assertEqual(bytes(data), b"abc")
 
@@ -116,7 +116,7 @@ class TestBufferedDatabase(unittest.TestCase):
             self.assertTrue(missing, "data should be 'missing'")
             self.assertEqual(bytes(data), b"abcdefg")
 
-        data, missing = bm.get_data_by_placement(p1, 0)
+        data, missing = bm.get_recording(p1, 0)
         self.assertTrue(missing, "data should be 'missing'")
         self.assertEqual(bytes(data), b"abcdefg")
 
@@ -149,11 +149,11 @@ class TestBufferedDatabase(unittest.TestCase):
             brd.start_new_extraction()
             brd.store_data_in_region_buffer(1, 2, 3, 0, False, b"def", True)
 
-        data, missing = bm.get_data_by_placement(p1, 0)
+        data, missing = bm.get_recording(p1, 0)
         self.assertFalse(missing, "data shouldn't be 'missing'")
         self.assertEqual(bytes(data), b"abcdef")
         bm.clear_recorded_data(1, 2, 3, 0)
-        data, missing = bm.get_data_by_placement(p1, 0)
+        data, missing = bm.get_recording(p1, 0)
         self.assertTrue(missing, "data should be 'missing'")
         self.assertEqual(bytes(data), b"")
 
@@ -165,7 +165,7 @@ class TestBufferedDatabase(unittest.TestCase):
         v = SimpleMachineVertex(None, label="V2")
         p = Placement(v, 1, 2, 5)
         with self.assertRaises(NotImplementedError):
-            bm.get_data_by_placement(p, 1)
+            bm.get_recording(p, 1)
 
     def test_not_data_recorded(self):
         writer = FecDataWriter.mock()
@@ -175,7 +175,7 @@ class TestBufferedDatabase(unittest.TestCase):
         writer.set_placements(info)
         bm = BufferManager()
         try:
-            bm.get_data_by_placement(p, 0)
+            bm.get_recording(p, 0)
             raise Exception("Exception should have been raised")
         except BufferedRegionNotPresent as ex:
             self.assertIn("should have record region", str(ex))
@@ -188,7 +188,7 @@ class TestBufferedDatabase(unittest.TestCase):
         writer.set_placements(info)
         bm = BufferManager()
         try:
-            bm.get_data_by_placement(p, 1)
+            bm.get_recording(p, 1)
             raise Exception("Exception should have been raised")
         except BufferedRegionNotPresent as ex:
             self.assertIn("not set to record or download region 1", str(ex))

--- a/unittests/interface/buffer_management/test_buffered_manager.py
+++ b/unittests/interface/buffer_management/test_buffered_manager.py
@@ -50,9 +50,10 @@ class MockAbstractReceiveBuffersToHost(
 class MockAbstractReceiveRegionsToHost(
         SimpleMachineVertex, AbstractReceiveRegionsToHost):
 
+    @overrides(AbstractReceiveRegionsToHost.get_download_regions)
     def get_download_regions(self, placement: Placement) -> Sequence[
             Tuple[int, int, int]]:
-        return [0]
+        return [0, 1235678, 90]
 
 
 class TestBufferedDatabase(unittest.TestCase):


### PR DESCRIPTION
API Change
BufferManager.get_data_by_placement replicated for

- get_recording
- get_download

Old method works as long as the vertex does not implement both data types.

Most get and store method split between recording and download.


--


must be done at the same time as:

https://github.com/SpiNNakerManchester/sPyNNaker/pull/1485
https://github.com/SpiNNakerManchester/JavaSpiNNaker/pull/1191

To use the new API

https://github.com/SpiNNakerManchester/SpiNNGym/pull/94
https://github.com/SpiNNakerManchester/SpiNNaker_PDP2/pull/87
https://github.com/SpiNNakerManchester/TSPonSpiNNaker/pull/41
https://github.com/SpiNNakerManchester/SpiNNakerGraphFrontEnd/pull/281
https://github.com/SpiNNakerManchester/MarkovChainMonteCarlo/pull/70
Bitbrains code not in master

