### PR TITLE
Allow run forever pause

### DIFF
--- a/c_common/front_end_common_lib/include/simulation.h
+++ b/c_common/front_end_common_lib/include/simulation.h
@@ -63,7 +63,10 @@ typedef enum simulation_commands {
     //! Asks the application to gather provenance data
     PROVENANCE_DATA_GATHERING = 8,
     //! Clears the IOBUF
-    IOBUF_CLEAR = 9
+    IOBUF_CLEAR = 9,
+    //! Asks the application to pause.  This relies on the application using
+    //! simulation_is_finished which can then handle the pause status better.
+    CMD_PAUSE = 10
 } simulation_commands;
 
 //! the definition of the callback used by provenance data functions

--- a/spinn_front_end_common/data/fec_data_writer.py
+++ b/spinn_front_end_common/data/fec_data_writer.py
@@ -190,7 +190,8 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
         :type increment: int or None
         """
         if increment is None:
-            if self.__fec_data._current_run_timesteps != 0:
+            current = self.__fec_data._current_run_timesteps
+            if current != 0 and current is not None:
                 raise NotImplementedError("Run forever after another run")
             self.__fec_data._current_run_timesteps = None
             return

--- a/unittests/data/test_simulator_data.py
+++ b/unittests/data/test_simulator_data.py
@@ -122,8 +122,7 @@ class TestSimulatorData(unittest.TestCase):
         writer.increment_current_run_timesteps(None)
         self.assertEqual(0, FecDataView.get_first_machine_time_step())
         self.assertIsNone(FecDataView.get_current_run_timesteps())
-        with self.assertRaises(NotImplementedError):
-            writer.increment_current_run_timesteps(None)
+        writer.increment_current_run_timesteps(None)
         with self.assertRaises(NotImplementedError):
             writer.increment_current_run_timesteps(100)
 


### PR DESCRIPTION
Allow run_forever to be called multiple times in a row.  This still doesn't allow run_forever followed by a fixed time run or vice versa as the timing is then uncertain.  Run forever multiple times can make sense to some simulations though.