### PR TITLE
clear next_buffer_time when stopping

### DIFF
--- a/c_common/models/reverse_iptag_multicast_source/src/reverse_iptag_multicast_source.c
+++ b/c_common/models/reverse_iptag_multicast_source/src/reverse_iptag_multicast_source.c
@@ -1250,7 +1250,8 @@ static void timer_callback(UNUSED uint unused0, UNUSED uint unused1) {
         if (recording_flags > 0) {
             recording_finalise();
         }
-
+        // clear the next buffer time
+        next_buffer_time = 0;
         log_debug("Last time of stop notification request: %d",
                 last_stop_notification_request);
 


### PR DESCRIPTION
when a spike source array is run in forever mode the first spike after the stop occurs twice.

This pr clears the cached next_buffer_time 

tested by:
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1505