### PR TITLE
only run ddl if a new file

### DIFF
--- a/spinn_front_end_common/utilities/sqlite_db.py
+++ b/spinn_front_end_common/utilities/sqlite_db.py
@@ -124,7 +124,7 @@ class SQLiteDB(object):
             ddl_file = None
         else:
             if os.path.exists(database_file):
-                # No need to run the ddl_file again
+                # No need to run the DDL file again
                 ddl_file = None
             self.__db = sqlite3.connect(database_file, timeout=timeout)
 

--- a/spinn_front_end_common/utilities/sqlite_db.py
+++ b/spinn_front_end_common/utilities/sqlite_db.py
@@ -120,7 +120,12 @@ class SQLiteDB(object):
             # https://stackoverflow.com/a/21794758/301832
             self.__db = sqlite3.connect(
                 f"{db_uri}?mode=ro", uri=True, timeout=timeout)
+            # can not run a ddl file
+            ddl_file = None
         else:
+            if os.path.exists(database_file):
+                # No need to run the ddl_file again
+                ddl_file = None
             self.__db = sqlite3.connect(database_file, timeout=timeout)
 
         # We want to assume control over transactions ourselves
@@ -131,7 +136,7 @@ class SQLiteDB(object):
         if text_factory is not None:
             self.__db.text_factory = text_factory
 
-        if not read_only and ddl_file:
+        if ddl_file:
             with open(ddl_file, encoding="utf-8") as f:
                 sql = f.read()
             self.__db.executescript(sql)

--- a/spinn_front_end_common/utilities/sqlite_db.py
+++ b/spinn_front_end_common/utilities/sqlite_db.py
@@ -120,7 +120,7 @@ class SQLiteDB(object):
             # https://stackoverflow.com/a/21794758/301832
             self.__db = sqlite3.connect(
                 f"{db_uri}?mode=ro", uri=True, timeout=timeout)
-            # can not run a ddl file
+            # can not run a DDL file
             ddl_file = None
         else:
             if os.path.exists(database_file):


### PR DESCRIPTION
To not have to store open database we create a new wrapper around the same db file many times.

It does not make send to run the create table if not exists code each time
