### PR TITLE
Fix pause

### DIFF
--- a/spinn_front_end_common/utilities/scp/__init__.py
+++ b/spinn_front_end_common/utilities/scp/__init__.py
@@ -17,10 +17,12 @@ from .load_mc_routes_process import LoadMCRoutesProcess
 from .reinjector_control_process import ReinjectorControlProcess
 from .update_runtime_process import UpdateRuntimeProcess
 from .get_current_time_process import GetCurrentTimeProcess
+from .send_pause_process import SendPauseProcess
 
 __all__ = (
     "ClearIOBUFProcess",
     "LoadMCRoutesProcess",
     "ReinjectorControlProcess",
     "UpdateRuntimeProcess",
-    "GetCurrentTimeProcess")
+    "GetCurrentTimeProcess",
+    "SendPauseProcess")

--- a/spinn_front_end_common/utilities/scp/send_pause_process.py
+++ b/spinn_front_end_common/utilities/scp/send_pause_process.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2016 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import partial
+from spinn_utilities.overrides import overrides
+from spinn_utilities.progress_bar import ProgressBar
+from spinn_machine import CoreSubsets
+from spinnman.messages.sdp import SDPHeader, SDPFlag
+from spinnman.messages.scp.abstract_messages import AbstractSCPRequest
+from spinnman.messages.scp import SCPRequestHeader
+from spinnman.messages.scp.impl import CheckOKResponse
+from spinnman.processes import AbstractMultiConnectionProcess
+from spinnman.model.enums import SDP_PORTS, SDP_RUNNING_MESSAGE_CODES
+
+
+class _SendPauseRequest(AbstractSCPRequest[CheckOKResponse]):
+    def __init__(self, x: int, y: int, p: int):
+        """
+        :param int x:
+        :param int y:
+        :param int p:
+        """
+        # pylint: disable=too-many-arguments
+        sdp_flags = SDPFlag.REPLY_EXPECTED
+
+        super().__init__(
+            SDPHeader(
+                flags=sdp_flags,
+                destination_port=SDP_PORTS.RUNNING_COMMAND_SDP_PORT.value,
+                destination_cpu=p, destination_chip_x=x, destination_chip_y=y),
+            SCPRequestHeader(
+                command=SDP_RUNNING_MESSAGE_CODES.SDP_PAUSE_ID_CODE))
+
+    @overrides(AbstractSCPRequest.get_scp_response)
+    def get_scp_response(self) -> CheckOKResponse:
+        return CheckOKResponse(
+            "update runtime",
+            SDP_RUNNING_MESSAGE_CODES.SDP_PAUSE_ID_CODE.value)
+
+
+class SendPauseProcess(AbstractMultiConnectionProcess[CheckOKResponse]):
+    """
+    Send pause to a set of cores
+
+    .. note::
+        The cores must be using the simulation interface.
+    """
+    __slots__ = ()
+
+    def __receive_response(
+            self, progress: ProgressBar, _response: CheckOKResponse):
+        progress.update()
+
+    def send_pause(self, core_subsets: CoreSubsets, n_cores: int):
+        """
+        :param ~spinn_machine.CoreSubsets core_subsets:
+        :param int n_cores: Number of cores being updated
+        """
+        with ProgressBar(n_cores, "Sending pause request") as progress, \
+                self._collect_responses():
+            for core_subset in core_subsets:
+                for processor_id in core_subset.processor_ids:
+                    self._send_request(
+                        _SendPauseRequest(
+                            core_subset.x, core_subset.y, processor_id),
+                        callback=partial(self.__receive_response, progress))


### PR DESCRIPTION
Fix issues with pause.  Sometimes I see failure to read the next message because pause messages do return a response but it wasn't being read.  This makes pause request a full process, and then removes the need to do anything complex in the application_runner, except to wait for the end of simulation after sending the message.