### PR TITLE
Atexit write errorfile

### DIFF
--- a/spinn_front_end_common/data/fec_data_view.py
+++ b/spinn_front_end_common/data/fec_data_view.py
@@ -51,8 +51,6 @@ if TYPE_CHECKING:
     from spinn_front_end_common.abstract_models import LiveOutputDevice
 
 logger = FormatAdapter(logging.getLogger(__name__))
-FINISHED_FILENAME = "finished"
-ERRORED_FILENAME = "errored"
 _EMPTY_CORE_SUBSETS = CoreSubsets()
 hash(_EMPTY_CORE_SUBSETS)
 
@@ -215,6 +213,8 @@ class FecDataView(PacmanDataView, SpiNNManDataView):
     repositories as all methods are available to subclasses
     """
 
+    FINISHED_FILENAME = "finished"
+    ERRORED_FILENAME = "errored"
     __fec_data = _FecDataModel()
 
     __slots__ = ()
@@ -625,18 +625,6 @@ class FecDataView(PacmanDataView, SpiNNManDataView):
             f"{now.year:04}-{now.month:02}-{now.day:02}-{now.hour:02}"
             f"-{now.minute:02}-{now.second:02}-{now.microsecond:06}")
 
-
-    def write_finished_file(self) -> None:
-        """
-        Write a finished file to flag that the code has finished cleanly
-
-        This file signals the report directory can be removed.
-        """
-        finished_file_name = os.path.join(
-            self.get_timestamp_dir_path(), FINISHED_FILENAME)
-        with open(finished_file_name, "w", encoding="utf-8") as f:
-            f.writelines(self._get_timestamp())
-
     @classmethod
     def write_errored_file(cls, message: Optional[str] = None) -> None:
         """
@@ -654,11 +642,11 @@ class FecDataView(PacmanDataView, SpiNNManDataView):
         :param message: An error message to included
         """
         errored_file_name = os.path.join(
-            cls.get_timestamp_dir_path(), ERRORED_FILENAME)
+            cls.get_timestamp_dir_path(), cls.ERRORED_FILENAME)
 
         if message is None:
             finished_file_name = os.path.join(
-                cls.get_timestamp_dir_path(), FINISHED_FILENAME)
+                cls.get_timestamp_dir_path(), cls.FINISHED_FILENAME)
             if os.path.exists(finished_file_name):
                 return
 

--- a/spinn_front_end_common/data/fec_data_view.py
+++ b/spinn_front_end_common/data/fec_data_view.py
@@ -628,7 +628,7 @@ class FecDataView(PacmanDataView, SpiNNManDataView):
     @classmethod
     def write_errored_file(cls, message: Optional[str] = None) -> None:
         """
-        Writes an ``errored`` file that signals code has finished an error
+        Writes an ``errored`` file that signals code if the code has errored
 
         Not written if there is a finished file exists and
         there is no error message.

--- a/spinn_front_end_common/data/fec_data_writer.py
+++ b/spinn_front_end_common/data/fec_data_writer.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import atexit
-import datetime
 import logging
 import math
 import os
@@ -51,8 +50,6 @@ logger = FormatAdapter(logging.getLogger(__name__))
 __temp_dir = None
 
 REPORTS_DIRNAME = "reports"
-FINISHED_FILENAME = "finished"
-ERRORED_FILENAME = "errored"
 
 
 class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
@@ -128,14 +125,9 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
         self.set_report_dir_path(
             self._child_folder(directory, REPORTS_DIRNAME))
 
-    @classmethod
-    def _get_timestamp(cls) -> str:
-        now = datetime.datetime.now()
-        return (
-            f"{now.year:04}-{now.month:02}-{now.day:02}-{now.hour:02}"
-            f"-{now.minute:02}-{now.second:02}-{now.microsecond:06}")
-
     def __create_timestamp_directory(self) -> None:
+        if self.__fec_data._timestamp_dir_path is not None:
+            self.write_errored_file()
         while True:
             try:
                 self.__fec_data._timestamp_dir_path = self._child_folder(
@@ -145,35 +137,6 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
                 return
             except OSError:
                 time.sleep(0.5)
-
-    def write_finished_file(self) -> None:
-        """
-        Write a finished file that allows file removal to only remove
-        folders that are finished.
-        """
-        finished_file_name = os.path.join(
-            self.get_timestamp_dir_path(), FINISHED_FILENAME)
-        with open(finished_file_name, "w", encoding="utf-8") as f:
-            f.writelines(self._get_timestamp)
-
-    @classmethod
-    def write_errored_file(cls) -> None:
-        """
-        Writes an ``errored`` file that allows file removal to only remove
-        folders that have errors if requested to do so
-        """
-        finished_file_name = os.path.join(
-            cls.get_timestamp_dir_path(), FINISHED_FILENAME)
-        if os.path.exists(finished_file_name):
-            return
-
-        errored_file_name = os.path.join(
-            cls.get_timestamp_dir_path(), ERRORED_FILENAME)
-        if os.path.exists(errored_file_name):
-            return
-
-        with open(errored_file_name, "w", encoding="utf-8") as f:
-            f.writelines(cls._get_timestamp())
 
     def set_allocation_controller(self, allocation_controller: Optional[
             MachineAllocationController]):

--- a/spinn_front_end_common/data/fec_data_writer.py
+++ b/spinn_front_end_common/data/fec_data_writer.py
@@ -138,6 +138,17 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
             except OSError:
                 time.sleep(0.5)
 
+    def write_finished_file(self) -> None:
+        """
+        Write a finished file to flag that the code has finished cleanly
+
+        This file signals the report directory can be removed.
+        """
+        finished_file_name = os.path.join(
+            self.get_timestamp_dir_path(), self.FINISHED_FILENAME)
+        with open(finished_file_name, "w", encoding="utf-8") as f:
+            f.writelines(self._get_timestamp())
+
     def set_allocation_controller(self, allocation_controller: Optional[
             MachineAllocationController]):
         """

--- a/spinn_front_end_common/data/fec_data_writer.py
+++ b/spinn_front_end_common/data/fec_data_writer.py
@@ -175,7 +175,6 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
         with open(errored_file_name, "w", encoding="utf-8") as f:
             f.writelines(cls._get_timestamp())
 
-
     def set_allocation_controller(self, allocation_controller: Optional[
             MachineAllocationController]):
         """

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -2320,13 +2320,13 @@ class AbstractSpinnakerBase(ConfigHandler):
 
         except Exception as e:
             self._recover_from_error(e)
-            self.write_errored_file()
+            self._data_writer.write_errored_file()
             raise
         finally:
             # shut down the machine properly
             self._shutdown()
 
-        self.write_finished_file()
+        self._data_writer.write_finished_file()
         # No matching FecTimer.end_category as shutdown stops timer
 
     def _execute_application_finisher(self) -> None:

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -2320,7 +2320,7 @@ class AbstractSpinnakerBase(ConfigHandler):
 
         except Exception as e:
             self._recover_from_error(e)
-            self._data_writer.write_errored_file()
+            self._data_writer.write_errored_file(str(e))
             raise
         finally:
             # shut down the machine properly

--- a/spinn_front_end_common/interface/config_handler.py
+++ b/spinn_front_end_common/interface/config_handler.py
@@ -28,6 +28,8 @@ from spinn_front_end_common.interface.interface_functions.\
     insert_extra_monitor_vertices_to_graphs import (
         sample_monitor_vertex, sample_speedup_vertex)
 from spinn_front_end_common.interface.provenance import LogStoreDB
+from spinn_front_end_common.data.fec_data_view import (
+    ERRORED_FILENAME, FINISHED_FILENAME)
 from spinn_front_end_common.data.fec_data_writer import FecDataWriter
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 
@@ -192,10 +194,10 @@ class ConfigHandler(object):
                 for current_oldest_file in files_in_report_folder:
                     finished_flag = os.path.join(os.path.join(
                         starting_directory, current_oldest_file),
-                        self._data_writer.FINISHED_FILENAME)
+                        FINISHED_FILENAME)
                     errored_flag = os.path.join(os.path.join(
                         starting_directory, current_oldest_file),
-                        self._data_writer.ERRORED_FILENAME)
+                        ERRORED_FILENAME)
                     finished_flag_exists = os.path.exists(finished_flag)
                     errored_flag_exists = os.path.exists(errored_flag)
                     if finished_flag_exists and (

--- a/spinn_front_end_common/interface/config_handler.py
+++ b/spinn_front_end_common/interface/config_handler.py
@@ -236,24 +236,3 @@ class ConfigHandler(object):
             f.write("\n")
             f.write("Traceback of setup call:\n")
             traceback.print_stack(file=f)
-
-    def __write_marker_file(self, file_name: str):
-        app_file_name = os.path.join(
-            self._data_writer.get_timestamp_dir_path(), file_name)
-        with open(app_file_name, "w", encoding="utf-8") as f:
-            # TODO What should this file contain?
-            f.writelines("file_name")
-
-    def write_finished_file(self) -> None:
-        """
-        Write a finished file that allows file removal to only remove
-        folders that are finished.
-        """
-        self.__write_marker_file(FINISHED_FILENAME)
-
-    def write_errored_file(self) -> None:
-        """
-        Writes an ``errored`` file that allows file removal to only remove
-        folders that have errors if requested to do so
-        """
-        self.__write_marker_file(ERRORED_FILENAME)

--- a/spinn_front_end_common/interface/config_handler.py
+++ b/spinn_front_end_common/interface/config_handler.py
@@ -34,9 +34,6 @@ from spinn_front_end_common.utilities.exceptions import ConfigurationException
 logger = FormatAdapter(logging.getLogger(__name__))
 
 APP_DIRNAME = 'application_generated_data_files'
-FINISHED_FILENAME = "finished"
-ERRORED_FILENAME = "errored"
-REPORTS_DIRNAME = "reports"
 TIMESTAMP_FILENAME = "time_stamp"
 WARNING_LOGS_FILENAME = "warning_logs.txt"
 
@@ -195,10 +192,10 @@ class ConfigHandler(object):
                 for current_oldest_file in files_in_report_folder:
                     finished_flag = os.path.join(os.path.join(
                         starting_directory, current_oldest_file),
-                        FINISHED_FILENAME)
+                        self._data_writer.FINISHED_FILENAME)
                     errored_flag = os.path.join(os.path.join(
                         starting_directory, current_oldest_file),
-                        ERRORED_FILENAME)
+                        self._data_writer.ERRORED_FILENAME)
                     finished_flag_exists = os.path.exists(finished_flag)
                     errored_flag_exists = os.path.exists(errored_flag)
                     if finished_flag_exists and (

--- a/spinn_front_end_common/interface/config_handler.py
+++ b/spinn_front_end_common/interface/config_handler.py
@@ -28,8 +28,6 @@ from spinn_front_end_common.interface.interface_functions.\
     insert_extra_monitor_vertices_to_graphs import (
         sample_monitor_vertex, sample_speedup_vertex)
 from spinn_front_end_common.interface.provenance import LogStoreDB
-from spinn_front_end_common.data.fec_data_view import (
-    ERRORED_FILENAME, FINISHED_FILENAME)
 from spinn_front_end_common.data.fec_data_writer import FecDataWriter
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 
@@ -194,10 +192,10 @@ class ConfigHandler(object):
                 for current_oldest_file in files_in_report_folder:
                     finished_flag = os.path.join(os.path.join(
                         starting_directory, current_oldest_file),
-                        FINISHED_FILENAME)
+                        self._data_writer.FINISHED_FILENAME)
                     errored_flag = os.path.join(os.path.join(
                         starting_directory, current_oldest_file),
-                        ERRORED_FILENAME)
+                        self._data_writer.ERRORED_FILENAME)
                     finished_flag_exists = os.path.exists(finished_flag)
                     errored_flag_exists = os.path.exists(errored_flag)
                     if finished_flag_exists and (


### PR DESCRIPTION
There is code to cleanup the reports directory based on the existence of "finished" and "errored" files,

But we rarely write "errored" files.

This pr add coded as soon as the report directory is created to mark it errored unless already marked finished when
1. A new timestamp directory is created
2. The code ends

The finished file is also changed to hold the timestamp of when it was finished.