### PR TITLE
Run forever minor

### DIFF
--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -30,7 +30,7 @@ from pacman.model.placements import Placement
 from spinn_front_end_common.data import FecDataView
 from spinn_front_end_common.utilities.constants import BYTES_PER_WORD
 from spinn_front_end_common.utilities.exceptions import (
-    BufferableRegionTooSmall, SpinnFrontEndException)
+    SpinnFrontEndException)
 from spinn_front_end_common.utilities.helpful_functions import (
     locate_memory_region_for_placement, locate_extra_monitor_mc_receiver)
 from spinn_front_end_common.interface.buffer_management.storage_objects \
@@ -330,9 +330,9 @@ class BufferManager(object):
                 progress.update(len(data))
 
         if not sent_message:
-            raise BufferableRegionTooSmall(
-                f"The buffer size {bytes_to_go} is too small for any data to "
-                f"be added for region {region} of vertex {vertex}")
+            raise SpinnFrontEndException(
+                f"Unable to create message for {region=} on {vertex=} "
+                f"while is_empty reports false.")
 
         # If there are no more messages and there is space, add a stop request
         if (not vertex.is_next_timestamp(region) and

--- a/spinn_front_end_common/interface/buffer_management/buffer_models/sends_buffers_from_host_pre_buffered_impl.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_models/sends_buffers_from_host_pre_buffered_impl.py
@@ -67,7 +67,7 @@ class SendsBuffersFromHostPreBufferedImpl(
 
     @overrides(AbstractSendsBuffersFromHost.get_next_key)
     def get_next_key(self, region: int) -> int:
-        return self.send_buffers[region].next_key
+        return self.send_buffers[region].next_key()
 
     @overrides(AbstractSendsBuffersFromHost.is_empty)
     def is_empty(self, region: int) -> bool:

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffered_sending_region.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffered_sending_region.py
@@ -155,7 +155,6 @@ class BufferedSendingRegion(object):
             return bool(self._buffer[timestamp])
         return False
 
-    @property
     def next_key(self) -> int:
         """
         The next key to be sent.


### PR DESCRIPTION
Cherry pick from https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1224/

- energy reports changes not done as being picked up by a different PR

- Stop run has little to no affect if not running forever not done as a different PR will improve how that is done
- reverse ip tag change not needed as first_machine_time_step changes between run forever runs