### PR TITLE
Typing for FEC

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -27,5 +27,6 @@ jobs:
       coverage-package: spinn_front_end_common
       flake8-packages: spinn_front_end_common unittests fec_integration_tests
       pylint-packages: spinn_front_end_common
-      mypy-packages: spinn_front_end_common unittests fec_integration_tests
+      mypy-packages: unittests fec_integration_tests
+      mypy-full_packages: spinn_front_end_common
     secrets: inherit

--- a/mypy.bash
+++ b/mypy.bash
@@ -25,4 +25,4 @@ man="../SpiNNMan/spinnman"
 pacman="../PACMAN/pacman"
 spalloc="../spalloc/spalloc_client"
 
-mypy --python-version 3.8 $utils $machine $man $pacman $spalloc spinn_front_end_common unittests
+mypy --python-version 3.8 $utils $machine $man $pacman $spalloc spinn_front_end_common unittests fec_integration_tests

--- a/mypyd.bash
+++ b/mypyd.bash
@@ -25,4 +25,5 @@ man="../SpiNNMan/spinnman"
 pacman="../PACMAN/pacman"
 spalloc="../spalloc/spalloc_client"
 
-mypy --python-version 3.8 $utils $machine $man $pacman $spalloc spinn_front_end_common unittests
+mypy --python-version 3.8 --disallow-untyped-defs $utils $machine $man $pacman $spalloc spinn_front_end_common
+

--- a/spinn_front_end_common/abstract_models/abstract_generates_data_specification.py
+++ b/spinn_front_end_common/abstract_models/abstract_generates_data_specification.py
@@ -14,8 +14,12 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
+from spinn_utilities.overrides import overrides
 from spinn_utilities.require_subclass import require_subclass
+from pacman.model.graphs.machine import MachineVertex
 from pacman.model.placements import Placement
+from pacman.model.resources import AbstractSDRAM
+
 from .abstract_has_associated_binary import AbstractHasAssociatedBinary
 if TYPE_CHECKING:
     from spinn_front_end_common.interface.ds import DataSpecificationGenerator
@@ -40,4 +44,10 @@ class AbstractGeneratesDataSpecification(object, metaclass=AbstractBase):
         :param ~pacman.model.placements.Placement placement:
             The placement the vertex is located at
         """
+        raise NotImplementedError
+
+    @property
+    @overrides(MachineVertex.sdram_required)
+    @abstractmethod
+    def sdram_required(self) -> AbstractSDRAM:
         raise NotImplementedError

--- a/spinn_front_end_common/abstract_models/abstract_generates_data_specification.py
+++ b/spinn_front_end_common/abstract_models/abstract_generates_data_specification.py
@@ -34,8 +34,8 @@ class AbstractGeneratesDataSpecification(object, metaclass=AbstractBase):
     __slots__ = ()
 
     @abstractmethod
-    def generate_data_specification(
-            self, spec: DataSpecificationGenerator, placement: Placement):
+    def generate_data_specification(self, spec: DataSpecificationGenerator,
+                                    placement: Placement) -> None:
         """
         Generate a data specification.
 

--- a/spinn_front_end_common/abstract_models/abstract_generates_data_specification.py
+++ b/spinn_front_end_common/abstract_models/abstract_generates_data_specification.py
@@ -50,4 +50,5 @@ class AbstractGeneratesDataSpecification(object, metaclass=AbstractBase):
     @overrides(MachineVertex.sdram_required)
     @abstractmethod
     def sdram_required(self) -> AbstractSDRAM:
+        # pylint: disable=missing-function-docstring
         raise NotImplementedError

--- a/spinn_front_end_common/abstract_models/abstract_rewrites_data_specification.py
+++ b/spinn_front_end_common/abstract_models/abstract_rewrites_data_specification.py
@@ -32,8 +32,8 @@ class AbstractRewritesDataSpecification(object, metaclass=AbstractBase):
     __slots__ = ()
 
     @abstractmethod
-    def regenerate_data_specification(
-            self, spec: DataSpecificationReloader, placement: Placement):
+    def regenerate_data_specification(self, spec: DataSpecificationReloader,
+                                      placement: Placement) -> None:
         """
         Regenerate the data specification, only generating regions that
         have changed and need to be reloaded.
@@ -55,7 +55,7 @@ class AbstractRewritesDataSpecification(object, metaclass=AbstractBase):
         raise NotImplementedError
 
     @abstractmethod
-    def set_reload_required(self, new_value: bool):
+    def set_reload_required(self, new_value: bool) -> None:
         """
         Indicate that the regions have been reloaded.
 

--- a/spinn_front_end_common/abstract_models/impl/machine_allocation_controller.py
+++ b/spinn_front_end_common/abstract_models/impl/machine_allocation_controller.py
@@ -51,7 +51,7 @@ class MachineAllocationController(object, metaclass=AbstractBase):
         thread.start()
 
     @abstractmethod
-    def extend_allocation(self, new_total_run_time: float):
+    def extend_allocation(self, new_total_run_time: float) -> None:
         """
         Extend the allocation of the machine from the original run time.
 
@@ -191,7 +191,7 @@ class MachineAllocationController(object, metaclass=AbstractBase):
         """
         return False
 
-    def make_report(self, filename: str):
+    def make_report(self, filename: str) -> None:
         """
         Asks the controller to make a report of details of allocations.
         By default, this does nothing.

--- a/spinn_front_end_common/abstract_models/impl/machine_data_specable_vertex.py
+++ b/spinn_front_end_common/abstract_models/impl/machine_data_specable_vertex.py
@@ -32,8 +32,8 @@ class MachineDataSpecableVertex(
     __slots__ = ()
 
     @overrides(AbstractGeneratesDataSpecification.generate_data_specification)
-    def generate_data_specification(
-            self, spec: DataSpecificationGenerator, placement: Placement):
+    def generate_data_specification(self, spec: DataSpecificationGenerator,
+                                    placement: Placement) -> None:
         tags = FecDataView.get_tags()
         iptags = tags.get_ip_tags_for_vertex(placement.vertex)
         reverse_iptags = tags.get_reverse_ip_tags_for_vertex(placement.vertex)
@@ -44,7 +44,7 @@ class MachineDataSpecableVertex(
     def generate_machine_data_specification(
             self, spec: DataSpecificationGenerator, placement: Placement,
             iptags: Optional[Iterable[IPTag]],
-            reverse_iptags: Optional[Iterable[ReverseIPTag]]):
+            reverse_iptags: Optional[Iterable[ReverseIPTag]]) -> None:
         """
         :param ~data_specification.DataSpecificationGenerator spec:
             The data specification to write into.

--- a/spinn_front_end_common/data/fec_data_view.py
+++ b/spinn_front_end_common/data/fec_data_view.py
@@ -870,7 +870,8 @@ class FecDataView(PacmanDataView, SpiNNManDataView):
             cls.get_provenance_dir_path(), "system_provenance_data")
 
     @classmethod
-    def _child_folder(cls, parent, child_name, must_create=False):
+    def _child_folder(cls, parent: str, child_name: str,
+                      must_create: bool = False) -> str:
         """
         :param str parent:
         :param str child_name:
@@ -979,7 +980,7 @@ class FecDataView(PacmanDataView, SpiNNManDataView):
     def add_live_packet_gatherer_parameters(
             cls, live_packet_gatherer_params: LivePacketGatherParameters,
             vertex_to_record_from: ApplicationVertex,
-            partition_ids: Iterable[str]):
+            partition_ids: Iterable[str]) -> None:
         """
         Adds parameters for a new live packet gatherer (LPG) if needed, or
         adds to the tracker for parameters.
@@ -1252,7 +1253,7 @@ class FecDataView(PacmanDataView, SpiNNManDataView):
 
     @classmethod
     def add_database_socket_address(
-            cls, database_socket_address: SocketAddress):
+            cls, database_socket_address: SocketAddress) -> None:
         """
         Adds a socket address to the list of known addresses.
 
@@ -1267,7 +1268,8 @@ class FecDataView(PacmanDataView, SpiNNManDataView):
 
     @classmethod
     def add_database_socket_addresses(
-            cls, database_socket_addresses: Optional[Iterable[SocketAddress]]):
+            cls, database_socket_addresses: Optional[Iterable[SocketAddress]]
+            ) -> None:
         """
         Adds all socket addresses to the list of known addresses.
 
@@ -1297,7 +1299,7 @@ class FecDataView(PacmanDataView, SpiNNManDataView):
 
     @classmethod
     def add_live_output_vertex(
-            cls, vertex: ApplicationVertex, partition_id: str):
+            cls, vertex: ApplicationVertex, partition_id: str) -> None:
         """
         Add a vertex that is to be output live, and so wants its atom IDs
         recorded in the database.
@@ -1324,9 +1326,9 @@ class FecDataView(PacmanDataView, SpiNNManDataView):
         return iter(cls.__fec_data._live_output_vertices)
 
     @classmethod
-    def get_next_ds_references(cls, number):
+    def get_next_ds_references(cls, number: int) -> List[int]:
         """
-        Get a a list of unique data specification references
+        Get a list of unique data specification references
 
         These will be unique since the last hard reset
 
@@ -1339,7 +1341,7 @@ class FecDataView(PacmanDataView, SpiNNManDataView):
         return list(references)
 
     @classmethod
-    def add_live_output_device(cls, device: LiveOutputDevice):
+    def add_live_output_device(cls, device: LiveOutputDevice) -> None:
         """
         Add a live output device.
 

--- a/spinn_front_end_common/data/fec_data_writer.py
+++ b/spinn_front_end_common/data/fec_data_writer.py
@@ -180,7 +180,8 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
             raise TypeError("buffer_manager must be a BufferManager")
         self.__fec_data._buffer_manager = buffer_manager
 
-    def increment_current_run_timesteps(self, increment: Optional[int]) -> None:
+    def increment_current_run_timesteps(
+            self, increment: Optional[int]) -> None:
         """
         Increment the current_run_timesteps and sets first_machine_time_step.
 

--- a/spinn_front_end_common/data/fec_data_writer.py
+++ b/spinn_front_end_common/data/fec_data_writer.py
@@ -150,7 +150,7 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
             f.writelines(self._get_timestamp())
 
     def set_allocation_controller(self, allocation_controller: Optional[
-            MachineAllocationController]):
+            MachineAllocationController]) -> None:
         """
         Sets the allocation controller variable.
 
@@ -170,7 +170,7 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
                     "Expecting only the SpallocJobController to be proxying")
             self.__fec_data._spalloc_job = allocation_controller.job
 
-    def set_buffer_manager(self, buffer_manager: BufferManager):
+    def set_buffer_manager(self, buffer_manager: BufferManager) -> None:
         """
         Sets the Buffer manager variable.
 
@@ -180,7 +180,7 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
             raise TypeError("buffer_manager must be a BufferManager")
         self.__fec_data._buffer_manager = buffer_manager
 
-    def increment_current_run_timesteps(self, increment: Optional[int]):
+    def increment_current_run_timesteps(self, increment: Optional[int]) -> None:
         """
         Increment the current_run_timesteps and sets first_machine_time_step.
 
@@ -224,7 +224,7 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
                 "Last run was longer than duration supported by recording")
         self.__fec_data._current_run_timesteps = current_run_timesteps
 
-    def set_max_run_time_steps(self, max_run_time_steps: int):
+    def set_max_run_time_steps(self, max_run_time_steps: int) -> None:
         """
         Sets the max_run_time_steps value
 
@@ -240,7 +240,7 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
     def set_up_timings(
             self, simulation_time_step_us: Optional[int],
             time_scale_factor: Optional[float],
-            default_time_scale_factor: Optional[float] = None):
+            default_time_scale_factor: Optional[float] = None) -> None:
         """
         Set up timings for the simulation.
 
@@ -276,7 +276,7 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
             raise
 
     def _set_simulation_time_step(
-            self, simulation_time_step_us: Optional[int]):
+            self, simulation_time_step_us: Optional[int]) -> None:
         """
         :param simulation_time_step_us:
             An explicitly specified time step for the simulation.  If `None`,
@@ -307,7 +307,7 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
 
     def _set_time_scale_factor(
             self, time_scale_factor: Optional[float],
-            default_time_scale_factor: Optional[float]):
+            default_time_scale_factor: Optional[float]) -> None:
         """
         Set up time_scale_factor.
 
@@ -374,7 +374,7 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
 
     def set_system_multicast_routing_data(
             self, data: Tuple[
-                MulticastRoutingTables, Dict[XY, int], Dict[XY, int]]):
+                MulticastRoutingTables, Dict[XY, int], Dict[XY, int]]) -> None:
         """
         Sets the system_multicast_routing_data.
 
@@ -398,7 +398,7 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
         self.__fec_data._data_in_multicast_routing_tables = routing_tables
         self.__fec_data._system_multicast_router_timeout_keys = timeout_keys
 
-    def set_ipaddress(self, ip_address: str):
+    def set_ipaddress(self, ip_address: str) -> None:
         """
         :param str ip_address:
         """
@@ -407,7 +407,7 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
         self.__fec_data._ipaddress = ip_address
 
     def set_fixed_routes(
-            self, fixed_routes: Dict[Tuple[int, int], RoutingEntry]):
+            self, fixed_routes: Dict[Tuple[int, int], RoutingEntry]) -> None:
         """
         :param fixed_routes:
         :type fixed_routes:
@@ -417,7 +417,7 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
             raise TypeError("fixed_routes must be a dict")
         self.__fec_data._fixed_routes = fixed_routes
 
-    def set_java_caller(self, java_caller: JavaCaller):
+    def set_java_caller(self, java_caller: JavaCaller) -> None:
         """
         :param JavaCaller java_caller:
         """
@@ -432,7 +432,7 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
         self.__fec_data._next_sync_signal = Signal.SYNC0
 
     def set_executable_types(self, executable_types: Dict[
-            ExecutableType, CoreSubsets]):
+            ExecutableType, CoreSubsets]) -> None:
         """
         :param executable_types:
         :type executable_types: dict(
@@ -443,15 +443,8 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
             raise TypeError("executable_types must be a Dict")
         self.__fec_data._executable_types = executable_types
 
-    def set_live_packet_gatherer_parameters(self, params):
-        """
-        testing method will not work outside of mock
-        """
-        if not self._is_mocked():
-            raise NotImplementedError("This call is only for testing")
-        self.__fec_data._live_packet_recorder_params = params
-
-    def set_database_file_path(self, database_file_path: Optional[str]):
+    def set_database_file_path(
+            self, database_file_path: Optional[str]) -> None:
         """
         Sets the database_file_path variable. Possibly to `None`.
 
@@ -462,7 +455,8 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
             raise TypeError("database_file_path must be a str or None")
         self.__fec_data._database_file_path = database_file_path
 
-    def set_executable_targets(self, executable_targets: ExecutableTargets):
+    def set_executable_targets(
+            self, executable_targets: ExecutableTargets) -> None:
         """
         Sets the executable_targets
 
@@ -472,7 +466,7 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
             raise TypeError("executable_targets must be a ExecutableTargets")
         self.__fec_data._executable_targets = executable_targets
 
-    def set_ds_database_path(self, ds_database_path: str):
+    def set_ds_database_path(self, ds_database_path: str) -> None:
         """
         Sets the Data Spec targets database.
 
@@ -489,7 +483,7 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
             "DataSpeedUpPacketGatherMachineVertex)")
 
     def set_gatherer_map(self, gatherer_map: Dict[
-            Chip, DataSpeedUpPacketGatherMachineVertex]):
+            Chip, DataSpeedUpPacketGatherMachineVertex]) -> None:
         """
         Sets the map of Chip to Gatherer Vertices.
 
@@ -516,7 +510,7 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
             "ExtraMonitorSupportMachineVertex)")
 
     def set_monitor_map(self, monitor_map: Dict[
-            Chip, ExtraMonitorSupportMachineVertex]):
+            Chip, ExtraMonitorSupportMachineVertex]) -> None:
         """
         Sets the map of Chip to Monitor Vertices.
 
@@ -540,7 +534,7 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
         self.__fec_data._monitor_map = monitor_map
 
     def set_notification_protocol(
-            self, notification_protocol: NotificationProtocol):
+            self, notification_protocol: NotificationProtocol) -> None:
         """
         Sets the notification_protocol.
 
@@ -564,11 +558,11 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
 
     @classmethod
     @overrides(FecDataView.add_vertex)
-    def add_vertex(cls, vertex: ApplicationVertex):
+    def add_vertex(cls, vertex: ApplicationVertex) -> None:
         # Avoid the safety check in FecDataView
         PacmanDataWriter.add_vertex(vertex)
 
-    def set_n_run_steps(self, n_run_steps: int):
+    def set_n_run_steps(self, n_run_steps: int) -> None:
         """
         Sets the number of expected run-steps
 

--- a/spinn_front_end_common/data/fec_data_writer.py
+++ b/spinn_front_end_common/data/fec_data_writer.py
@@ -110,7 +110,7 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
 
     def __create_run_dir_path(self) -> None:
         self.set_run_dir_path(self._child_folder(
-            self.__fec_data._timestamp_dir_path,
+            self.get_timestamp_dir_path(),
             f"run_{self.__fec_data._run_number}"))
 
     def __create_reports_directory(self) -> None:

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -26,7 +26,7 @@ import threading
 import types
 from threading import Condition
 from typing import (
-    Dict, Iterable, Optional, Sequence, Tuple, Type,
+    Any, Dict, Iterable, Optional, Sequence, Tuple, Type,
     TypeVar, Union, cast, final)
 
 import ebrains_drive  # type: ignore[import]
@@ -2455,7 +2455,7 @@ class AbstractSpinnakerBase(ConfigHandler):
         transceiver.send_signal(self._data_writer.get_app_id(), sync_signal)
 
     @staticmethod
-    def __reset_object(obj) -> None:
+    def __reset_object(obj: Any) -> None:
         # Reset an object if appropriate
         if isinstance(obj, AbstractCanReset):
             obj.reset_to_first_timestep()

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -28,6 +28,7 @@ from threading import Condition
 from typing import (
     Any, Dict, Iterable, Optional, Sequence, Tuple, Type,
     TypeVar, Union, cast, final)
+from types import FrameType
 
 import ebrains_drive  # type: ignore[import]
 from numpy import __version__ as numpy_version
@@ -245,7 +246,7 @@ class AbstractSpinnakerBase(ConfigHandler):
         with FecTimer("Cleanup reports folder based on cfg", TimerWork.REPORT):
             self.__reset_remove_data()
 
-    def __reset_remove_data(self):
+    def __reset_remove_data(self) -> None:
         run_dir = self._data_writer.get_run_dir_path()
 
         if not get_config_bool("Reports", "keep_json_files"):
@@ -276,7 +277,7 @@ class AbstractSpinnakerBase(ConfigHandler):
                 except OSError:
                     pass
 
-    def _stop_remove_data(self):
+    def _stop_remove_data(self) -> None:
         with FecTimer("Cleanup reports folder based on cfg", TimerWork.REPORT):
             self.__reset_remove_data()
 
@@ -298,7 +299,8 @@ class AbstractSpinnakerBase(ConfigHandler):
         if get_config_bool("Java", "use_java"):
             self._data_writer.set_java_caller(JavaCaller())
 
-    def __signal_handler(self, _signal, _frame) -> None:
+    def __signal_handler(
+            self, _signal: int, _frame: Optional[FrameType]) -> None:
         """
         Handles closing down of script via keyboard interrupt
 
@@ -398,7 +400,7 @@ class AbstractSpinnakerBase(ConfigHandler):
 
     def exception_handler(
             self, exc_type: Type[BaseException], value: BaseException,
-            traceback_obj: Optional[types.TracebackType]):
+            traceback_obj: Optional[types.TracebackType]) -> None:
         """
         Handler of exceptions.
 
@@ -427,7 +429,7 @@ class AbstractSpinnakerBase(ConfigHandler):
             "Therefore the run call will exit immediately.")
         return False
 
-    def run_until_complete(self, n_steps: Optional[int] = None):
+    def run_until_complete(self, n_steps: Optional[int] = None) -> None:
         """
         Run a simulation until it completes.
 
@@ -441,7 +443,7 @@ class AbstractSpinnakerBase(ConfigHandler):
         self._run(n_steps, sync_time=0.0)
         FecTimer.end_category(TimerCategory.RUN_OTHER)
 
-    def run(self, run_time: Optional[float], sync_time: float = 0):
+    def run(self, run_time: Optional[float], sync_time: float = 0) -> None:
         """
         Run a simulation for a fixed amount of time.
 
@@ -511,7 +513,7 @@ class AbstractSpinnakerBase(ConfigHandler):
             f"{self._data_writer.get_hardware_time_step_us()} us")
         return n_machine_time_steps, total_run_time
 
-    def _run(self, run_time: Optional[float], sync_time: float):
+    def _run(self, run_time: Optional[float], sync_time: float) -> None:
         self._data_writer.start_run()
 
         try:
@@ -535,7 +537,7 @@ class AbstractSpinnakerBase(ConfigHandler):
         """
         return threading.get_ident() == threading.main_thread().ident
 
-    def __run(self, run_time: Optional[float], sync_time: float):
+    def __run(self, run_time: Optional[float], sync_time: float) -> None:
         """
         The main internal run function.
 
@@ -678,7 +680,8 @@ class AbstractSpinnakerBase(ConfigHandler):
             sys.excepthook = self.exception_handler
 
     @final
-    def _add_commands_to_command_sender(self, system_placements: Placements):
+    def _add_commands_to_command_sender(
+            self, system_placements: Placements) -> None:
         """
         Runs, times and logs the VirtualMachineGenerator if required.
 
@@ -850,7 +853,7 @@ class AbstractSpinnakerBase(ConfigHandler):
             self._data_writer.set_transceiver(transceiver)
             self._data_writer.set_machine(machine)
 
-    def _get_known_machine(self, total_run_time: float = 0.0):
+    def _get_known_machine(self, total_run_time: float = 0.0) -> None:
         """
         The Python machine description object.
 
@@ -921,7 +924,8 @@ class AbstractSpinnakerBase(ConfigHandler):
                 return
             network_specification()
 
-    def _execute_split_lpg_vertices(self, system_placements: Placements):
+    def _execute_split_lpg_vertices(
+            self, system_placements: Placements) -> None:
         """
         Runs, times and logs the SplitLPGVertices if required.
         """
@@ -973,7 +977,7 @@ class AbstractSpinnakerBase(ConfigHandler):
             self._data_writer.set_n_chips_in_graph(splitter_partitioner())
 
     def _execute_insert_chip_power_monitors(
-            self, system_placements: Placements):
+            self, system_placements: Placements) -> None:
         """
         Run, time and log the InsertChipPowerMonitorsToGraphs if required.
 
@@ -985,7 +989,7 @@ class AbstractSpinnakerBase(ConfigHandler):
 
     @final
     def _execute_insert_extra_monitor_vertices(
-            self, system_placements: Placements):
+            self, system_placements: Placements) -> None:
         """
         Run, time and log the InsertExtraMonitorVerticesToGraphs if required.
         """
@@ -1028,7 +1032,8 @@ class AbstractSpinnakerBase(ConfigHandler):
         cores -= ethernets * self._data_writer.get_ethernet_monitor_cores()
         return cores
 
-    def _execute_application_placer(self, system_placements: Placements):
+    def _execute_application_placer(
+            self, system_placements: Placements) -> None:
         """
         Runs, times and logs the Application Placer.
 
@@ -1041,7 +1046,7 @@ class AbstractSpinnakerBase(ConfigHandler):
             self._data_writer.set_placements(place_application_graph(
                 system_placements))
 
-    def _do_placer(self, system_placements: Placements):
+    def _do_placer(self, system_placements: Placements) -> None:
         """
         Runs, times and logs one of the placers.
 
@@ -1170,7 +1175,8 @@ class AbstractSpinnakerBase(ConfigHandler):
 
     @final
     def _execute_global_allocate(
-            self, extra_allocations: Iterable[Tuple[ApplicationVertex, str]]):
+            self, extra_allocations: Iterable[
+                Tuple[ApplicationVertex, str]]) -> None:
         """
         Runs, times and logs the Global Zoned Routing Info Allocator.
 
@@ -1186,7 +1192,8 @@ class AbstractSpinnakerBase(ConfigHandler):
 
     @final
     def _execute_flexible_allocate(
-            self, extra_allocations: Iterable[Tuple[ApplicationVertex, str]]):
+            self, extra_allocations: Iterable[
+                Tuple[ApplicationVertex, str]]) -> None:
         """
         Runs, times and logs the Zoned Routing Info Allocator.
 
@@ -1601,7 +1608,7 @@ class AbstractSpinnakerBase(ConfigHandler):
         pre_compress = "BitField" not in name
         return name, pre_compress
 
-    def _compression_skipable(self, tables) -> bool:
+    def _compression_skipable(self, tables: MulticastRoutingTables) -> bool:
         if get_config_bool(
                 "Mapping", "router_table_compress_as_far_as_possible"):
             return False
@@ -1609,7 +1616,7 @@ class AbstractSpinnakerBase(ConfigHandler):
         return (tables.get_max_number_of_entries()
                 <= machine.min_n_router_enteries)
 
-    def _execute_pre_compression(self, pre_compress: bool):
+    def _execute_pre_compression(self, pre_compress: bool) -> None:
         name = get_config_str_or_none("Mapping", "precompressor")
         if not pre_compress or name is None:
             # Declare the precompressed data to be the uncompressed data
@@ -1687,7 +1694,7 @@ class AbstractSpinnakerBase(ConfigHandler):
                 return
             router_report_from_router_tables()
 
-    def _check_uncompressed_routing_table(self):
+    def _check_uncompressed_routing_table(self) -> None:
         """
         Runs, times and logs the checking of uncompressed table
         """
@@ -2302,7 +2309,7 @@ class AbstractSpinnakerBase(ConfigHandler):
         self._print_iobuf(errors, warnings)
 
     @staticmethod
-    def _print_iobuf(errors: Iterable[str], warnings: Iterable[str]):
+    def _print_iobuf(errors: Iterable[str], warnings: Iterable[str]) -> None:
         """
         :param list(str) errors:
         :param list(str) warnings:

--- a/spinn_front_end_common/interface/buffer_management/buffer_manager.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_manager.py
@@ -1,3 +1,4 @@
+
 # Copyright (c) 2015 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -176,7 +177,7 @@ class BufferManager(object):
             return extra_mon_data
 
     @staticmethod
-    def _verify_data(extra_mon_data: bytes, txrx_data: bytes):
+    def _verify_data(extra_mon_data: bytes, txrx_data: bytes) -> None:
         sm = difflib.SequenceMatcher(a=extra_mon_data, b=txrx_data)
         failed_index = -1
         for (tag, i1, i2, j1, j2) in sm.get_opcodes():
@@ -236,7 +237,7 @@ class BufferManager(object):
         """
 
     def clear_recorded_data(
-            self, x: int, y: int, p: int, recording_region_id: int):
+            self, x: int, y: int, p: int, recording_region_id: int) -> None:
         """
         Removes the recorded data stored in memory.
 
@@ -286,7 +287,7 @@ class BufferManager(object):
 
     def _send_initial_messages(
             self, vertex: AbstractSendsBuffersFromHost, region: int,
-            progress: ProgressBar):
+            progress: ProgressBar) -> None:
         """
         Send the initial set of messages.
 
@@ -379,7 +380,7 @@ class BufferManager(object):
             self.__python_extract_no_monitors(recording_placements)
 
     def __python_extract_with_monitors(
-            self, recording_placements: List[Placement]):
+            self, recording_placements: List[Placement]) -> None:
         """
         :param list(~pacman.model.placements.Placement) recording_placements:
             Where to get the data from.
@@ -398,7 +399,7 @@ class BufferManager(object):
             self.__python_extract_no_monitors(recording_placements)
 
     def __python_extract_no_monitors(
-            self, recording_placements: List[Placement]):
+            self, recording_placements: List[Placement]) -> None:
         """
         :param list(~pacman.model.placements.Placement) recording_placements:
             Where to get the data from.
@@ -526,7 +527,7 @@ class BufferManager(object):
                 f"{recording_region_id} but there is no data"
             ) from lookup_error
 
-    def _retreive_by_placement(self, placement: Placement):
+    def _retreive_by_placement(self, placement: Placement) -> None:
         """
         Retrieve the data for a vertex; must be locked first.
 

--- a/spinn_front_end_common/interface/buffer_management/buffer_models/abstract_sends_buffers_from_host.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_models/abstract_sends_buffers_from_host.py
@@ -119,7 +119,7 @@ class AbstractSendsBuffersFromHost(object, metaclass=AbstractBase):
         raise NotImplementedError
 
     @abstractmethod
-    def rewind(self, region: int):
+    def rewind(self, region: int) -> None:
         """
         Rewinds the internal buffer in preparation of re-sending the spikes.
 

--- a/spinn_front_end_common/interface/buffer_management/buffer_models/sends_buffers_from_host_pre_buffered_impl.py
+++ b/spinn_front_end_common/interface/buffer_management/buffer_models/sends_buffers_from_host_pre_buffered_impl.py
@@ -74,5 +74,5 @@ class SendsBuffersFromHostPreBufferedImpl(
         return len(self.send_buffers[region].timestamps) == 0
 
     @overrides(AbstractSendsBuffersFromHost.rewind)
-    def rewind(self, region: int):
+    def rewind(self, region: int) -> None:
         self.send_buffers[region].rewind()

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
@@ -60,7 +60,7 @@ class BufferDatabase(BaseDatabase):
         :return: True if any region was changed
         :rtype: bool
         """
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT recording_region_id FROM recording_region_view
                 WHERE x = ? AND y = ? AND processor = ?
@@ -81,7 +81,7 @@ class BufferDatabase(BaseDatabase):
         :param region_id: region to clear
         :return:
         """
-        self.execute(
+        self.cursor().execute(
             """
             UPDATE recording_data SET
             content = CAST('' AS BLOB), content_len = 0, missing_data = 2
@@ -107,7 +107,7 @@ class BufferDatabase(BaseDatabase):
         :param int region_id:
         :rtype: memoryview, bool
         """
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT count(*) as n_extractions,
                 SUM(content_len) as total_content_length
@@ -131,7 +131,7 @@ class BufferDatabase(BaseDatabase):
         :param int region_id:
         :rtype: memoryview
         """
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT content, missing_data
                 FROM recording_data
@@ -158,7 +158,7 @@ class BufferDatabase(BaseDatabase):
             last_extraction_id = self.get_last_extraction_id()
             extraction_id = last_extraction_id + 1 + extraction_id
 
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT content, missing_data
                 FROM recording_data
@@ -183,7 +183,7 @@ class BufferDatabase(BaseDatabase):
             last_extraction_id = self.get_last_extraction_id()
             extraction_id = last_extraction_id + 1 + extraction_id
 
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT content, missing_data
                 FROM download_data
@@ -208,7 +208,7 @@ class BufferDatabase(BaseDatabase):
         c_buffer = bytearray(total_content_length)
         missing_data = False
         idx = 0
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT content, missing_data FROM recording_data
                 WHERE recording_region_id = ? ORDER BY extraction_id ASC
@@ -221,7 +221,7 @@ class BufferDatabase(BaseDatabase):
 
     def _find_existing_recording_region_id(
             self, x: int, y: int, p: int, region: int) -> Optional[int]:
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT recording_region_id
                 FROM recording_region_view
@@ -234,7 +234,7 @@ class BufferDatabase(BaseDatabase):
 
     def _find_existing_download_region_id(
             self, x: int, y: int, p: int, region: int) -> Optional[int]:
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT download_region_id
                 FROM download_region_view
@@ -277,7 +277,7 @@ class BufferDatabase(BaseDatabase):
             return region_info
 
         core_id = self._get_core_id(x, y, p)
-        self.execute(
+        self.cursor().execute(
             """
             INSERT INTO recording_region(
                 core_id, local_region_index)
@@ -301,7 +301,7 @@ class BufferDatabase(BaseDatabase):
             return region_info
 
         core_id = self._get_core_id(x, y, p)
-        self.execute(
+        self.cursor().execute(
             """
             INSERT INTO download_region(
                 core_id, local_region_index)
@@ -316,14 +316,14 @@ class BufferDatabase(BaseDatabase):
         Stores data passed into simulator setup
 
         """
-        for _ in self.execute(
+        for _ in self.cursor().execute(
                 """
                 SELECT hardware_time_step_ms
                 FROM setup
                 """):
             return
 
-        self.execute(
+        self.cursor().execute(
             """
             INSERT INTO setup(
                 setup_id, hardware_time_step_ms, time_scale_factor)
@@ -338,7 +338,7 @@ class BufferDatabase(BaseDatabase):
 
         """
         run_timesteps = FecDataView.get_current_run_timesteps() or 0
-        self.execute(
+        self.cursor().execute(
             """
             INSERT INTO extraction(run_timestep, n_run, n_loop, extract_time)
             VALUES(?, ?, ?, ?)
@@ -354,7 +354,7 @@ class BufferDatabase(BaseDatabase):
         Get the id of the current/ last extraction
 
         """
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT max(extraction_id) as max_id
                 FROM extraction
@@ -384,7 +384,7 @@ class BufferDatabase(BaseDatabase):
         datablob = Binary(data)
         region_id = self._get_recording_region_id(x, y, p, region)
         extraction_id = self.get_last_extraction_id()
-        self.execute(
+        self.cursor().execute(
             """
             INSERT INTO recording_data(
                 recording_region_id, extraction_id, content, content_len,
@@ -417,7 +417,7 @@ class BufferDatabase(BaseDatabase):
         datablob = Binary(data)
         download_region_id = self._get_download_region_id(x, y, p, region)
         extraction_id = self.get_last_extraction_id()
-        self.execute(
+        self.cursor().execute(
             """
             INSERT INTO download_data(
                 download_region_id, extraction_id, content, content_len,
@@ -518,7 +518,7 @@ class BufferDatabase(BaseDatabase):
         job = FecDataView.get_spalloc_job()
         if job is not None:
             config = job.get_session_credentials_for_db()
-            self.executemany(
+            self.cursor().executemany(
                 """
                 INSERT INTO proxy_configuration(kind, name, value)
                 VALUES(?, ?, ?)
@@ -533,13 +533,13 @@ class BufferDatabase(BaseDatabase):
         :param core_name:
         """
         try:
-            self.execute(
+            self.cursor().execute(
                 """
                 INSERT INTO core (x, y, processor, core_name)
                 VALUES (?, ?, ? ,?)
                 """, (x, y, p, core_name))
         except IntegrityError:
-            self.execute(
+            self.cursor().execute(
                 """
                 UPDATE core SET core_name = ?
                 WHERE x = ? AND y = ? and processor = ?
@@ -568,7 +568,7 @@ class BufferDatabase(BaseDatabase):
         :param int p: core p
         :rtype: str or None
         """
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT core_name
                 FROM core
@@ -582,7 +582,7 @@ class BufferDatabase(BaseDatabase):
         Gets the power monitor core for chip x, y
 
        """
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT the_value
                 FROM monitor_provenance

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffer_database.py
@@ -23,7 +23,7 @@ _SECONDS_TO_MICRO_SECONDS_CONVERSION = 1000
 PROVENANCE_CORE_KEY = "Power_Monitor_Core"
 
 
-def _timestamp():
+def _timestamp() -> int:
     return int(time.time() * _SECONDS_TO_MICRO_SECONDS_CONVERSION)
 
 
@@ -311,7 +311,7 @@ class BufferDatabase(BaseDatabase):
         assert region_id is not None
         return region_id
 
-    def store_setup_data(self):
+    def store_setup_data(self) -> None:
         """
         Stores data passed into simulator setup
 
@@ -332,7 +332,7 @@ class BufferDatabase(BaseDatabase):
                 FecDataView.get_hardware_time_step_ms(),
                 FecDataView.get_time_scale_factor()))
 
-    def start_new_extraction(self):
+    def start_new_extraction(self) -> int:
         """
         Stores the metadata for the extractions about to occur
 
@@ -364,7 +364,7 @@ class BufferDatabase(BaseDatabase):
         raise LookupError("No Extraction id found")
 
     def store_recording(self, x: int, y: int, p: int, region: int,
-                        missing: bool, data: bytes):
+                        missing: bool, data: bytes) -> None:
         """
         Store some information in the corresponding buffer for a
         specific chip, core and recording region.
@@ -396,7 +396,7 @@ class BufferDatabase(BaseDatabase):
 
     def store_download(
             self, x: int, y: int, p: int, region: int, missing: bool,
-            data: bytes):
+            data: bytes) -> None:
         """
         Store some information in the corresponding buffer for a
         specific chip, core and recording region.
@@ -524,12 +524,13 @@ class BufferDatabase(BaseDatabase):
                 VALUES(?, ?, ?)
                 """, [(k1, k2, v) for (k1, k2), v in config.items()])
 
-    def _set_core_name(self, x: int, y: int, p: int, core_name: Optional[str]):
+    def _set_core_name(
+            self, x: int, y: int, p: int, core_name: Optional[str]) -> None:
         """
         :param int x:
         :param int y:
         :param int p:
-        :param str core_name:
+        :param core_name:
         """
         try:
             self.execute(
@@ -576,14 +577,11 @@ class BufferDatabase(BaseDatabase):
             return str(row["core_name"], 'utf8')
         return None
 
-    def get_power_monitor_core(self, x, y) -> int:
+    def get_power_monitor_core(self, x: int, y: int) -> int:
         """
         Gets the power monitor core for chip x, y
 
-        :param str description:
-        :return: list of tuples x, y, value)
-        :rtype: list(tuple(int, int, float))
-        """
+       """
         for row in self.execute(
                 """
                 SELECT the_value

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffered_sending_region.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffered_sending_region.py
@@ -72,7 +72,7 @@ class BufferedSendingRegion(object):
         self._timestamps: List[int] = list()
         self._current_timestamp_pos: int = 0
 
-    def add_key(self, timestamp: int, key: int):
+    def add_key(self, timestamp: int, key: int) -> None:
         """
         Add a key to be sent at a given time.
 
@@ -84,7 +84,7 @@ class BufferedSendingRegion(object):
             self._buffer[timestamp] = list()
         self._buffer[timestamp].append(key)
 
-    def add_keys(self, timestamp: int, keys: Iterable[int]):
+    def add_keys(self, timestamp: int, keys: Iterable[int]) -> None:
         """
         Add a set of keys to be sent at the given time.
 

--- a/spinn_front_end_common/interface/buffer_management/storage_objects/buffers_sent_deque.py
+++ b/spinn_front_end_common/interface/buffer_management/storage_objects/buffers_sent_deque.py
@@ -98,7 +98,7 @@ class BuffersSentDeque(object):
             self._sent_stop_message = True
             self.add_message_to_send(EventStopRequest())
 
-    def add_message_to_send(self, message: AbstractEIEIOMessage):
+    def add_message_to_send(self, message: AbstractEIEIOMessage) -> None:
         """
         Add a message to send.  The message is converted to a sequenced
         message.

--- a/spinn_front_end_common/interface/config_handler.py
+++ b/spinn_front_end_common/interface/config_handler.py
@@ -75,7 +75,7 @@ class ConfigHandler(object):
         self._ensure_provenance_for_energy_report()
 
     def __toggle_config(self, section: str, option: str, to_false: List[str],
-                        to_true: List[str]):
+                        to_true: List[str]) -> None:
         previous = get_config_str(section, option).lower()
         if previous in to_true:
             set_config(section, option, "True")
@@ -144,7 +144,7 @@ class ConfigHandler(object):
         self._replaced_cfg("Reports", "report_enabled",
                            "[Mode]mode = Production to turn off most reports")
 
-    def _error_on_previous(self, option) -> None:
+    def _error_on_previous(self, option: str) -> None:
         try:
             get_config_str_list("Mapping", option)
         except NoOptionError:
@@ -155,7 +155,7 @@ class ConfigHandler(object):
             "See https://spinnakermanchester.github.io/common_pages/"
             "Algorithms.html.")
 
-    def _replaced_cfg(self, section: str, previous: str, new: str):
+    def _replaced_cfg(self, section: str, previous: str, new: str) -> None:
         if has_config_option(section, previous):
             if get_config_bool(section, previous):
                 raise ConfigurationException(
@@ -165,7 +165,7 @@ class ConfigHandler(object):
                 logger.warning(f"cfg setting [{section}] {previous} "
                                f"is no longer supported! Use {new} instead")
 
-    def _reserve_system_vertices(self):
+    def _reserve_system_vertices(self) -> None:
         """
         Reserves the sizes for the system vertices
         """
@@ -181,7 +181,7 @@ class ConfigHandler(object):
 
     def _remove_excess_folders(
             self, max_kept: int, starting_directory: str,
-            remove_errored_folders: Optional[bool]):
+            remove_errored_folders: Optional[bool]) -> None:
         try:
             files_in_report_folder = os.listdir(starting_directory)
 
@@ -245,7 +245,7 @@ class ConfigHandler(object):
             f.write("Traceback of setup call:\n")
             traceback.print_stack(file=f)
 
-    def _ensure_provenance_for_energy_report(self):
+    def _ensure_provenance_for_energy_report(self) -> None:
         if get_config_bool("Reports", "write_energy_report"):
             set_config("Reports", "read_router_provenance_data", "True")
             set_config("Reports", "read_placements_provenance_data", "True")

--- a/spinn_front_end_common/interface/ds/data_specification_base.py
+++ b/spinn_front_end_common/interface/ds/data_specification_base.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Sequence, TextIO, Union
+from typing import Any, Optional, Sequence, TextIO, Union
 
 import numpy
 
@@ -59,7 +59,7 @@ class DataSpecificationBase(object, metaclass=AbstractBase):
         self._region_num: Optional[int] = None
         self._size: Optional[int] = None
 
-    def _report(self, *args) -> None:
+    def _report(self, *args: Any) -> None:
         if self._report_writer is not None:
             text = "".join(
                 (repr(arg) if isinstance(arg, bytes) else str(arg))
@@ -70,7 +70,7 @@ class DataSpecificationBase(object, metaclass=AbstractBase):
         if self._report_writer is not None:
             self._report_writer.flush()
 
-    def comment(self, comment: str):
+    def comment(self, comment: str) -> None:
         """
         Write a comment to the text version of the specification.
 
@@ -84,7 +84,7 @@ class DataSpecificationBase(object, metaclass=AbstractBase):
     @abstractmethod
     def reserve_memory_region(
             self, region: int, size: int, label: Optional[str] = None,
-            reference: Optional[int] = None):
+            reference: Optional[int] = None) -> None:
         """
         Insert command to reserve a memory region.
 
@@ -103,7 +103,7 @@ class DataSpecificationBase(object, metaclass=AbstractBase):
 
     @abstractmethod
     def reference_memory_region(
-            self, region: int, ref: int, label: Optional[str] = None):
+            self, region: int, ref: int, label: Optional[str] = None) -> None:
         """
         Insert command to reference another memory region.
 
@@ -118,7 +118,7 @@ class DataSpecificationBase(object, metaclass=AbstractBase):
         """
         raise NotImplementedError
 
-    def switch_write_focus(self, region: int):
+    def switch_write_focus(self, region: int) -> None:
         """
         Insert command to switch the region being written to.
 
@@ -137,7 +137,8 @@ class DataSpecificationBase(object, metaclass=AbstractBase):
         if self._size <= 0:
             raise DataSpecException(f"No size set for region {region}")
 
-    def write_value(self, data: Union[int, float], data_type=DataType.UINT32):
+    def write_value(self, data: Union[int, float],
+                    data_type: DataType = DataType.UINT32) -> None:
         """
         Insert command to write a value (once) to the current write pointer,
         causing the write pointer to move on by the number of bytes required
@@ -170,7 +171,7 @@ class DataSpecificationBase(object, metaclass=AbstractBase):
         if len(as_bytes) > data_type.size:
             self._flush()
             raise ValueError(
-                f"{data}:{data_type.name} as bytes was {as_bytes} "
+                f"{data}:{data_type.name} as bytes was {as_bytes!r} "
                 f"when only {data_type.size} bytes expected")
         if len(self._content) % 4 != 0:  # check we are at a word boundary
             if len(as_bytes) % data_type.size != 0:
@@ -184,7 +185,7 @@ class DataSpecificationBase(object, metaclass=AbstractBase):
 
     def write_array(self, array_values: Union[
             Sequence[int], Sequence[float], numpy.ndarray],
-            data_type=DataType.UINT32):
+            data_type:DataType = DataType.UINT32) -> None:
         """
         Insert command to write an array, causing the write pointer
         to move on by (data type size * the array size), in bytes.
@@ -195,7 +196,8 @@ class DataSpecificationBase(object, metaclass=AbstractBase):
         """
         assert self._content is not None
         assert self._content_debug is not None
-        data = numpy.array(array_values, dtype=data_type.numpy_typename)
+        data: numpy.ndarray = numpy.array(
+            array_values, dtype=data_type.numpy_typename)
 
         encoded = data.tobytes()
 

--- a/spinn_front_end_common/interface/ds/data_specification_base.py
+++ b/spinn_front_end_common/interface/ds/data_specification_base.py
@@ -185,7 +185,7 @@ class DataSpecificationBase(object, metaclass=AbstractBase):
 
     def write_array(self, array_values: Union[
             Sequence[int], Sequence[float], numpy.ndarray],
-            data_type:DataType = DataType.UINT32) -> None:
+            data_type: DataType = DataType.UINT32) -> None:
         """
         Insert command to write an array, causing the write pointer
         to move on by (data type size * the array size), in bytes.

--- a/spinn_front_end_common/interface/ds/data_specification_generator.py
+++ b/spinn_front_end_common/interface/ds/data_specification_generator.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Union, cast
+from typing import Optional, TextIO, Union, cast
 from spinn_utilities.overrides import overrides
 from spinn_front_end_common.utilities.constants import BYTES_PER_WORD
 from spinn_front_end_common.utilities.exceptions import DataSpecException
@@ -35,7 +35,7 @@ class DataSpecificationGenerator(DataSpecificationBase):
             vertex: Union[
                 AbstractGeneratesDataSpecification,
                 AbstractRewritesDataSpecification],
-            ds_db: DsSqlliteDatabase, report_writer=None):
+            ds_db: DsSqlliteDatabase, report_writer: Optional[TextIO] = None):
         """
         :param int x:
         :param int y:
@@ -66,7 +66,7 @@ class DataSpecificationGenerator(DataSpecificationBase):
     @overrides(DataSpecificationBase.reserve_memory_region)
     def reserve_memory_region(
             self, region: int, size: int, label: Optional[str] = None,
-            reference: Optional[int] = None):
+            reference: Optional[int] = None) -> None:
         self._report("RESERVE memRegion=", region, " size=", size,
                      (f" label='{label}'" if label else None),
                      (f" REF {reference}" if reference is not None else None))
@@ -80,7 +80,7 @@ class DataSpecificationGenerator(DataSpecificationBase):
 
     @overrides(DataSpecificationBase.reference_memory_region)
     def reference_memory_region(
-            self, region: int, ref: int, label: Optional[str] = None):
+            self, region: int, ref: int, label: Optional[str] = None) -> None:
         self._report("REFERENCE memRegion=", region, " ref=", ref,
                      (f" label='{label}'" if label else None))
 

--- a/spinn_front_end_common/interface/ds/data_specification_reloader.py
+++ b/spinn_front_end_common/interface/ds/data_specification_reloader.py
@@ -29,7 +29,7 @@ class DataSpecificationReloader(DataSpecificationBase):
     @overrides(DataSpecificationBase.reserve_memory_region)
     def reserve_memory_region(
             self, region: int, size: int, label: Optional[str] = None,
-            reference: Optional[int] = None):
+            reference: Optional[int] = None) -> None:
         original_size = self._ds_db.get_region_size(
             self._x, self._y, self._p, region)
         if original_size != size:
@@ -41,7 +41,7 @@ class DataSpecificationReloader(DataSpecificationBase):
 
     @overrides(DataSpecificationBase.reference_memory_region)
     def reference_memory_region(
-            self, region: int, ref: int, label: Optional[str] = None):
+            self, region: int, ref: int, label: Optional[str] = None) -> None:
         raise NotImplementedError(
             "reference_memory_region unexpected during reload")
 

--- a/spinn_front_end_common/interface/ds/data_type.py
+++ b/spinn_front_end_common/interface/ds/data_type.py
@@ -338,7 +338,7 @@ class DataType(Enum):
         np.int64,
         "0.63 signed fixed point number"))  # rounding problem for max
 
-    def __new__(cls, value:int, size: int, min_val: Decimal, max_val: Decimal,
+    def __new__(cls, value: int, size: int, min_val: Decimal, max_val: Decimal,
                 scale: Decimal, struct_encoding: str, apply_scale: bool,
                 force_cast: Optional[Callable[[Any], int]],
                 numpy_typename: type, _doc: str) -> 'DataType':

--- a/spinn_front_end_common/interface/ds/data_type.py
+++ b/spinn_front_end_common/interface/ds/data_type.py
@@ -338,17 +338,20 @@ class DataType(Enum):
         np.int64,
         "0.63 signed fixed point number"))  # rounding problem for max
 
-    def __new__(cls, *args) -> 'DataType':
+    def __new__(cls, value:int, size: int, min_val: Decimal, max_val: Decimal,
+                scale: Decimal, struct_encoding: str, apply_scale: bool,
+                force_cast: Optional[Callable[[Any], int]],
+                numpy_typename: type, _doc: str) -> 'DataType':
         # pylint: disable=protected-access, too-many-arguments
         obj = object.__new__(cls)
-        obj._value_ = args[0]
-        obj.__doc__ = args[-1]
+        obj._value_ = value
+        obj.__doc__ = _doc
         return obj
 
-    def __init__(self, __, size: int, min_val: Decimal, max_val: Decimal,
+    def __init__(self, __: int, size: int, min_val: Decimal, max_val: Decimal,
                  scale: Decimal, struct_encoding: str, apply_scale: bool,
                  force_cast: Optional[Callable[[Any], int]],
-                 numpy_typename: type, _doc: str = ""):
+                 numpy_typename: type, _doc: str) -> None:
         # pylint: disable=protected-access, too-many-arguments
         self._size = size
         self._min = min_val
@@ -391,7 +394,7 @@ class DataType(Enum):
         """
         return self._max
 
-    def check_value(self, value: Union[int, float]):
+    def check_value(self, value: Union[int, float]) -> None:
         """
         Check the value against the allowed min and max
 

--- a/spinn_front_end_common/interface/ds/ds_sqllite_database.py
+++ b/spinn_front_end_common/interface/ds/ds_sqllite_database.py
@@ -78,7 +78,7 @@ class DsSqlliteDatabase(SQLiteDB):
         .. note:: Call of this method has to be delayed until inside the with
         """
         eth_chips = FecDataView.get_machine().ethernet_connected_chips
-        self.executemany(
+        self.cursor().executemany(
             """
             INSERT INTO ethernet(
                 ethernet_x, ethernet_y, ip_address)
@@ -113,7 +113,7 @@ class DsSqlliteDatabase(SQLiteDB):
             is_system = 1
         else:
             is_system = 0
-        self.execute(
+        self.cursor().execute(
             """
             INSERT INTO core(x, y, p, is_system)
             VALUES(?, ?, ?, ?)
@@ -133,7 +133,7 @@ class DsSqlliteDatabase(SQLiteDB):
         :rtype: list(int, int, int, int, int, int)
         """
         core_infos: List[Tuple[int, int, int, int, int]] = []
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT x, y, p, ethernet_x, ethernet_y
                 FROM core_view
@@ -151,7 +151,7 @@ class DsSqlliteDatabase(SQLiteDB):
         :param int y:
         """
         # skip if it already exists
-        for _ in self.execute(
+        for _ in self.cursor().execute(
                 """
                 SELECT x
                 FROM chip
@@ -160,7 +160,7 @@ class DsSqlliteDatabase(SQLiteDB):
                 """, (x, y)):
             return
         chip = FecDataView().get_chip_at(x, y)
-        self.execute(
+        self.cursor().execute(
             """
             INSERT INTO chip(x, y, ethernet_x, ethernet_y) VALUES(?, ?, ?, ?)
             """, (x, y, chip.nearest_ethernet_x, chip.nearest_ethernet_y))
@@ -184,7 +184,7 @@ class DsSqlliteDatabase(SQLiteDB):
         :type reference: int or None
         :return:
         """
-        self.execute(
+        self.cursor().execute(
             """
             INSERT INTO region(
                 x, y, p, region_num, size, reference_num, region_label)
@@ -203,7 +203,7 @@ class DsSqlliteDatabase(SQLiteDB):
         :return: The size of the region, in bytes
         :rtype: int
         """
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT size
                 FROM region
@@ -226,7 +226,7 @@ class DsSqlliteDatabase(SQLiteDB):
         :param ref_label: label for the referencing region
         :type ref_label: str or None
         """
-        self.execute(
+        self.cursor().execute(
             """
             INSERT INTO reference(
                 x, y, p, region_num, reference_num, ref_label)
@@ -250,7 +250,7 @@ class DsSqlliteDatabase(SQLiteDB):
         :return: Yields the referencing vertex region number and the pointer
         :rtype: iterable(tuple(int,int))
         """
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT ref_region, pointer
                 FROM linked_reference_view
@@ -271,7 +271,7 @@ class DsSqlliteDatabase(SQLiteDB):
         :return: x, y, p, region, reference, label for all unlinked references
         :rtype: iterable(tuple(int, int, int, int, int, str))
         """
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT  x, y, ref_p, ref_region, reference_num,
                     COALESCE(ref_label, "") as ref_label
@@ -294,7 +294,7 @@ class DsSqlliteDatabase(SQLiteDB):
         :return: x, y, p, region
         :rtype: iterable(tuple(int, int, int, int))
         """
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT x, y, p, region_num
                 FROM pointer_content_view
@@ -319,7 +319,7 @@ class DsSqlliteDatabase(SQLiteDB):
         :raises DsDatabaseException: If the region already has content
         """
         # check for previous content
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT content
                 FROM region
@@ -331,7 +331,7 @@ class DsSqlliteDatabase(SQLiteDB):
                     f"Illegal attempt to overwrite content for "
                     f"{x=} {y=} {p=} {region_num=}")
 
-        self.execute(
+        self.cursor().execute(
             """
             UPDATE region
             SET content = ?, content_debug = ?
@@ -357,7 +357,7 @@ class DsSqlliteDatabase(SQLiteDB):
         :rtype: int or None
         :raises DsDatabaseException: if the region is not known
         """
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT pointer
                 FROM region
@@ -381,7 +381,7 @@ class DsSqlliteDatabase(SQLiteDB):
         :rtype: dict(int, int)
         """
         regions: Dict[int, int] = dict()
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT region_num, size
                 FROM region
@@ -406,7 +406,7 @@ class DsSqlliteDatabase(SQLiteDB):
             or 0 if there are no regions for this core
         :rtype: int
         """
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT COALESCE(sum(size), 0) as total
                 FROM region
@@ -427,7 +427,7 @@ class DsSqlliteDatabase(SQLiteDB):
         :param int start_address: The base address for the whole core
         :raises DsDatabaseException: if the region is not known
         """
-        self.execute(
+        self.cursor().execute(
             """
             UPDATE core
             SET start_address = ?
@@ -447,7 +447,7 @@ class DsSqlliteDatabase(SQLiteDB):
         :return: The base address for the whole core
         :rtype: int
         """
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT start_address
                 FROM core
@@ -468,7 +468,7 @@ class DsSqlliteDatabase(SQLiteDB):
         :param int region_num:
         :param int pointer:  start address
         """
-        self.execute(
+        self.cursor().execute(
             """
             UPDATE region
             SET pointer = ?
@@ -495,7 +495,7 @@ class DsSqlliteDatabase(SQLiteDB):
         :return: number, pointer and (content or None)
         :rtype: iterable(tuple(int, int, bytearray or None))
         """
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT region_num, content, pointer
                 FROM pointer_content_view
@@ -524,7 +524,7 @@ class DsSqlliteDatabase(SQLiteDB):
         :return: number, pointer and (content or None)
         :rtype: iterable(tuple(int, int, bytearray or None))
         """
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT region_num, content, pointer
                 FROM region
@@ -543,7 +543,7 @@ class DsSqlliteDatabase(SQLiteDB):
         :rtype: int
         :raises DsDatabaseException:
         """
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT MAX(LENGTH(content)) AS size
                 FROM region NATURAL JOIN CORE
@@ -568,7 +568,7 @@ class DsSqlliteDatabase(SQLiteDB):
         :rtype: list(tuple(int, int))
         """
         sizes: List[Tuple[int, int]] = []
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT LENGTH(content) AS size, COUNT(*) AS num
                 FROM region NATURAL JOIN core
@@ -593,7 +593,7 @@ class DsSqlliteDatabase(SQLiteDB):
         :return: Yields the (x, y, p)
         :rtype: iterable(tuple(int,int,int))
         """
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT x, y, p FROM core
                 """):
@@ -608,7 +608,7 @@ class DsSqlliteDatabase(SQLiteDB):
         :rtype: int
         :raises DsDatabaseException:
         """
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT COUNT(*) as count FROM core
                 LIMIT 1
@@ -628,7 +628,7 @@ class DsSqlliteDatabase(SQLiteDB):
         """
         to_malloc = APP_PTR_TABLE_BYTE_SIZE
         # try the fast way using regions
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT regions_size
                 FROM region_size_view
@@ -650,7 +650,7 @@ class DsSqlliteDatabase(SQLiteDB):
         """
         to_write = APP_PTR_TABLE_BYTE_SIZE
         # try the fast way using regions
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT contents_size
                 FROM content_size_view
@@ -676,7 +676,7 @@ class DsSqlliteDatabase(SQLiteDB):
             and memory_written
         :rtype: iterable(tuple(tuple(int, int, int), int, int, int))
         """
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT x, y, p, start_address, to_write,malloc_size
                 FROM core_summary_view
@@ -698,7 +698,7 @@ class DsSqlliteDatabase(SQLiteDB):
             job = cast('SpallocJobController', mac)._job
             if isinstance(job, SpallocJob):
                 config = job.get_session_credentials_for_db()
-                self.executemany(
+                self.cursor().executemany(
                     """
                     INSERT INTO proxy_configuration(kind, name, value)
                     VALUES(?, ?, ?)
@@ -709,7 +709,7 @@ class DsSqlliteDatabase(SQLiteDB):
         Sets the app id
         """
         # check for previous content
-        self.execute(
+        self.cursor().execute(
             """
             INSERT INTO app_id(app_id)
             VALUES(?)

--- a/spinn_front_end_common/interface/ds/ds_sqllite_database.py
+++ b/spinn_front_end_common/interface/ds/ds_sqllite_database.py
@@ -65,7 +65,7 @@ class DsSqlliteDatabase(SQLiteDB):
         super().__init__(
             database_file, ddl_file=_DDL_FILE if self._init_file else None)
 
-    def _context_entered(self):
+    def _context_entered(self) -> None:
         super()._context_entered()
         if self._init_file:
             self.__init_ethernets()
@@ -88,7 +88,7 @@ class DsSqlliteDatabase(SQLiteDB):
                 for ethernet in eth_chips))
 
     def set_core(self, x: int, y: int, p: int,
-                 vertex: AbstractHasAssociatedBinary):
+                 vertex: AbstractHasAssociatedBinary) -> None:
         """
         Creates a database record for the core with this x,y,z
 
@@ -145,7 +145,7 @@ class DsSqlliteDatabase(SQLiteDB):
                  row["ethernet_x"], row["ethernet_y"]))
         return core_infos
 
-    def _set_chip(self, x: int, y: int):
+    def _set_chip(self, x: int, y: int) -> None:
         """
         :param int x:
         :param int y:
@@ -167,7 +167,7 @@ class DsSqlliteDatabase(SQLiteDB):
 
     def set_memory_region(
             self, x: int, y: int, p: int, region_num: int, size: int,
-            reference: Optional[int], label: Optional[str]):
+            reference: Optional[int], label: Optional[str]) -> int:
         """
         Writes the information to reserve a memory region into the database
 

--- a/spinn_front_end_common/interface/ds/ds_sqllite_database.py
+++ b/spinn_front_end_common/interface/ds/ds_sqllite_database.py
@@ -214,7 +214,7 @@ class DsSqlliteDatabase(SQLiteDB):
         raise DsDatabaseException(f"Region {region_num} not set")
 
     def set_reference(self, x: int, y: int, p: int, region_num: int,
-                      reference: int, ref_label: Optional[str]):
+                      reference: int, ref_label: Optional[str]) -> None:
         """
         Writes a outgoing region_reference into the database
 
@@ -305,7 +305,7 @@ class DsSqlliteDatabase(SQLiteDB):
 
     def set_region_content(
             self, x: int, y: int, p: int, region_num: int, content: bytes,
-            content_debug: Optional[str]):
+            content_debug: Optional[str]) -> None:
         """
         Sets the content for this region
 
@@ -416,7 +416,8 @@ class DsSqlliteDatabase(SQLiteDB):
             return row["total"]
         raise DsDatabaseException("Query failed unexpectedly")
 
-    def set_start_address(self, x: int, y: int, p: int, start_address: int):
+    def set_start_address(
+            self, x: int, y: int, p: int, start_address: int) -> None:
         """
         Sets the base address for a core and calculates pointers
 
@@ -456,8 +457,8 @@ class DsSqlliteDatabase(SQLiteDB):
             return row["start_address"]
         raise DsDatabaseException(f"No core {x=} {y=} {p=}")
 
-    def set_region_pointer(
-            self, x: int, y: int, p: int, region_num: int, pointer: int):
+    def set_region_pointer(self, x: int, y: int, p: int, region_num: int,
+                           pointer: int) -> None:
         """
         Sets the pointer to the start of the address for this x, y, p region.
 

--- a/spinn_front_end_common/interface/interface_functions/application_runner.py
+++ b/spinn_front_end_common/interface/interface_functions/application_runner.py
@@ -152,8 +152,8 @@ class _ApplicationRunner(object):
         notification_interface.send_stop_pause_notification()
         return latest_runtime
 
-    def _run_wait(
-            self, runtime: Optional[float], time_threshold: Optional[float]):
+    def _run_wait(self, runtime: Optional[float],
+                  time_threshold: Optional[float]) -> None:
         """
         :param int runtime:
         :param float time_threshold:
@@ -169,7 +169,7 @@ class _ApplicationRunner(object):
         sleep(time_to_wait)
         self._wait_for_end(timeout=time_threshold)
 
-    def _wait_for_start(self, timeout: Optional[float] = None):
+    def _wait_for_start(self, timeout: Optional[float] = None) -> None:
         """
         :param timeout:
         :type timeout: float or None
@@ -194,7 +194,7 @@ class _ApplicationRunner(object):
                 # fire all signals as required
                 self.__txrx.send_signal(self.__app_id, sync_signal)
 
-    def _wait_for_end(self, timeout: Optional[float] = None):
+    def _wait_for_end(self, timeout: Optional[float] = None) -> None:
         """
         :param timeout:
         :type timeout: float or None

--- a/spinn_front_end_common/interface/interface_functions/chip_provenance_updater.py
+++ b/spinn_front_end_common/interface/interface_functions/chip_provenance_updater.py
@@ -28,7 +28,7 @@ _ONE_WORD = struct.Struct("<I")
 _LIMIT = 10
 
 
-def chip_provenance_updater(all_core_subsets: CoreSubsets):
+def chip_provenance_updater(all_core_subsets: CoreSubsets) -> None:
     """
     Forces all cores to generate provenance data, and then exit.
 
@@ -88,7 +88,7 @@ class _ChipProvenanceUpdater(object):
 
     def _update_provenance(
             self, total_processors: int, processors_completed: int,
-            progress: ProgressBar):
+            progress: ProgressBar) -> None:
         """
         :param int total_processors:
         :param int processors_completed:

--- a/spinn_front_end_common/interface/interface_functions/chip_runtime_updater.py
+++ b/spinn_front_end_common/interface/interface_functions/chip_runtime_updater.py
@@ -17,7 +17,7 @@ from spinn_front_end_common.data import FecDataView
 from spinn_front_end_common.utilities.scp import UpdateRuntimeProcess
 
 
-def chip_runtime_updater(n_sync_steps: int):
+def chip_runtime_updater(n_sync_steps: int) -> None:
     """
     Updates the runtime of an application running on a SpiNNaker machine.
 

--- a/spinn_front_end_common/interface/interface_functions/database_interface.py
+++ b/spinn_front_end_common/interface/interface_functions/database_interface.py
@@ -52,7 +52,7 @@ def database_interface(runtime: Optional[float]) -> Optional[str]:
         return writer.database_path
 
 
-def _write_to_db(w: DatabaseWriter, runtime: Optional[float]):
+def _write_to_db(w: DatabaseWriter, runtime: Optional[float]) -> None:
     """
     :param DatabaseWriter w:
     :param int runtime:

--- a/spinn_front_end_common/interface/interface_functions/dsg_region_reloader.py
+++ b/spinn_front_end_common/interface/interface_functions/dsg_region_reloader.py
@@ -13,13 +13,15 @@
 # limitations under the License.
 
 from spinn_utilities.progress_bar import ProgressBar
+
+from pacman.model.placements import Placement
+
 from spinn_front_end_common.interface.ds import (
     DsSqlliteDatabase, DataSpecificationReloader)
 from spinn_front_end_common.utilities.utility_calls import get_report_writer
 from spinn_front_end_common.abstract_models import (
     AbstractRewritesDataSpecification)
 from spinn_front_end_common.data import FecDataView
-
 
 def reload_dsg_regions() -> None:
     """
@@ -33,7 +35,8 @@ def reload_dsg_regions() -> None:
             regenerate_data_spec(placement, ds_database)
 
 
-def regenerate_data_spec(placement, ds_database) -> bool:
+def regenerate_data_spec(
+        placement: Placement, ds_database: DsSqlliteDatabase) -> bool:
     """
     Regenerate a data specification for a placement.
 

--- a/spinn_front_end_common/interface/interface_functions/dsg_region_reloader.py
+++ b/spinn_front_end_common/interface/interface_functions/dsg_region_reloader.py
@@ -23,6 +23,7 @@ from spinn_front_end_common.abstract_models import (
     AbstractRewritesDataSpecification)
 from spinn_front_end_common.data import FecDataView
 
+
 def reload_dsg_regions() -> None:
     """
     Reloads DSG regions where needed.

--- a/spinn_front_end_common/interface/interface_functions/energy_provenance_reporter.py
+++ b/spinn_front_end_common/interface/interface_functions/energy_provenance_reporter.py
@@ -30,7 +30,7 @@ _BASIC_PROPERTIES = (
 _PROV_KEY = "power_provenance"
 
 
-def energy_provenance_reporter(power_used: PowerUsed):
+def energy_provenance_reporter(power_used: PowerUsed) -> None:
     """
     Converts the power usage information into provenance data.
 

--- a/spinn_front_end_common/interface/interface_functions/graph_binary_gatherer.py
+++ b/spinn_front_end_common/interface/interface_functions/graph_binary_gatherer.py
@@ -55,7 +55,7 @@ class _GraphBinaryGatherer(object):
 
         return self._exe_targets
 
-    def __get_binary(self, placement: Placement):
+    def __get_binary(self, placement: Placement) -> None:
         """
         :param ~pacman.model.placements.Placement placement:
         """

--- a/spinn_front_end_common/interface/interface_functions/graph_data_specification_writer.py
+++ b/spinn_front_end_common/interface/interface_functions/graph_data_specification_writer.py
@@ -15,7 +15,7 @@
 from collections import defaultdict
 import logging
 import os
-from typing import Iterable, List, Sequence, Optional
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
 from spinn_utilities.progress_bar import ProgressBar
 from spinn_utilities.log import FormatAdapter
@@ -36,9 +36,10 @@ from spinn_front_end_common.utilities.utility_calls import get_report_writer
 logger = FormatAdapter(logging.getLogger(__name__))
 
 
-def graph_data_specification_writer(placement_order=None):
+def graph_data_specification_writer(
+        placement_order: Optional[Sequence[Placement]] = None) -> str:
     """
-    :param list(~pacman.model.placements.Placement) placement_order:
+    :param placement_order:
         the optional order in which placements should be examined
     :return: Path to DSG targets database
     :rtype: str
@@ -59,11 +60,12 @@ class _GraphDataSpecificationWriter(object):
         # Dict of list of vertices by chip coordinates
         "_vertices_by_chip")
 
-    def __init__(self):
-        self._sdram_usage = defaultdict(lambda: 0)
+    def __init__(self) -> None:
+        self._sdram_usage: Dict[Tuple[int, int], int] = defaultdict(lambda: 0)
         self._vertices_by_chip = defaultdict(list)
 
-    def run(self, placement_order: Optional[Sequence[Placement]] = None):
+    def run(self,
+            placement_order: Optional[Sequence[Placement]] = None) -> str:
         """
         :param list(~pacman.model.placements.Placement) placement_order:
             the optional order in which placements should be examined
@@ -195,7 +197,7 @@ class _GraphDataSpecificationWriter(object):
             f"Too much SDRAM has been used on {x}, {y}.  Vertices and"
             f" their usage on that chip is as follows:\n{memory_usage}")
 
-    def _run_check_queries(self, ds_db: DsSqlliteDatabase):
+    def _run_check_queries(self, ds_db: DsSqlliteDatabase) -> None:
         msg = ""
         for x, y, p, region, reference, lbl in ds_db.get_unlinked_references():
             if lbl is None:

--- a/spinn_front_end_common/interface/interface_functions/graph_data_specification_writer.py
+++ b/spinn_front_end_common/interface/interface_functions/graph_data_specification_writer.py
@@ -62,7 +62,8 @@ class _GraphDataSpecificationWriter(object):
 
     def __init__(self) -> None:
         self._sdram_usage: Dict[Tuple[int, int], int] = defaultdict(lambda: 0)
-        self._vertices_by_chip = defaultdict(list)
+        self._vertices_by_chip: Dict[Tuple[int, int],
+            List[AbstractGeneratesDataSpecification]] = defaultdict(list)
 
     def run(self,
             placement_order: Optional[Sequence[Placement]] = None) -> str:
@@ -103,16 +104,6 @@ class _GraphDataSpecificationWriter(object):
                 if generated and isinstance(
                         vertex, AbstractRewritesDataSpecification):
                     vertices_to_reset.append(vertex)
-
-                # If the spec wasn't generated directly, and there is an
-                # application vertex, try with that
-                if not generated and vertex.app_vertex is not None:
-                    generated = self.__generate_data_spec_for_vertices(
-                        placement, vertex.app_vertex, ds_db)
-                    if generated and isinstance(
-                            vertex.app_vertex,
-                            AbstractRewritesDataSpecification):
-                        vertices_to_reset.append(vertex.app_vertex)
 
             # Ensure that the vertices know their regions have been reloaded
             for rewriter in vertices_to_reset:

--- a/spinn_front_end_common/interface/interface_functions/graph_data_specification_writer.py
+++ b/spinn_front_end_common/interface/interface_functions/graph_data_specification_writer.py
@@ -63,7 +63,8 @@ class _GraphDataSpecificationWriter(object):
     def __init__(self) -> None:
         self._sdram_usage: Dict[Tuple[int, int], int] = defaultdict(lambda: 0)
         self._vertices_by_chip: Dict[Tuple[int, int],
-                List[AbstractGeneratesDataSpecification]] = defaultdict(list)
+                                List[AbstractGeneratesDataSpecification]] =\
+            defaultdict(list)
 
     def run(self,
             placement_order: Optional[Sequence[Placement]] = None) -> str:

--- a/spinn_front_end_common/interface/interface_functions/graph_data_specification_writer.py
+++ b/spinn_front_end_common/interface/interface_functions/graph_data_specification_writer.py
@@ -62,8 +62,8 @@ class _GraphDataSpecificationWriter(object):
 
     def __init__(self) -> None:
         self._sdram_usage: Dict[Tuple[int, int], int] = defaultdict(lambda: 0)
-        self._vertices_by_chip: Dict[Tuple[int, int],
-                                List[AbstractGeneratesDataSpecification]] =\
+        self._vertices_by_chip: \
+            Dict[Tuple[int, int], List[AbstractGeneratesDataSpecification]] =\
             defaultdict(list)
 
     def run(self,

--- a/spinn_front_end_common/interface/interface_functions/graph_data_specification_writer.py
+++ b/spinn_front_end_common/interface/interface_functions/graph_data_specification_writer.py
@@ -63,7 +63,7 @@ class _GraphDataSpecificationWriter(object):
     def __init__(self) -> None:
         self._sdram_usage: Dict[Tuple[int, int], int] = defaultdict(lambda: 0)
         self._vertices_by_chip: Dict[Tuple[int, int],
-            List[AbstractGeneratesDataSpecification]] = defaultdict(list)
+                List[AbstractGeneratesDataSpecification]] = defaultdict(list)
 
     def run(self,
             placement_order: Optional[Sequence[Placement]] = None) -> str:

--- a/spinn_front_end_common/interface/interface_functions/hbp_allocator.py
+++ b/spinn_front_end_common/interface/interface_functions/hbp_allocator.py
@@ -58,7 +58,7 @@ class _HBPJobController(MachineAllocationController):
         super().__init__("HBPJobController")
 
     @overrides(MachineAllocationController.extend_allocation)
-    def extend_allocation(self, new_total_run_time: float):
+    def extend_allocation(self, new_total_run_time: float) -> None:
         r = requests.get(self._extend_lease_url, params={
             "runTime": str(new_total_run_time)}, timeout=10)
         r.raise_for_status()
@@ -69,12 +69,12 @@ class _HBPJobController(MachineAllocationController):
         r.raise_for_status()
         return r.json()
 
-    def _release(self, machine_name: str):
+    def _release(self, machine_name: str) -> None:
         r = requests.delete(self._release_machine_url, params={
             "machineName": machine_name}, timeout=10)
         r.raise_for_status()
 
-    def _set_power(self, machine_name: str, power_on: bool):
+    def _set_power(self, machine_name: str, power_on: bool) -> None:
         r = requests.put(self._set_power_url, params={
             "machineName": machine_name, "on": str(power_on)}, timeout=10)
         r.raise_for_status()
@@ -105,7 +105,7 @@ class _HBPJobController(MachineAllocationController):
         """
         return self._power_on
 
-    def set_power(self, power: bool):
+    def set_power(self, power: bool) -> None:
         """
         Sets the power to the new state.
 

--- a/spinn_front_end_common/interface/interface_functions/host_no_bitfield_router_compression.py
+++ b/spinn_front_end_common/interface/interface_functions/host_no_bitfield_router_compression.py
@@ -139,7 +139,8 @@ class Compression(object):
             raise SpinnFrontEndException(
                 f"The router compressor failed on {self.__failures}")
 
-    def _load_routing_table(self, table: AbstractMulticastRoutingTable):
+    def _load_routing_table(
+            self, table: AbstractMulticastRoutingTable) -> None:
         """
         :param pacman.model.routing_tables.AbstractMulticastRoutingTable table:
             the router table to load

--- a/spinn_front_end_common/interface/interface_functions/insert_chip_power_monitors_to_graphs.py
+++ b/spinn_front_end_common/interface/interface_functions/insert_chip_power_monitors_to_graphs.py
@@ -32,7 +32,7 @@ def sample_chip_power_monitor() -> ChipPowerMonitorMachineVertex:
         "Sample ChipPowerMonitorMachineVertex")
 
 
-def insert_chip_power_monitors_to_graphs(placements: Placements):
+def insert_chip_power_monitors_to_graphs(placements: Placements) -> None:
     """
     Adds chip power monitors into a given graph.
 

--- a/spinn_front_end_common/interface/interface_functions/load_data_specification.py
+++ b/spinn_front_end_common/interface/interface_functions/load_data_specification.py
@@ -101,7 +101,7 @@ class _LoadDataSpecification(object):
             receiver.load_application_routing_tables()
 
     # pylint: disable=unused-private-member
-    def __java_app(self, use_monitors: bool):
+    def __java_app(self, use_monitors: bool) -> None:
         """
         :param bool use_monitors:
         """
@@ -119,7 +119,8 @@ class _LoadDataSpecification(object):
         java_caller.load_app_data_specification(use_monitors)
         progress.end()
 
-    def load_data_specs(self, is_system: bool, uses_advanced_monitors: bool):
+    def load_data_specs(
+            self, is_system: bool, uses_advanced_monitors: bool) -> None:
         """
         Execute the data specs for all system targets.
         """
@@ -147,7 +148,8 @@ class _LoadDataSpecification(object):
         FecDataView.get_java_caller().load_system_data_specification()
         progress.end()
 
-    def __python_load(self, is_system: bool, uses_advanced_monitors: bool):
+    def __python_load(
+            self, is_system: bool, uses_advanced_monitors: bool) -> None:
         """
         Does the Data Specification Execution and loading using Python.
         """
@@ -186,8 +188,8 @@ class _LoadDataSpecification(object):
         if uses_advanced_monitors:
             self.__reset_router_timeouts()
 
-    def __python_malloc_core(
-            self, ds_database: DsSqlliteDatabase, x: int, y: int, p: int):
+    def __python_malloc_core(self, ds_database: DsSqlliteDatabase,
+                             x: int, y: int, p: int) -> None:
         region_sizes = ds_database.get_region_sizes(x, y, p)
         total_size = sum(region_sizes.values())
         malloc_size = total_size + APP_PTR_TABLE_BYTE_SIZE

--- a/spinn_front_end_common/interface/interface_functions/load_executable_images.py
+++ b/spinn_front_end_common/interface/interface_functions/load_executable_images.py
@@ -59,8 +59,8 @@ def load_sys_images() -> None:
         raise e
 
 
-def _load_images(
-        filter_predicate: Callable[[ExecutableType], bool], label: str):
+def _load_images(filter_predicate: Callable[[ExecutableType], bool],
+                 label: str) -> None:
     """
     :param callable(ExecutableType,bool) filter_predicate:
     :param str label
@@ -107,7 +107,7 @@ def filter_targets(
     return cores
 
 
-def _start_simulation(cores: ExecutableTargets, app_id: int):
+def _start_simulation(cores: ExecutableTargets, app_id: int) -> None:
     """
     :param ~.ExecutableTargets cores:
         Possible subset of all ExecutableTargets to start

--- a/spinn_front_end_common/interface/interface_functions/locate_executable_start_type.py
+++ b/spinn_front_end_common/interface/interface_functions/locate_executable_start_type.py
@@ -46,7 +46,8 @@ def locate_executable_start_type() -> Dict[ExecutableType, CoreSubsets]:
     return binary_start_types
 
 
-def __add_vertex_to_subset(placement: Placement, core_subsets: CoreSubsets):
+def __add_vertex_to_subset(
+        placement: Placement, core_subsets: CoreSubsets) -> None:
     """
     :param ~.Placement placement:
     :param ~.CoreSubsets core_subsets:

--- a/spinn_front_end_common/interface/interface_functions/placements_provenance_gatherer.py
+++ b/spinn_front_end_common/interface/interface_functions/placements_provenance_gatherer.py
@@ -25,7 +25,7 @@ logger = FormatAdapter(logging.getLogger(__name__))
 
 
 def placements_provenance_gatherer(
-        n_placements: int, placements: Iterable[Placement]):
+        n_placements: int, placements: Iterable[Placement]) -> None:
     """
     Gets provenance information from the specified placements.
 
@@ -47,7 +47,7 @@ def placements_provenance_gatherer(
             logger.warning("{}", error)
 
 
-def _add_placement_provenance(placement: Placement, errors: List[str]):
+def _add_placement_provenance(placement: Placement, errors: List[str]) -> None:
     """
     :param ~.Placement placement:
     :param list(str) errors:

--- a/spinn_front_end_common/interface/interface_functions/profile_data_gatherer.py
+++ b/spinn_front_end_common/interface/interface_functions/profile_data_gatherer.py
@@ -42,7 +42,7 @@ def profile_data_gatherer() -> None:
                 _write(placement, profile_data, provenance_file_path)
 
 
-def _write(p: Placement, profile_data: ProfileData, directory: str):
+def _write(p: Placement, profile_data: ProfileData, directory: str) -> None:
     """
     :param ~.Placement p:
     :param ProfileData profile_data:

--- a/spinn_front_end_common/interface/interface_functions/router_provenance_gatherer.py
+++ b/spinn_front_end_common/interface/interface_functions/router_provenance_gatherer.py
@@ -103,7 +103,7 @@ class _RouterProvenanceGatherer(object):
     def _add_unseen_router_chip_diagnostic(
             self, chip: Chip,
             reinjection_data: Optional[Dict[Chip, ReInjectionStatus]],
-            prefix: str):
+            prefix: str) -> None:
         """
         :param ~.Chip chip:
         :param dict(Chip,ReInjectionStatus) reinjection_data:
@@ -135,7 +135,7 @@ class _RouterProvenanceGatherer(object):
             self, chip: Chip, diagnostics: RouterDiagnostics,
             status: Optional[ReInjectionStatus], expected: bool,
             table: Optional[AbstractMulticastRoutingTable],
-            prefix: str):
+            prefix: str) -> None:
         """
         Describes the router diagnostics for one router.
 

--- a/spinn_front_end_common/interface/interface_functions/routing_setup.py
+++ b/spinn_front_end_common/interface/interface_functions/routing_setup.py
@@ -43,7 +43,8 @@ def routing_setup() -> None:
         _set_router_diagnostic_filters(table.x, table.y, transceiver)
 
 
-def _set_router_diagnostic_filters(x: int, y: int, transceiver: Transceiver):
+def _set_router_diagnostic_filters(
+        x: int, y: int, transceiver: Transceiver) -> None:
     """
     :param int x:
     :param int y:

--- a/spinn_front_end_common/interface/interface_functions/routing_table_loader.py
+++ b/spinn_front_end_common/interface/interface_functions/routing_table_loader.py
@@ -17,7 +17,7 @@ from pacman.model.routing_tables import MulticastRoutingTables
 from spinn_front_end_common.data import FecDataView
 
 
-def routing_table_loader(router_tables: MulticastRoutingTables):
+def routing_table_loader(router_tables: MulticastRoutingTables) -> None:
     """
     Loads routes into initialised routers.
 

--- a/spinn_front_end_common/interface/interface_functions/spalloc_allocator.py
+++ b/spinn_front_end_common/interface/interface_functions/spalloc_allocator.py
@@ -84,7 +84,7 @@ class SpallocJobController(MachineAllocationController):
         return self._job
 
     @overrides(MachineAllocationController.extend_allocation)
-    def extend_allocation(self, new_total_run_time: float):
+    def extend_allocation(self, new_total_run_time: float) -> None:
         # Does Nothing in this allocator - machines are held until exit
         pass
 
@@ -193,7 +193,7 @@ class SpallocJobController(MachineAllocationController):
         return self.__use_proxy
 
     @overrides(MachineAllocationController.make_report)
-    def make_report(self, filename: str):
+    def make_report(self, filename: str) -> None:
         with open(filename, "w", encoding="utf-8") as report:
             report.write(f"Job: {self._job}")
 
@@ -217,7 +217,7 @@ class _OldSpallocJobController(MachineAllocationController):
         super().__init__("SpallocJobController", host)
 
     @overrides(MachineAllocationController.extend_allocation)
-    def extend_allocation(self, new_total_run_time: float):
+    def extend_allocation(self, new_total_run_time: float) -> None:
         # Does Nothing in this allocator - machines are held until exit
         pass
 
@@ -233,7 +233,7 @@ class _OldSpallocJobController(MachineAllocationController):
         """
         return self._job.power
 
-    def set_power(self, power: bool):
+    def set_power(self, power: bool) -> None:
         """
         :param bool power:
         """

--- a/spinn_front_end_common/interface/interface_functions/split_lpg_vertices.py
+++ b/spinn_front_end_common/interface/interface_functions/split_lpg_vertices.py
@@ -19,7 +19,7 @@ from spinn_front_end_common.utility_models.live_packet_gather import (
     LivePacketGather, _LPGSplitter)
 
 
-def split_lpg_vertices(system_placements: Placements):
+def split_lpg_vertices(system_placements: Placements) -> None:
     """
     Split any LPG vertices found.
 

--- a/spinn_front_end_common/interface/interface_functions/system_multicast_routing_generator.py
+++ b/spinn_front_end_common/interface/interface_functions/system_multicast_routing_generator.py
@@ -14,7 +14,7 @@
 
 from collections import defaultdict
 import logging
-from typing import Dict, Tuple, Set, Optional, cast
+from typing import Dict, List, Tuple, Set, Optional, cast
 
 from spinn_utilities.log import FormatAdapter
 from spinn_utilities.typing.coords import XY
@@ -174,7 +174,8 @@ class _SystemMulticastRoutingGenerator(object):
         return tree
 
     def _add_routing_entry(
-            self, chip: Chip, key: int, *, processor_id=None, link_ids=None):
+            self, chip: Chip, key: int, *, processor_id: Optional[int] = None,
+            link_ids: Optional[List[int]] = None) -> None:
         """
         Adds a routing entry on this chip, creating the table if needed.
 
@@ -203,8 +204,8 @@ class _SystemMulticastRoutingGenerator(object):
             routing_entry=routing_entry)
         table.add_multicast_routing_entry(entry)
 
-    def _add_routing_entries(
-            self, ethernet_chip: Chip, tree: Dict[Chip, Tuple[Chip, int]]):
+    def _add_routing_entries(self, ethernet_chip: Chip,
+                             tree: Dict[Chip, Tuple[Chip, int]]) -> None:
         """
         Adds the routing entries based on the tree.
 

--- a/spinn_front_end_common/interface/java_caller.py
+++ b/spinn_front_end_common/interface/java_caller.py
@@ -187,7 +187,7 @@ class JavaCaller(object):
             self._machine_json_path = write_json_machine(progress_bar=False)
         return self._machine_json_path
 
-    def set_placements(self, used_placements: Iterable[Placement]):
+    def set_placements(self, used_placements: Iterable[Placement]) -> None:
         """
         Passes in the placements leaving this class to decide pass it to
         Java.
@@ -218,7 +218,7 @@ class JavaCaller(object):
             raise SpinnFrontEndException("placements not set")
         return self.__placement_json
 
-    def _json_placement(self, placement: Placement):
+    def _json_placement(self, placement: Placement) -> JsonObject:
         """
         :param ~pacman.model.placements.Placement placement:
         :rtype: dict
@@ -318,7 +318,7 @@ class JavaCaller(object):
                     "y": chip.y,
                     "p": self._monitor_cores[chip]}
                 if chip in by_chip:
-                    json_placements = [
+                    json_placements: JsonArray = [
                         self._json_placement(placement)
                         for placement in by_chip[chip]]
                     if json_placements:
@@ -355,7 +355,7 @@ class JavaCaller(object):
 
         return path
 
-    def _run_java(self, *args: str):
+    def _run_java(self, *args: str) -> None:
         """
         Does the actual running of `JavaSpiNNaker`. Arguments are those that
         will be processed by the `main` method on the Java side.

--- a/spinn_front_end_common/interface/profiling/profile_data.py
+++ b/spinn_front_end_common/interface/profiling/profile_data.py
@@ -58,7 +58,7 @@ class ProfileData(object):
         self._tags: Dict[str, Tuple[numpy.ndarray, numpy.ndarray]] = dict()
         self._max_time: float = 0.0
 
-    def add_data(self, data: bytes):
+    def add_data(self, data: bytes) -> None:
         """
         Add profiling data read from the profile section.
 
@@ -96,9 +96,9 @@ class ProfileData(object):
             self._add_tag_data(
                 entry_tags, entry_times_ms, exit_tags, exit_times_ms, tag)
 
-    def _add_tag_data(
-            self, entry_tags: numpy.ndarray, entry_times: numpy.ndarray,
-            exit_tags: numpy.ndarray, exit_times: numpy.ndarray, tag: int):
+    def _add_tag_data(self, entry_tags: numpy.ndarray,
+                      entry_times: numpy.ndarray, exit_tags: numpy.ndarray,
+                      exit_times: numpy.ndarray, tag: int) -> None:
         """
         :param ~numpy.ndarray entry_tags:
         :param ~numpy.ndarray entry_times:

--- a/spinn_front_end_common/interface/profiling/profile_utils.py
+++ b/spinn_front_end_common/interface/profiling/profile_utils.py
@@ -41,7 +41,7 @@ def get_profile_region_size(n_samples: int) -> int:
 
 
 def reserve_profile_region(
-        spec: DataSpecificationGenerator, region: int, n_samples: int):
+        spec: DataSpecificationGenerator, region: int, n_samples: int) -> None:
     """
     Reserves the profile region for recording the profile data.
 
@@ -56,7 +56,7 @@ def reserve_profile_region(
 
 
 def write_profile_region_data(
-        spec: DataSpecificationGenerator, region: int, n_samples: int):
+        spec: DataSpecificationGenerator, region: int, n_samples: int) -> None:
     """
     Writes the profile region data.
 

--- a/spinn_front_end_common/interface/provenance/abstract_provides_provenance_data_from_machine.py
+++ b/spinn_front_end_common/interface/provenance/abstract_provides_provenance_data_from_machine.py
@@ -28,7 +28,7 @@ class AbstractProvidesProvenanceDataFromMachine(
     __slots__ = ()
 
     @abstractmethod
-    def get_provenance_data_from_machine(self, placement: Placement):
+    def get_provenance_data_from_machine(self, placement: Placement) -> None:
         """
         Get provenance data items for a placement and store them in the
         provenance DB.

--- a/spinn_front_end_common/interface/provenance/fec_timer.py
+++ b/spinn_front_end_common/interface/provenance/fec_timer.py
@@ -17,7 +17,9 @@ import logging
 import os
 import time
 from datetime import timedelta
-from typing import List, Optional, Tuple, Union, TYPE_CHECKING
+from typing import List, Optional, Tuple, Type, Union, TYPE_CHECKING
+from types import TracebackType
+
 from typing_extensions import Literal, Self
 from spinn_utilities.config_holder import (get_config_bool)
 from spinn_utilities.log import FormatAdapter
@@ -288,7 +290,9 @@ class FecTimer(object):
         """
         return timedelta(microseconds=time_diff / _NANO_TO_MICRO)
 
-    def __exit__(self, exc_type, exc_value, traceback) -> Literal[False]:
+    def __exit__(self, exc_type: Optional[Type],
+                 exc_val: Optional[BaseException],
+                 exc_tb: Optional[TracebackType]) -> Literal[False]:
         if self._start_time is None:
             return False
         time_taken = self._stop_timer()
@@ -325,7 +329,7 @@ class FecTimer(object):
         return time_now
 
     @classmethod
-    def _change_category(cls, category: TimerCategory):
+    def _change_category(cls, category: TimerCategory) -> None:
         """
         This method should only be called via the View!
 
@@ -338,7 +342,8 @@ class FecTimer(object):
         cls._category_time = time_now
 
     @classmethod
-    def start_category(cls, category: TimerCategory, machine_on=None):
+    def start_category(cls, category: TimerCategory,
+                       machine_on: Optional[bool] = None) -> None:
         """
         This method should only be called via the View!
 
@@ -355,7 +360,7 @@ class FecTimer(object):
             cls._machine_on = machine_on
 
     @classmethod
-    def end_category(cls, category: TimerCategory):
+    def end_category(cls, category: TimerCategory) -> None:
         """
         This method should only be
         called via the View!

--- a/spinn_front_end_common/interface/provenance/fec_timer.py
+++ b/spinn_front_end_common/interface/provenance/fec_timer.py
@@ -62,7 +62,7 @@ class FecTimer(object):
     APPLICATION_RUNNER = "Application runner"
 
     @classmethod
-    def setup(cls, simulator: AbstractSpinnakerBase):
+    def setup(cls, simulator: AbstractSpinnakerBase) -> None:
         """
         Checks and saves cfg values so they don't have to be read each time
 
@@ -88,7 +88,7 @@ class FecTimer(object):
         self._start_time = time.perf_counter_ns()
         return self
 
-    def _report(self, message: str):
+    def _report(self, message: str) -> None:
         if self._provenance_path is not None:
             with open(self._provenance_path, "a", encoding="utf-8") as p_file:
                 p_file.write(f"{message}\n")
@@ -96,14 +96,14 @@ class FecTimer(object):
             logger.info(message)
 
     def _insert_timing(
-            self, time_taken: timedelta, skip_reason: Optional[str]):
+            self, time_taken: timedelta, skip_reason: Optional[str]) -> None:
         if self._category_id is not None:
             with GlobalProvenance() as db:
                 db.insert_timing(
                     self._category_id, self._algorithm, self._work,
                     time_taken, skip_reason)
 
-    def skip(self, reason: str):
+    def skip(self, reason: str) -> None:
         """
         Records that the algorithms is being skipped and ends the timer.
 
@@ -256,7 +256,7 @@ class FecTimer(object):
         self.skip(reason)
         return True
 
-    def error(self, reason: str):
+    def error(self, reason: str) -> None:
         """
          Ends an algorithm timing and records that it failed.
 

--- a/spinn_front_end_common/interface/provenance/global_provenance.py
+++ b/spinn_front_end_common/interface/provenance/global_provenance.py
@@ -93,7 +93,7 @@ class GlobalProvenance(SQLiteDB):
         :param str description: The package for which the version applies
         :param str the_value: The version to be recorded
         """
-        self.execute(
+        self.cursor().execute(
             """
             INSERT INTO version_provenance(
                 description, the_value)
@@ -109,7 +109,7 @@ class GlobalProvenance(SQLiteDB):
         :param bool machine_on: If the machine was done during all
             or some of the time
         """
-        self.execute(
+        self.cursor().execute(
             """
             INSERT INTO category_timer_provenance(
                 category, machine_on, n_run, n_loop)
@@ -132,7 +132,7 @@ class GlobalProvenance(SQLiteDB):
                 (delta.seconds * MICRO_TO_MILLISECOND_CONVERSION) +
                 (delta.microseconds / MICRO_TO_MILLISECOND_CONVERSION))
 
-        self.execute(
+        self.cursor().execute(
             """
             UPDATE category_timer_provenance
             SET
@@ -157,7 +157,7 @@ class GlobalProvenance(SQLiteDB):
         time_taken = (
                 (delta.seconds * MICRO_TO_MILLISECOND_CONVERSION) +
                 (delta.microseconds / MICRO_TO_MILLISECOND_CONVERSION))
-        self.execute(
+        self.cursor().execute(
             """
             INSERT INTO timer_provenance(
                 category_id, algorithm, work, time_taken, skip_reason)
@@ -175,7 +175,7 @@ class GlobalProvenance(SQLiteDB):
         """
         if timestamp is None:
             timestamp = datetime.now()
-        self.execute(
+        self.cursor().execute(
             """
             INSERT INTO p_log_provenance(
                 timestamp, level, message)
@@ -190,7 +190,7 @@ class GlobalProvenance(SQLiteDB):
         This will lock the database and then try to do a log
         """
         # lock the database
-        self.execute(
+        self.cursor().execute(
             """
             INSERT INTO version_provenance(
                 description, the_value)
@@ -230,7 +230,7 @@ class GlobalProvenance(SQLiteDB):
         :rtype: list(tuple or ~sqlite3.Row)
         """
         results = []
-        for row in self.execute(query, list(params)):
+        for row in self.cursor().execute(query, list(params)):
             results.append(row)
         return results
 

--- a/spinn_front_end_common/interface/provenance/global_provenance.py
+++ b/spinn_front_end_common/interface/provenance/global_provenance.py
@@ -86,7 +86,7 @@ class GlobalProvenance(SQLiteDB):
         SQLiteDB.__init__(self, database_file, ddl_file=_DDL_FILE,
                           row_factory=None, text_factory=None)
 
-    def insert_version(self, description: str, the_value: str):
+    def insert_version(self, description: str, the_value: str) -> None:
         """
         Inserts data into the version_provenance table
 
@@ -100,7 +100,8 @@ class GlobalProvenance(SQLiteDB):
             VALUES(?, ?)
             """, [description, the_value])
 
-    def insert_category(self, category: TimerCategory, machine_on: bool):
+    def insert_category(
+            self, category: TimerCategory, machine_on: bool) -> int:
         """
         Inserts category into the category_timer_provenance  returning id
 
@@ -119,7 +120,8 @@ class GlobalProvenance(SQLiteDB):
              FecDataView.get_run_step()])
         return self.lastrowid
 
-    def insert_category_timing(self, category_id: int, delta: timedelta):
+    def insert_category_timing(
+            self, category_id: int, delta: timedelta) -> None:
         """
         Inserts run time into the category
 
@@ -140,7 +142,7 @@ class GlobalProvenance(SQLiteDB):
 
     def insert_timing(
             self, category: int, algorithm: str, work: TimerWork,
-            delta: timedelta, skip_reason: Optional[str]):
+            delta: timedelta, skip_reason: Optional[str]) -> None:
         """
         Inserts algorithms run times into the timer_provenance table
 
@@ -164,7 +166,7 @@ class GlobalProvenance(SQLiteDB):
             [category, algorithm, work.work_name, time_taken, skip_reason])
 
     def store_log(self, level: int, message: str,
-                  timestamp: Optional[datetime] = None):
+                  timestamp: Optional[datetime] = None) -> None:
         """
         Stores log messages into the database
 
@@ -181,7 +183,7 @@ class GlobalProvenance(SQLiteDB):
             """,
             [timestamp, level, message])
 
-    def _test_log_locked(self, text: str):
+    def _test_log_locked(self, text: str) -> None:
         """
         THIS IS A TESTING METHOD.
 

--- a/spinn_front_end_common/interface/provenance/log_store_db.py
+++ b/spinn_front_end_common/interface/provenance/log_store_db.py
@@ -29,7 +29,7 @@ class LogStoreDB(LogStore):
     @overrides(LogStore.store_log)
     def store_log(
             self, level: int, message: str,
-            timestamp: Optional[datetime] = None):
+            timestamp: Optional[datetime] = None) -> None:
         try:
             with GlobalProvenance() as db:
                 db.store_log(level, message, timestamp)

--- a/spinn_front_end_common/interface/provenance/provenance_reader.py
+++ b/spinn_front_end_common/interface/provenance/provenance_reader.py
@@ -23,7 +23,7 @@ from spinn_front_end_common.utilities.base_database import (
 
 #: Basic types supported natively by SQLite
 _MonitorItem: TypeAlias = Tuple[int, int, _SqliteTypes]
-_RouterItem: TypeAlias = Tuple[int, int, Union[int, float]]
+_RouterItem: TypeAlias = Tuple[int, int, int]
 
 
 class ProvenanceReader(BaseDatabase):

--- a/spinn_front_end_common/interface/provenance/provenance_reader.py
+++ b/spinn_front_end_common/interface/provenance/provenance_reader.py
@@ -105,7 +105,7 @@ class ProvenanceReader(BaseDatabase):
             statement
         :rtype: list(tuple or ~sqlite3.Row)
         """
-        return list(self.execute(query, list(params)))
+        return list(self.cursor().execute(query, list(params)))
 
     def cores_with_late_spikes(self) -> List[Tuple[int, int, int, int]]:
         """

--- a/spinn_front_end_common/interface/provenance/provenance_reader.py
+++ b/spinn_front_end_common/interface/provenance/provenance_reader.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import os
-from typing import Iterable, List, Optional, Sequence, Tuple, Union, cast
+from typing import Iterable, List, Optional, Sequence, Tuple, cast
 from typing_extensions import TypeAlias
 from spinn_utilities.typing.coords import XYP
 from spinn_front_end_common.data import FecDataView

--- a/spinn_front_end_common/interface/provenance/provenance_writer.py
+++ b/spinn_front_end_common/interface/provenance/provenance_writer.py
@@ -61,7 +61,7 @@ class ProvenanceWriter(BaseDatabase):
         """
         if not get_config_bool("Reports", "write_provenance"):
             return
-        self.execute(
+        self.cursor().execute(
             """
             INSERT INTO power_provenance(
                 description, the_value)
@@ -84,7 +84,7 @@ class ProvenanceWriter(BaseDatabase):
         """
         if not get_config_bool("Reports", "write_provenance"):
             return
-        self.execute(
+        self.cursor().execute(
             """
             INSERT INTO gatherer_provenance(
                 x, y, address, bytes, run, description, the_value)
@@ -118,7 +118,7 @@ class ProvenanceWriter(BaseDatabase):
         :param str description: type of value
         :param the_value: data
         """
-        self.execute(
+        self.cursor().execute(
             """
             INSERT INTO monitor_provenance(
                 x, y, description, the_value)
@@ -141,7 +141,7 @@ class ProvenanceWriter(BaseDatabase):
         """
         if not get_config_bool("Reports", "write_provenance"):
             return
-        self.execute(
+        self.cursor().execute(
             """
             INSERT INTO router_provenance(
                 x, y, description, the_value, expected)
@@ -163,7 +163,7 @@ class ProvenanceWriter(BaseDatabase):
         if not get_config_bool("Reports", "write_provenance"):
             return
         core_id = self._get_core_id(x, y, p)
-        self.execute(
+        self.cursor().execute(
             """
             INSERT INTO core_provenance(
                 core_id, description, the_value)
@@ -182,7 +182,7 @@ class ProvenanceWriter(BaseDatabase):
         if not get_config_bool("Reports", "write_provenance"):
             logger.warning(message)
             return
-        self.execute(
+        self.cursor().execute(
             """
             INSERT INTO reports(message)
             VALUES(?)
@@ -211,7 +211,7 @@ class ProvenanceWriter(BaseDatabase):
         """
         if not get_config_bool("Reports", "write_provenance"):
             return
-        self.execute(
+        self.cursor().execute(
             """
             INSERT OR IGNORE INTO connector_provenance(
                 pre_population, post_population, the_type, description,
@@ -234,7 +234,7 @@ class ProvenanceWriter(BaseDatabase):
             return
         if not connections:
             return
-        self.executemany(
+        self.cursor().executemany(
             """
             INSERT OR IGNORE INTO boards_provenance(
             ethernet_x, ethernet_y, ip_addres)
@@ -249,7 +249,7 @@ class ProvenanceWriter(BaseDatabase):
         This will lock the database and then try to do a log
         """
         # lock the database
-        self.execute(
+        self.cursor().execute(
             """
             INSERT INTO reports(message)
             VALUES(?)

--- a/spinn_front_end_common/interface/provenance/provenance_writer.py
+++ b/spinn_front_end_common/interface/provenance/provenance_writer.py
@@ -127,7 +127,7 @@ class ProvenanceWriter(BaseDatabase):
 
     def insert_router(
             self, x: int, y: int, description: str,
-            the_value: Union[int, float],
+            the_value: int,
             expected: bool = True) -> None:
         """
         Inserts data into the `router_provenance` table.

--- a/spinn_front_end_common/interface/provenance/provenance_writer.py
+++ b/spinn_front_end_common/interface/provenance/provenance_writer.py
@@ -106,8 +106,8 @@ class ProvenanceWriter(BaseDatabase):
         if get_config_bool("Reports", "write_provenance"):
             self.insert_monitor_value(x, y, description, the_value)
 
-    def insert_monitor_value(
-            self, x: int, y: int, description: str, the_value: _SqliteTypes):
+    def insert_monitor_value(self, x: int, y: int, description: str,
+                             the_value: _SqliteTypes) -> None:
         """
         Inserts data into the `monitor_provenance` table.
 

--- a/spinn_front_end_common/interface/provenance/provenance_writer.py
+++ b/spinn_front_end_common/interface/provenance/provenance_writer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import logging
-from typing import Dict, Optional, Tuple, Union
+from typing import Dict, Optional, Tuple
 from spinn_utilities.config_holder import (
     get_config_int_or_none, get_config_bool)
 from spinn_utilities.log import FormatAdapter
@@ -242,7 +242,7 @@ class ProvenanceWriter(BaseDatabase):
             """, ((x, y, ipaddress)
                   for ((x, y), ipaddress) in connections.items()))
 
-    def _test_log_locked(self, text:str) -> None:
+    def _test_log_locked(self, text: str) -> None:
         """
         THIS IS A TESTING METHOD.
 

--- a/spinn_front_end_common/interface/provenance/provenance_writer.py
+++ b/spinn_front_end_common/interface/provenance/provenance_writer.py
@@ -52,7 +52,7 @@ class ProvenanceWriter(BaseDatabase):
         """
         super().__init__(database_file)
 
-    def insert_power(self, description: str, the_value: _SqliteTypes):
+    def insert_power(self, description: str, the_value: _SqliteTypes) -> None:
         """
         Inserts a general power value into the `power_provenance` table.
 
@@ -70,7 +70,7 @@ class ProvenanceWriter(BaseDatabase):
 
     def insert_gatherer(
             self, x: int, y: int, address: int, bytes_read: int, run: int,
-            description: str, the_value: _SqliteTypes):
+            description: str, the_value: _SqliteTypes) -> None:
         """
         Records provenance into the `gatherer_provenance` table.
 
@@ -91,15 +91,15 @@ class ProvenanceWriter(BaseDatabase):
             VALUES(?, ?, ?, ?, ?, ?, ?)
             """, [x, y, address, bytes_read, run, description, the_value])
 
-    def insert_monitor(
-            self, x: int, y: int, description: str, the_value: _SqliteTypes):
+    def insert_monitor(self, x: int, y: int, description: str,
+                       the_value: _SqliteTypes) -> None:
         """
         Inserts data into the `monitor_provenance` table.
 
         :param int x: X coordinate of the chip
         :param int y: Y coordinate of the chip
         :param str description: type of value
-        :param int the_value: data
+        :param the_value: data
         """
         if not get_config_bool("Reports", "write_provenance"):
             return
@@ -113,7 +113,7 @@ class ProvenanceWriter(BaseDatabase):
     def insert_router(
             self, x: int, y: int, description: str,
             the_value: Union[int, float],
-            expected: bool = True):
+            expected: bool = True) -> None:
         """
         Inserts data into the `router_provenance` table.
 
@@ -135,7 +135,7 @@ class ProvenanceWriter(BaseDatabase):
 
     def insert_core(
             self, x: int, y: int, p: int, description: str,
-            the_value: _SqliteTypes):
+            the_value: _SqliteTypes) -> None:
         """
         Inserts data for a specific core into the `core_provenance` table.
 
@@ -155,7 +155,7 @@ class ProvenanceWriter(BaseDatabase):
             VALUES(?, ?, ?)
             """, [core_id, description, the_value])
 
-    def insert_report(self, message: str):
+    def insert_report(self, message: str) -> None:
         """
         Save and if applicable logs a message to the `reports` table.
 
@@ -184,7 +184,7 @@ class ProvenanceWriter(BaseDatabase):
 
     def insert_connector(
             self, pre_population: str, post_population: str, the_type: str,
-            description: str, the_value: _SqliteTypes):
+            description: str, the_value: _SqliteTypes) -> None:
         """
         Inserts edge data into the `connector_provenance`
 
@@ -207,7 +207,7 @@ class ProvenanceWriter(BaseDatabase):
              the_value])
 
     def insert_board_provenance(self, connections: Optional[
-            Dict[Tuple[int, int], str]]):
+            Dict[Tuple[int, int], str]]) -> None:
         """
         Write the connection details retrieved from spalloc_client job to the
         `boards_provenance` table.
@@ -227,7 +227,7 @@ class ProvenanceWriter(BaseDatabase):
             """, ((x, y, ipaddress)
                   for ((x, y), ipaddress) in connections.items()))
 
-    def _test_log_locked(self, text):
+    def _test_log_locked(self, text:str) -> None:
         """
         THIS IS A TESTING METHOD.
 

--- a/spinn_front_end_common/interface/provenance/provides_provenance_data_from_machine_impl.py
+++ b/spinn_front_end_common/interface/provenance/provides_provenance_data_from_machine_impl.py
@@ -24,6 +24,7 @@ from pacman.model.placements import Placement
 from spinn_front_end_common.utilities.helpful_functions import (
     get_region_base_address_offset)
 from spinn_front_end_common.data import FecDataView
+from spinn_front_end_common.interface.ds import DataSpecificationGenerator
 from spinn_front_end_common.utilities.constants import BYTES_PER_WORD
 from spinn_front_end_common.utilities.helpful_functions import n_word_struct
 
@@ -74,7 +75,8 @@ class ProvidesProvenanceDataFromMachineImpl(
         """
         raise NotImplementedError
 
-    def reserve_provenance_data_region(self, spec) -> None:
+    def reserve_provenance_data_region(
+            self, spec: DataSpecificationGenerator ) -> None:
         """
         :param ~data_specification.DataSpecificationGenerator spec:
             The data specification being written.
@@ -142,7 +144,7 @@ class ProvidesProvenanceDataFromMachineImpl(
 
     def parse_system_provenance_items(
             self, label: str, x: int, y: int, p: int,
-            provenance_data: Sequence[int]):
+            provenance_data: Sequence[int]) -> None:
         """
         Given some words of provenance data, convert the portion of them that
         describes the system provenance into proper provenance items.
@@ -246,7 +248,7 @@ class ProvidesProvenanceDataFromMachineImpl(
 
     def parse_extra_provenance_items(
             self, label: str, x: int, y: int, p: int,
-            provenance_data: Sequence[int]):
+            provenance_data: Sequence[int]) -> None:
         # pylint: disable=unused-argument
         """
         Convert the remaining provenance words (those not in the standard set)
@@ -273,7 +275,7 @@ class ProvidesProvenanceDataFromMachineImpl(
         AbstractProvidesProvenanceDataFromMachine.
         get_provenance_data_from_machine,
         extend_doc=False)
-    def get_provenance_data_from_machine(self, placement: Placement):
+    def get_provenance_data_from_machine(self, placement: Placement) -> None:
         """
         Retrieve the provenance data.
 

--- a/spinn_front_end_common/interface/provenance/provides_provenance_data_from_machine_impl.py
+++ b/spinn_front_end_common/interface/provenance/provides_provenance_data_from_machine_impl.py
@@ -76,7 +76,7 @@ class ProvidesProvenanceDataFromMachineImpl(
         raise NotImplementedError
 
     def reserve_provenance_data_region(
-            self, spec: DataSpecificationGenerator ) -> None:
+            self, spec: DataSpecificationGenerator) -> None:
         """
         :param ~data_specification.DataSpecificationGenerator spec:
             The data specification being written.

--- a/spinn_front_end_common/interface/provenance/router_prov_mapper.py
+++ b/spinn_front_end_common/interface/provenance/router_prov_mapper.py
@@ -15,12 +15,11 @@
 import argparse
 import os
 # pylint: disable=no-name-in-module
-from types import TracebackType
+import sqlite3
+from types import ModuleType, TracebackType
 from typing import (
     Any, ContextManager, FrozenSet, Iterable, List, Optional, Tuple, Type,
     cast)
-import sqlite3
-from types import ModuleType
 
 import numpy
 from typing_extensions import Literal

--- a/spinn_front_end_common/interface/provenance/timer_category.py
+++ b/spinn_front_end_common/interface/provenance/timer_category.py
@@ -31,12 +31,12 @@ class TimerCategory(Enum):
     RESETTING = (auto(), "Resetting")
     SHUTTING_DOWN = (auto(), "Shutting down")
 
-    def __new__(cls, *args) -> 'TimerCategory':
+    def __new__(cls, value:int, category_name: str) -> 'TimerCategory':
         obj = object.__new__(cls)
-        obj._value_ = args[0]
+        obj._value_ = value
         return obj
 
-    def __init__(self, __, category_name: str):
+    def __init__(self, __: int, category_name: str) -> None:
         self._category_name = category_name
 
     @property

--- a/spinn_front_end_common/interface/provenance/timer_category.py
+++ b/spinn_front_end_common/interface/provenance/timer_category.py
@@ -31,7 +31,7 @@ class TimerCategory(Enum):
     RESETTING = (auto(), "Resetting")
     SHUTTING_DOWN = (auto(), "Shutting down")
 
-    def __new__(cls, value:int, category_name: str) -> 'TimerCategory':
+    def __new__(cls, value: int, __: str) -> 'TimerCategory':
         obj = object.__new__(cls)
         obj._value_ = value
         return obj

--- a/spinn_front_end_common/interface/provenance/timer_work.py
+++ b/spinn_front_end_common/interface/provenance/timer_work.py
@@ -33,12 +33,12 @@ class TimerWork(Enum):
     EXTRACT_DATA = (auto(), "Extracting Data")
     REPORT = (auto(), "Reporting")
 
-    def __new__(cls, *args) -> 'TimerWork':
+    def __new__(cls, value: int, __: str) -> 'TimerWork':
         obj = object.__new__(cls)
-        obj._value_ = args[0]
+        obj._value_ = value
         return obj
 
-    def __init__(self, __, work_name: str):
+    def __init__(self, __: int, work_name: str):
         self._work_name = work_name
 
     @property

--- a/spinn_front_end_common/interface/splitter_selectors/splitter_selector.py
+++ b/spinn_front_end_common/interface/splitter_selectors/splitter_selector.py
@@ -35,7 +35,7 @@ def splitter_selector() -> None:
             vertex_selector(app_vertex)
 
 
-def vertex_selector(app_vertex: ApplicationVertex):
+def vertex_selector(app_vertex: ApplicationVertex) -> None:
     """
     Main point for selecting a splitter object for a given app vertex.
 

--- a/spinn_front_end_common/utilities/base_database.py
+++ b/spinn_front_end_common/utilities/base_database.py
@@ -26,7 +26,7 @@ _SECONDS_TO_MICRO_SECONDS_CONVERSION = 1000
 _SqliteTypes: TypeAlias = Union[str, int, float, bytes, None]
 
 
-def _timestamp():
+def _timestamp() -> int:
     return int(time.time() * _SECONDS_TO_MICRO_SECONDS_CONVERSION)
 
 

--- a/spinn_front_end_common/utilities/base_database.py
+++ b/spinn_front_end_common/utilities/base_database.py
@@ -86,14 +86,14 @@ class BaseDatabase(SQLiteDB):
         :param int p:
         :rtype: int
         """
-        for row in self.execute(
+        for row in self.cursor().execute(
                 """
                 SELECT core_id FROM core
                 WHERE x = ? AND y = ? AND processor = ?
                 LIMIT 1
                 """, (x, y, p)):
             return row["core_id"]
-        self.execute(
+        self.cursor().execute(
             """
             INSERT INTO core(x, y, processor) VALUES(?, ?, ?)
             """, (x, y, p))

--- a/spinn_front_end_common/utilities/connections/live_event_connection.py
+++ b/spinn_front_end_common/utilities/connections/live_event_connection.py
@@ -20,9 +20,12 @@ from time import sleep
 from typing import (
     Callable, Dict, Iterable, List, Optional, Set, Tuple, Union,
     cast)
+
 from typing_extensions import TypeGuard
+
 from spinn_utilities.log import FormatAdapter
 from spinn_utilities.logger_utils import warn_once
+
 from spinnman.messages.eieio.data_messages import (
     EIEIODataMessage, KeyPayloadDataElement, KeyDataElement)
 from spinnman.messages.eieio import EIEIOType, AbstractEIEIOMessage
@@ -37,6 +40,7 @@ from spinnman.utilities.utility_functions import reprogram_tag_to_listener
 from spinnman.messages.eieio import (
     read_eieio_command_message, read_eieio_data_message)
 from spinnman.spalloc import SpallocEIEIOConnection, SpallocEIEIOListener
+
 from spinn_front_end_common.utilities.constants import NOTIFY_PORT
 from spinn_front_end_common.utilities.database import (
     DatabaseConnection, DatabaseReader)
@@ -189,7 +193,7 @@ class LiveEventConnection(DatabaseConnection):
         self.__expect_scp_response_lock = Condition()
         self.__scp_response_received: Optional[bytes] = None
 
-    def add_send_label(self, label: str):
+    def add_send_label(self, label: str) -> None:
         """
         Adds a send label.
 
@@ -204,7 +208,7 @@ class LiveEventConnection(DatabaseConnection):
             self.__pause_stop_callbacks[label] = list()
             self.__init_callbacks[label] = list()
 
-    def add_receive_label(self, label: str):
+    def add_receive_label(self, label: str) -> None:
         """
         Adds a receive label is possible.
 
@@ -225,7 +229,8 @@ class LiveEventConnection(DatabaseConnection):
             self.__pause_stop_callbacks[label] = list()
             self.__init_callbacks[label] = list()
 
-    def add_init_callback(self, label: str, init_callback: _InitCallback):
+    def add_init_callback(
+            self, label: str, init_callback: _InitCallback) -> None:
         """
         Add a callback to be called to initialise a vertex.
 
@@ -243,7 +248,7 @@ class LiveEventConnection(DatabaseConnection):
 
     def add_receive_callback(
             self, label: str, live_event_callback: _RcvTimeCallback,
-            translate_key: bool = True):
+            translate_key: bool = True) -> None:
         """
         Add a callback for the reception of time events from a vertex.
 
@@ -276,7 +281,7 @@ class LiveEventConnection(DatabaseConnection):
 
     def add_receive_no_time_callback(
             self, label: str, live_event_callback: _RcvCallback,
-            translate_key: bool = True):
+            translate_key: bool = True) -> None:
         """
         Add a callback for the reception of live events from a vertex.
 
@@ -295,7 +300,8 @@ class LiveEventConnection(DatabaseConnection):
         self.__no_time_event_callbacks[label_id].append(
             (live_event_callback, translate_key))
 
-    def add_start_callback(self, label: str, start_callback: _Callback):
+    def add_start_callback(
+            self, label: str, start_callback: _Callback) -> None:
         """
         Add a callback for the start of the simulation.
 
@@ -314,7 +320,7 @@ class LiveEventConnection(DatabaseConnection):
         self.add_start_resume_callback(label, start_callback)
 
     def add_start_resume_callback(
-            self, label: str, start_resume_callback: _Callback):
+            self, label: str, start_resume_callback: _Callback) -> None:
         """
         Add a callback for the start and resume state of the simulation.
 
@@ -328,7 +334,7 @@ class LiveEventConnection(DatabaseConnection):
         self.__start_resume_callbacks[label].append(start_resume_callback)
 
     def add_pause_stop_callback(
-            self, label: str, pause_stop_callback: _Callback):
+            self, label: str, pause_stop_callback: _Callback) -> None:
         """
         Add a callback for the pause and stop state of the simulation.
 
@@ -341,7 +347,7 @@ class LiveEventConnection(DatabaseConnection):
         """
         self.__pause_stop_callbacks[label].append(pause_stop_callback)
 
-    def __read_database_callback(self, db_reader: DatabaseReader):
+    def __read_database_callback(self, db_reader: DatabaseReader) -> None:
         """
         :param DatabaseReader db_reader:
         """
@@ -366,8 +372,8 @@ class LiveEventConnection(DatabaseConnection):
                 init_callback(
                     label, vertex_size, run_time_ms, machine_timestep / 1000.0)
 
-    def __init_sender(
-            self, database: DatabaseReader, vertex_sizes: Dict[str, int]):
+    def __init_sender(self, database: DatabaseReader,
+                      vertex_sizes: Dict[str, int]) -> None:
         """
         :param DatabaseReader database:
         :param dict(str,int) vertex_sizes:
@@ -387,8 +393,8 @@ class LiveEventConnection(DatabaseConnection):
                 database.get_atom_id_to_key_mapping(label)
             vertex_sizes[label] = len(self._atom_id_to_key[label])
 
-    def __init_receivers(
-            self, database: DatabaseReader, vertex_sizes: Dict[str, int]):
+    def __init_receivers(self, database: DatabaseReader,
+                         vertex_sizes: Dict[str, int]) -> None:
         """
         :param DatabaseReader database:
         :param dict(str,int) vertex_sizes:
@@ -477,7 +483,8 @@ class LiveEventConnection(DatabaseConnection):
             self.__receiver_connection.close()
             self.__receiver_connection = None
 
-    def __launch_thread(self, kind: str, label: str, callback: _Callback):
+    def __launch_thread(
+            self, kind: str, label: str, callback: _Callback) -> None:
         thread = Thread(
             target=callback, args=(label, self),
             name=(f"{kind} callback thread for live_event_connection "
@@ -564,7 +571,7 @@ class LiveEventConnection(DatabaseConnection):
             raise ConfigurationException("no receive labels defined")
         return self.__receive_labels[label_id]
 
-    def __handle_time_packet(self, packet: EIEIODataMessage):
+    def __handle_time_packet(self, packet: EIEIODataMessage) -> None:
         key_times_labels: Dict[int, Dict[int, List[int]]] = defaultdict(
             lambda: defaultdict(list))
         atoms_times_labels: Dict[int, Dict[int, List[int]]] = defaultdict(
@@ -598,7 +605,7 @@ class LiveEventConnection(DatabaseConnection):
                     else:
                         c_back(label, time, key_times_labels[time][label_id])
 
-    def __handle_no_time_packet(self, packet: EIEIODataMessage):
+    def __handle_no_time_packet(self, packet: EIEIODataMessage) -> None:
         while packet.is_next_element:
             element = packet.next_element
             if not isinstance(element, (
@@ -628,13 +635,13 @@ class LiveEventConnection(DatabaseConnection):
             else:
                 self.__handle_unknown_key(key)
 
-    def __handle_unknown_key(self, key: int):
+    def __handle_unknown_key(self, key: int) -> None:
         if key not in self.__error_keys:
             self.__error_keys.add(key)
             logger.warning("Received unexpected key {}", key)
 
     def send_event(self, label: str, atom_id: int,
-                   send_full_keys: bool = False):
+                   send_full_keys: bool = False) -> None:
         """
         Send an event from a single atom.
 
@@ -649,7 +656,7 @@ class LiveEventConnection(DatabaseConnection):
         self.send_events(label, [atom_id], send_full_keys)
 
     def send_events(self, label: str, atom_ids: List[int],
-                    send_full_keys: bool = False):
+                    send_full_keys: bool = False) -> None:
         """
         Send a number of events.
 
@@ -688,7 +695,7 @@ class LiveEventConnection(DatabaseConnection):
                 sleep(0.1)
 
     def send_event_with_payload(
-            self, label: str, atom_id: int, payload: int):
+            self, label: str, atom_id: int, payload: int) -> None:
         """
         Send an event with a payload from a single atom.
 
@@ -701,7 +708,7 @@ class LiveEventConnection(DatabaseConnection):
 
     def send_events_with_payloads(
             self, label: str,
-            atom_ids_and_payloads: List[Tuple[int, int]]):
+            atom_ids_and_payloads: List[Tuple[int, int]]) -> None:
         """
         Send a number of events with payloads.
 
@@ -732,7 +739,7 @@ class LiveEventConnection(DatabaseConnection):
                 sleep(0.1)
 
     def send_eieio_message(
-            self, message: AbstractEIEIOMessage, label: str):
+            self, message: AbstractEIEIOMessage, label: str) -> None:
         """
         Send an EIEIO message (using one-way the live input) to the
         vertex with the given label.
@@ -748,7 +755,7 @@ class LiveEventConnection(DatabaseConnection):
         self._send(message, x, y, p, ip_address)
 
     def _send(self, message: AbstractEIEIOMessage, x: int, y: int, p: int,
-              ip_address: str):
+              ip_address: str) -> None:
         """
         Send an EIEIO message to a particular core.
 

--- a/spinn_front_end_common/utilities/connections/live_event_connection.py
+++ b/spinn_front_end_common/utilities/connections/live_event_connection.py
@@ -547,7 +547,7 @@ class LiveEventConnection(DatabaseConnection):
                 return True
             return False
 
-    def __do_receive_packet(self, data: bytes):
+    def __do_receive_packet(self, data: bytes) -> None:
         if self.__handle_scp_packet(data):
             return
 
@@ -555,7 +555,8 @@ class LiveEventConnection(DatabaseConnection):
         try:
             header = _ONE_SHORT.unpack_from(data)[0]
             if header & 0xC000 == 0x4000:
-                return read_eieio_command_message(data, 0)
+                read_eieio_command_message(data, 0)
+                return
             packet: EIEIODataMessage = read_eieio_data_message(data, 0)
             if packet.eieio_header.is_time:
                 self.__handle_time_packet(packet)

--- a/spinn_front_end_common/utilities/database/database_connection.py
+++ b/spinn_front_end_common/utilities/database/database_connection.py
@@ -85,7 +85,8 @@ class DatabaseConnection(UDPConnection):
         thread.daemon = True
         thread.start()
 
-    def add_database_callback(self, database_callback_function: _DBCB):
+    def add_database_callback(
+            self, database_callback_function: _DBCB) -> None:
         """
         Add a database callback to be called when the database is ready.
 
@@ -114,7 +115,7 @@ class DatabaseConnection(UDPConnection):
         finally:
             self.__running = False
 
-    def __process_run_cycle(self, timeout: float):
+    def __process_run_cycle(self, timeout: float) -> None:
         """
         Heart of :py:meth:`__run`.
         """
@@ -133,7 +134,8 @@ class DatabaseConnection(UDPConnection):
         if self.__pause_and_stop_callback is not None:
             self.__pause_stop()
 
-    def __read_db(self, toolchain_address: Tuple[str, int], data: bytes):
+    def __read_db(
+            self, toolchain_address: Tuple[str, int], data: bytes) -> None:
         # Read the read packet confirmation
         logger.info("{}:{} Reading database",
                     self.local_ip_address, self.local_port)
@@ -181,7 +183,7 @@ class DatabaseConnection(UDPConnection):
         self.__pause_and_stop_callback()
 
     def __send_command(
-            self, command: CMDS, toolchain_address: Tuple[str, int]):
+            self, command: CMDS, toolchain_address: Tuple[str, int]) -> None:
         self.send_to(EIEIOCommandHeader(command.value).bytestring,
                      toolchain_address)
 

--- a/spinn_front_end_common/utilities/database/database_reader.py
+++ b/spinn_front_end_common/utilities/database/database_reader.py
@@ -30,14 +30,6 @@ class DatabaseReader(SQLiteDB):
         self.__job: Optional[SpallocJob] = None
         self.__looked_for_job = False
 
-    def __exec_one(self, query, *args):
-        self.execute(query + " LIMIT 1", args)
-        return self.fetchone()
-
-    @staticmethod
-    def __r2t(row, *args):
-        return tuple(None if row is None else row[key] for key in args)
-
     def get_job(self) -> Optional[SpallocJob]:
         """
         Get the job described in the database. If no job exists, direct
@@ -117,15 +109,17 @@ class DatabaseReader(SQLiteDB):
             chip_x, chip_y)
         :rtype: tuple(str, int, bool, str, int, int, int)
         """
-        return self.__r2t(
-            self.__exec_one(
-                """
-                SELECT * FROM app_output_tag_view
-                WHERE pre_vertex_label = ?
-                    AND post_vertex_label LIKE ?
-                """, label, str(receiver_label) + "%"),
-            "ip_address", "port", "strip_sdp", "board_address", "tag",
-            "chip_x", "chip_y")
+        self.execute(
+            """
+            SELECT * FROM app_output_tag_view
+            WHERE pre_vertex_label = ?
+            AND post_vertex_label LIKE ?
+            LIMIT 1
+            """, (label, str(receiver_label) + "%"))
+        row = self.fetchone()
+        return (row["ip_address"], row["port"], row["strip_sdp"],
+                row["board_address"], row["tag"], row["chip_x"],
+                row["chip_y"])
 
     def get_configuration_parameter_value(
             self, parameter_name: str) -> Optional[float]:
@@ -136,16 +130,14 @@ class DatabaseReader(SQLiteDB):
         :return: The value of the parameter
         :rtype: float or None
         """
-        row = self.__exec_one(
+        self.execute(
             """
             SELECT value FROM configuration_parameters
             WHERE parameter_id = ?
-            """, parameter_name)
+            LIMIT 1
+            """, (parameter_name,))
+        row = self.fetchone()
         return None if row is None else float(row["value"])
-
-    @staticmethod
-    def __xyp(row) -> Tuple[int, int, int]:
-        return int(row["x"]), int(row["y"]), int(row["p"])
 
     def get_placements(self, label: str) -> List[Tuple[int, int, int]]:
         """
@@ -156,7 +148,8 @@ class DatabaseReader(SQLiteDB):
         :rtype: list(tuple(int, int, int))
         """
         return [
-            self.__xyp(row) for row in self.execute(
+            (int(row["x"]), int(row["y"]), int(row["p"]))
+            for row in self.execute(
                 """
                 SELECT x, y, p FROM application_vertex_placements
                 WHERE vertex_label = ?
@@ -171,11 +164,13 @@ class DatabaseReader(SQLiteDB):
         :return: The IP address of the Ethernet to use to contact the chip
         :rtype: str or None
         """
-        row = self.__exec_one(
+        self.execute(
             """
             SELECT eth_ip_address FROM chip_eth_info
             WHERE x = ? AND y = ? OR x = 0 AND y = 0
             ORDER BY x DESC
-            """, x, y)
+            LIMIT 1
+            """, (x, y))
+        row = self.fetchone()
         # Should only fail if no machine is present or a bad XY given!
         return None if row is None else row["eth_ip_address"]

--- a/spinn_front_end_common/utilities/database/database_reader.py
+++ b/spinn_front_end_common/utilities/database/database_reader.py
@@ -44,7 +44,8 @@ class DatabaseReader(SQLiteDB):
             job_url = None
             cookies = {}
             headers = {}
-            for row in self.execute("""
+            for row in self.cursor().execute(
+                    """
                     SELECT kind, name, value FROM proxy_configuration
                     """):
                 kind, name, value = row
@@ -75,7 +76,7 @@ class DatabaseReader(SQLiteDB):
         """
         return {
             row["event"]: row["atom"]
-            for row in self.execute(
+            for row in self.cursor().execute(
                 """
                 SELECT * FROM label_event_atom_view
                 WHERE label = ?
@@ -91,7 +92,7 @@ class DatabaseReader(SQLiteDB):
         """
         return {
             row["atom"]: row["event"]
-            for row in self.execute(
+            for row in self.cursor().execute(
                 """
                 SELECT * FROM label_event_atom_view
                 WHERE label = ?
@@ -109,7 +110,7 @@ class DatabaseReader(SQLiteDB):
             chip_x, chip_y)
         :rtype: tuple(str, int, bool, str, int, int, int)
         """
-        self.execute(
+        self.cursor().execute(
             """
             SELECT * FROM app_output_tag_view
             WHERE pre_vertex_label = ?
@@ -130,7 +131,7 @@ class DatabaseReader(SQLiteDB):
         :return: The value of the parameter
         :rtype: float or None
         """
-        self.execute(
+        self.cursor().execute(
             """
             SELECT value FROM configuration_parameters
             WHERE parameter_id = ?
@@ -149,7 +150,7 @@ class DatabaseReader(SQLiteDB):
         """
         return [
             (int(row["x"]), int(row["y"]), int(row["p"]))
-            for row in self.execute(
+            for row in self.cursor().execute(
                 """
                 SELECT x, y, p FROM application_vertex_placements
                 WHERE vertex_label = ?
@@ -164,7 +165,7 @@ class DatabaseReader(SQLiteDB):
         :return: The IP address of the Ethernet to use to contact the chip
         :rtype: str or None
         """
-        self.execute(
+        self.cursor().execute(
             """
             SELECT eth_ip_address FROM chip_eth_info
             WHERE x = ? AND y = ? OR x = 0 AND y = 0

--- a/spinn_front_end_common/utilities/database/database_writer.py
+++ b/spinn_front_end_common/utilities/database/database_writer.py
@@ -100,7 +100,7 @@ class DatabaseWriter(SQLiteDB):
         :rtype: int
         """
         try:
-            self.execute(sql, args)
+            self.cursor().execute(sql, args)
             return self.lastrowid
         except Exception:
             logger.exception("problem with insertion; argument types are {}",
@@ -118,7 +118,7 @@ class DatabaseWriter(SQLiteDB):
                 x_dimension, y_dimension)
             VALUES(?, ?)
             """, machine.width, machine.height)
-        self.executemany(
+        self.cursor().executemany(
             """
             INSERT INTO Machine_chip(
                 no_processors, chip_x, chip_y, machine_id,
@@ -163,7 +163,7 @@ class DatabaseWriter(SQLiteDB):
 
         :param int runtime: the amount of time the application is to run for
         """
-        self.executemany(
+        self.cursor().executemany(
             """
             INSERT INTO configuration_parameters (
                 parameter_id, value)
@@ -185,7 +185,7 @@ class DatabaseWriter(SQLiteDB):
         job = FecDataView.get_spalloc_job()
         if job is not None:
             config = job.get_session_credentials_for_db()
-            self.executemany(
+            self.cursor().executemany(
                 """
                 INSERT INTO proxy_configuration(kind, name, value)
                 VALUES(?, ?, ?)
@@ -200,7 +200,7 @@ class DatabaseWriter(SQLiteDB):
             if placement.vertex not in self.__vertex_to_id:
                 self.__add_machine_vertex(placement.vertex)
         # add records
-        self.executemany(
+        self.cursor().executemany(
             """
             INSERT INTO Placements(
                 vertex_id, chip_x, chip_y, chip_p, machine_id)
@@ -215,7 +215,7 @@ class DatabaseWriter(SQLiteDB):
         Adds the tags into the database.
         """
         tags = FecDataView.get_tags()
-        self.executemany(
+        self.cursor().executemany(
             """
             INSERT INTO IP_tags(
                 vertex_id, tag, board_address, ip_address, port,
@@ -259,7 +259,7 @@ class DatabaseWriter(SQLiteDB):
                         f"{key_vertices[key]}")
                 key_vertices[key] = m_vertex
             m_vertex_id = self.__vertex_to_id[m_vertex]
-            self.executemany(
+            self.cursor().executemany(
                 """
                 INSERT INTO event_to_atom_mapping(
                     vertex_id, event_id, atom_id)
@@ -275,7 +275,7 @@ class DatabaseWriter(SQLiteDB):
         for device in devices:
             for m_vertex, atom_keys in device.get_device_output_keys().items():
                 m_vertex_id = self.__vertex_to_id[m_vertex]
-                self.executemany(
+                self.cursor().executemany(
                     """
                     INSERT INTO event_to_atom_mapping(
                         vertex_id, event_id, atom_id)
@@ -326,7 +326,7 @@ class DatabaseWriter(SQLiteDB):
             for (m_vertex, part_id, lpg_m_vertex) in
             self._get_machine_lpg_mappings(part))
 
-        self.executemany(
+        self.cursor().executemany(
             """
             INSERT INTO m_vertex_to_lpg_vertex(
                 pre_vertex_id, partition_id, post_vertex_id)

--- a/spinn_front_end_common/utilities/database/database_writer.py
+++ b/spinn_front_end_common/utilities/database/database_writer.py
@@ -15,7 +15,8 @@
 from __future__ import annotations
 import logging
 import os
-from typing import Dict, Iterable, List, Optional, Tuple, cast, TYPE_CHECKING
+from typing import (
+    cast, Dict, Iterable, List, Optional, Tuple, TYPE_CHECKING, Union)
 from spinn_utilities.log import FormatAdapter
 from spinn_machine import Machine
 from pacman.model.graphs import AbstractVertex
@@ -37,10 +38,6 @@ if TYPE_CHECKING:
 logger = FormatAdapter(logging.getLogger(__name__))
 DB_NAME = "input_output_database.sqlite3"
 INIT_SQL = "db.sql"
-
-
-def _extract_int(x):
-    return None if x is None else int(x)
 
 
 class DatabaseWriter(SQLiteDB):
@@ -97,7 +94,7 @@ class DatabaseWriter(SQLiteDB):
         """
         return self._database_path
 
-    def __insert(self, sql: str, *args) -> int:
+    def __insert(self, sql: str, *args: Union[str, int, None]) -> int:
         """
         :param str sql:
         :rtype: int
@@ -160,7 +157,7 @@ class DatabaseWriter(SQLiteDB):
         self.__vertex_to_id[m_vertex] = m_vertex_id
         return m_vertex_id
 
-    def add_system_params(self, runtime: Optional[float]):
+    def add_system_params(self, runtime: Optional[float]) -> None:
         """
         Write system parameters into the database.
 
@@ -231,7 +228,7 @@ class DatabaseWriter(SQLiteDB):
 
     def create_atom_to_event_id_mapping(
             self, machine_vertices: Optional[
-                Iterable[Tuple[MachineVertex, str]]]):
+                Iterable[Tuple[MachineVertex, str]]]) -> None:
         """
         :param machine_vertices:
         :type machine_vertices:
@@ -271,7 +268,7 @@ class DatabaseWriter(SQLiteDB):
             )
 
     def create_device_atom_event_id_mapping(
-            self, devices: Iterable[LiveOutputDevice]):
+            self, devices: Iterable[LiveOutputDevice]) -> None:
         """
         Add output mappings for devices.
         """

--- a/spinn_front_end_common/utilities/db.sql
+++ b/spinn_front_end_common/utilities/db.sql
@@ -189,7 +189,7 @@ CREATE TABLE IF NOT EXISTS router_provenance(
     x INTEGER NOT NULL,
     y INTEGER NOT NULL,
     description STRING NOT NULL,
-    the_value FLOAT NOT NULL,
+    the_value INTEGER NOT NULL,
     expected INTEGER NOT NULL);
 
 -- Compute some basic statistics per router over the router provenance

--- a/spinn_front_end_common/utilities/emergency_recovery.py
+++ b/spinn_front_end_common/utilities/emergency_recovery.py
@@ -68,7 +68,7 @@ def _emergency_state_check() -> None:
 
 
 def _emergency_iobuf_extract(
-        executable_targets: Optional[ExecutableTargets] = None):
+        executable_targets: Optional[ExecutableTargets] = None) -> None:
     """
     :param executable_targets:
         The specific targets to extract, or `None` for all
@@ -81,7 +81,7 @@ def _emergency_iobuf_extract(
 
 
 def emergency_recover_state_from_failure(
-        vertex: AbstractHasAssociatedBinary, placement: Placement):
+        vertex: AbstractHasAssociatedBinary, placement: Placement) -> None:
     """
     Used to get at least *some* information out of a core when something
     goes badly wrong. Not a replacement for what abstract spinnaker base does.

--- a/spinn_front_end_common/utilities/iobuf_extractor.py
+++ b/spinn_front_end_common/utilities/iobuf_extractor.py
@@ -227,7 +227,7 @@ class IOBufExtractor(object):
 
     def __extract_iobufs_for_binary(
             self, core_subsets: CoreSubsets, binary: str,
-            error_entries: List[str], warn_entries: List[str]):
+            error_entries: List[str], warn_entries: List[str]) -> None:
         """
         :param ~.CoreSubsets core_subsets: Where the binary is deployed
         :param str binary: What binary was deployed there.
@@ -252,7 +252,7 @@ class IOBufExtractor(object):
 
     def __process_one_iobuf(
             self, iobuf: IOBuffer, file_path: str, replacer: Replacer,
-            error_entries: List[str], warn_entries: List[str]):
+            error_entries: List[str], warn_entries: List[str]) -> None:
         """
         :param ~.IOBuffer iobuf:
         :param str file_path:
@@ -300,8 +300,8 @@ class IOBufExtractor(object):
         return io_buffers
 
     @staticmethod
-    def __add_value_if_match(
-            regex: Pattern, line: str, entries: List[str], iobuf: IOBuffer):
+    def __add_value_if_match(regex: Pattern, line: str,
+                             entries: List[str], iobuf: IOBuffer) -> None:
         """
         :param ~typing.Pattern regex:
         :param str line:

--- a/spinn_front_end_common/utilities/report_functions/bit_field_compressor_report.py
+++ b/spinn_front_end_common/utilities/report_functions/bit_field_compressor_report.py
@@ -34,7 +34,7 @@ MERGED_NAME = "bit_fields_merged"
 NOT_APPLICABLE = "N/A"
 
 
-def generate_provenance_item(x: int, y: int, bit_fields_merged: int):
+def generate_provenance_item(x: int, y: int, bit_fields_merged: int) -> None:
     """
     Generates a provenance item in the format BitFieldCompressorReport expects.
 

--- a/spinn_front_end_common/utilities/report_functions/board_chip_report.py
+++ b/spinn_front_end_common/utilities/report_functions/board_chip_report.py
@@ -40,7 +40,8 @@ def board_chip_report() -> None:
         _write_report(writer, machine, progress_bar)
 
 
-def _write_report(writer: TextIO, machine: Machine, progress_bar: ProgressBar):
+def _write_report(
+        writer: TextIO, machine: Machine, progress_bar: ProgressBar) -> None:
     """
     :param ~io.FileIO writer:
     :param ~spinn_machine.Machine machine:

--- a/spinn_front_end_common/utilities/report_functions/energy_report.py
+++ b/spinn_front_end_common/utilities/report_functions/energy_report.py
@@ -33,7 +33,7 @@ class EnergyReport(object):
     # energy report file name
     _SUMMARY_FILENAME = "energy_report.rpt"
 
-    def write_energy_report(self, power_used: PowerUsed):
+    def write_energy_report(self, power_used: PowerUsed) -> None:
         """
         Writes the report.
 
@@ -50,7 +50,7 @@ class EnergyReport(object):
             self._write_summary_report(f, power_used)
 
     @classmethod
-    def _write_summary_report(cls, f: TextIO, power_used: PowerUsed):
+    def _write_summary_report(cls, f: TextIO, power_used: PowerUsed) -> None:
         """
         Write summary file.
 

--- a/spinn_front_end_common/utilities/report_functions/memory_map_on_host_chip_report.py
+++ b/spinn_front_end_common/utilities/report_functions/memory_map_on_host_chip_report.py
@@ -57,7 +57,8 @@ def memory_map_on_host_chip_report() -> None:
                     file_name)
 
 
-def _describe_mem_map(f: TextIO, txrx: Transceiver, x: int, y: int, p: int):
+def _describe_mem_map(
+        f: TextIO, txrx: Transceiver, x: int, y: int, p: int) -> None:
     """
     :param ~spinnman.transceiver.Transceiver txrx:
     """

--- a/spinn_front_end_common/utilities/report_functions/network_specification.py
+++ b/spinn_front_end_common/utilities/report_functions/network_specification.py
@@ -39,7 +39,7 @@ def network_specification() -> None:
                          " for writing.", filename)
 
 
-def _write_report(f: TextIO, vertex: ApplicationVertex):
+def _write_report(f: TextIO, vertex: ApplicationVertex) -> None:
     """
     :param ~io.FileIO f:
     :param ~pacman.model.graphs.application.ApplicationVertex vertex:

--- a/spinn_front_end_common/utilities/report_functions/reports.py
+++ b/spinn_front_end_common/utilities/report_functions/reports.py
@@ -211,7 +211,7 @@ def router_report_from_paths() -> None:
 
 
 def _write_one_router_partition_report(
-        f: TextIO, partition: ApplicationEdgePartition):
+        f: TextIO, partition: ApplicationEdgePartition) -> None:
     """
     :param ~io.FileIO f:
     :param AbstractSingleSourcePartition partition:
@@ -263,7 +263,7 @@ def partitioner_report() -> None:
             file_name)
 
 
-def _write_one_vertex_partition(f: TextIO, vertex: ApplicationVertex):
+def _write_one_vertex_partition(f: TextIO, vertex: ApplicationVertex) -> None:
     """
     :param ~io.FileIO f:
     :param ~pacman.model.graphs.application.ApplicationVertex vertex:
@@ -314,7 +314,7 @@ def placement_report_with_application_graph_by_vertex() -> None:
 
 
 def _write_one_vertex_application_placement(
-        f: TextIO, vertex: ApplicationVertex):
+        f: TextIO, vertex: ApplicationVertex) -> None:
     """
     :param ~io.FileIO f:
     :param ~pacman.model.graphs.application.ApplicationVertex vertex:
@@ -379,7 +379,7 @@ def placement_report_with_application_graph_by_core() -> None:
             file_name)
 
 
-def _write_one_chip_application_placement(f: TextIO, chip: Chip):
+def _write_one_chip_application_placement(f: TextIO, chip: Chip) -> None:
     """
     :param ~io.FileIO f:
     :param ~spinn_machine.Chip chip:
@@ -452,7 +452,7 @@ def sdram_usage_report_per_chip() -> None:
 
 def _sdram_usage_report_per_chip_with_timesteps(
         f: TextIO, timesteps: Optional[int], progress: ProgressBar,
-        end_progress: bool, details: bool):
+        end_progress: bool, details: bool) -> None:
     """
     :param ~io.FileIO f:
     :param int timesteps: Either the plan or data timesteps
@@ -502,8 +502,8 @@ def _sdram_usage_report_per_chip_with_timesteps(
             pass
 
 
-def routing_info_report(
-        extra_allocations: Iterable[Tuple[ApplicationVertex, str]] = ()):
+def routing_info_report(extra_allocations: Iterable[
+        Tuple[ApplicationVertex, str]] = ()) -> None:
     """
     Generates a report which says which keys is being allocated to each
     vertex.
@@ -532,7 +532,7 @@ def routing_info_report(
 
 def _write_vertex_virtual_keys(
         f: TextIO, pre_vertex: ApplicationVertex, part_id: str,
-        routing_infos: RoutingInfo):
+        routing_infos: RoutingInfo) -> None:
     """
     :param ~io.FileIO f:
     :param ~pacman.model.graphs.application.ApplicationVertex pre_vertex:
@@ -572,7 +572,7 @@ def router_report_from_router_tables() -> None:
 
 
 def router_report_from_compressed_router_tables(
-        routing_tables: MulticastRoutingTables):
+        routing_tables: MulticastRoutingTables) -> None:
     """
     Report the compressed routing tables.
 
@@ -590,8 +590,8 @@ def router_report_from_compressed_router_tables(
             generate_routing_table(routing_table, top_level_folder)
 
 
-def generate_routing_table(
-        routing_table: AbstractMulticastRoutingTable, top_level_folder: str):
+def generate_routing_table(routing_table: AbstractMulticastRoutingTable,
+                           top_level_folder: str) -> None:
     """
     :param routing_table: The routing table to describe
     :type routing_table:
@@ -641,7 +641,7 @@ def _compression_ratio(uncompressed: int, compressed: int) -> float:
 
 
 def generate_comparison_router_report(
-        compressed_routing_tables: MulticastRoutingTables):
+        compressed_routing_tables: MulticastRoutingTables) -> None:
     """
     Make a report on comparison of the compressed and uncompressed
     routing tables.

--- a/spinn_front_end_common/utilities/scp/clear_iobuf_process.py
+++ b/spinn_front_end_common/utilities/scp/clear_iobuf_process.py
@@ -51,11 +51,11 @@ class ClearIOBUFProcess(AbstractMultiConnectionProcess[CheckOKResponse]):
     __slots__ = ()
 
     def __receive_response(
-            self, progress: ProgressBar, _response: CheckOKResponse):
+            self, progress: ProgressBar, _response: CheckOKResponse) -> None:
         progress.update()
 
     def clear_iobuf(self, core_subsets: CoreSubsets,
-                    n_cores: Optional[int] = None):
+                    n_cores: Optional[int] = None) -> None:
         """
         :param ~spinn_machine.CoreSubsets core_subsets:
         :param int n_cores: Defaults to the number of cores in `core_subsets`.

--- a/spinn_front_end_common/utilities/scp/get_current_time_process.py
+++ b/spinn_front_end_common/utilities/scp/get_current_time_process.py
@@ -24,7 +24,8 @@ from spinnman.messages.sdp import SDPHeader, SDPFlag
 from spinnman.messages.scp.abstract_messages import (
     AbstractSCPRequest, AbstractSCPResponse)
 from spinnman.messages.scp import SCPRequestHeader
-from spinnman.processes import AbstractMultiConnectionProcess
+from spinnman.processes import (
+    AbstractMultiConnectionProcess, MostDirectConnectionSelector)
 from spinnman.model.enums import (
     SDP_PORTS, SDP_RUNNING_MESSAGE_CODES)
 from spinnman.messages.scp.enums import SCPResult
@@ -39,12 +40,12 @@ class _GetCurrentTimeResponse(AbstractSCPResponse):
         "__current_time",
     )
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
-        self.__current_time = None
+        self.__current_time: Optional[int] = None
 
     @overrides(AbstractSCPResponse.read_data_bytestring)
-    def read_data_bytestring(self, data: bytes, offset: int):
+    def read_data_bytestring(self, data: bytes, offset: int) -> None:
         result = self.scp_response_header.result
         # We can accept a no-reply response here; that could just mean
         # that the count wasn't complete (but might be enough anyway)
@@ -57,6 +58,7 @@ class _GetCurrentTimeResponse(AbstractSCPResponse):
     def current_time(self) -> int:
         """ Get the current time from the response
         """
+        assert self.__current_time is not None
         return self.__current_time
 
 
@@ -96,13 +98,13 @@ class GetCurrentTimeProcess(
         "__earliest_time"
     )
 
-    def __init__(self, connection_selector):
+    def __init__(self, connection_selector: MostDirectConnectionSelector):
         super().__init__(connection_selector)
-        self.__latest_time = None
-        self.__earliest_time = None
+        self.__latest_time: Optional[int] = None
+        self.__earliest_time: Optional[int] = None
 
-    def __receive_response(
-            self, progress: ProgressBar, response: _GetCurrentTimeResponse):
+    def __receive_response(self, progress: ProgressBar,
+                           response: _GetCurrentTimeResponse) -> None:
         progress.update()
         current_time = response.current_time
         if self.__latest_time is None or current_time > self.__latest_time:

--- a/spinn_front_end_common/utilities/scp/load_mc_routes_process.py
+++ b/spinn_front_end_common/utilities/scp/load_mc_routes_process.py
@@ -26,7 +26,7 @@ class LoadMCRoutesProcess(AbstractMultiConnectionProcess[CheckOKResponse]):
     """
     __slots__ = ()
 
-    def load_application_mc_routes(self, core_subsets: CoreSubsets):
+    def load_application_mc_routes(self, core_subsets: CoreSubsets) -> None:
         """
         Load the saved application multicast routes.
 
@@ -39,7 +39,7 @@ class LoadMCRoutesProcess(AbstractMultiConnectionProcess[CheckOKResponse]):
                     self._send_request(LoadApplicationMCRoutesMessage(
                         core_subset.x, core_subset.y, processor_id))
 
-    def load_system_mc_routes(self, core_subsets: CoreSubsets):
+    def load_system_mc_routes(self, core_subsets: CoreSubsets) -> None:
         """
         Load the saved system multicast routes.
 

--- a/spinn_front_end_common/utilities/scp/reinjector_control_process.py
+++ b/spinn_front_end_common/utilities/scp/reinjector_control_process.py
@@ -34,7 +34,7 @@ class ReinjectorControlProcess(AbstractMultiConnectionProcess):
     """
     __slots__ = ()
 
-    def clear_queue(self, core_subsets: CoreSubsets):
+    def clear_queue(self, core_subsets: CoreSubsets) -> None:
         """
         Clear the reinjection queue.
 
@@ -46,7 +46,7 @@ class ReinjectorControlProcess(AbstractMultiConnectionProcess):
                     self._send_request(ClearReinjectionQueueMessage(
                         core_subset.x, core_subset.y, processor_id))
 
-    def reset_counters(self, core_subsets: CoreSubsets):
+    def reset_counters(self, core_subsets: CoreSubsets) -> None:
         """
         Reset the packet counters.
 
@@ -61,7 +61,7 @@ class ReinjectorControlProcess(AbstractMultiConnectionProcess):
     @staticmethod
     def __handle_response(
             result: Dict[Chip, ReInjectionStatus],
-            response: GetReinjectionStatusMessageResponse):
+            response: GetReinjectionStatusMessageResponse) -> None:
         """
         :param dict result:
         :param GetReinjectionStatusMessageResponse response:
@@ -113,7 +113,8 @@ class ReinjectorControlProcess(AbstractMultiConnectionProcess):
 
     def set_packet_types(
             self, core_subsets: CoreSubsets, point_to_point: bool,
-            multicast: bool, nearest_neighbour: bool, fixed_route: bool):
+            multicast: bool, nearest_neighbour: bool,
+            fixed_route: bool) -> None:
         """
         Set what types of packets should be reinjected.
 
@@ -131,8 +132,8 @@ class ReinjectorControlProcess(AbstractMultiConnectionProcess):
                         core_subset.x, core_subset.y, processor_id, multicast,
                         point_to_point, fixed_route, nearest_neighbour))
 
-    def set_wait1_timeout(
-            self, mantissa: int, exponent: int, core_subsets: CoreSubsets):
+    def set_wait1_timeout(self, mantissa: int, exponent: int,
+                          core_subsets: CoreSubsets) -> None:
         """
         The wait1 timeout is the time from when a packet is received to
         when emergency routing becomes enabled.
@@ -147,8 +148,8 @@ class ReinjectorControlProcess(AbstractMultiConnectionProcess):
                 self.__set_timeout(
                     core_subset, processor_id, mantissa, exponent, wait=1)
 
-    def set_wait2_timeout(
-            self, mantissa: int, exponent: int, core_subsets: CoreSubsets):
+    def set_wait2_timeout(self, mantissa: int, exponent: int,
+                          core_subsets: CoreSubsets) -> None:
         """
         The wait2 timeout is the time from when a packet has emergency
         routing enabled for it to when it is dropped.
@@ -165,7 +166,7 @@ class ReinjectorControlProcess(AbstractMultiConnectionProcess):
 
     def __set_timeout(
             self, core: CoreSubset, processor_id: int,
-            mantissa: int, exponent: int, *, wait: int):
+            mantissa: int, exponent: int, *, wait: int) -> None:
         """
         Set a timeout for a router controlled by an extra monitor on a core.
         This is not a parallelised operation in order to aid debugging when

--- a/spinn_front_end_common/utilities/scp/send_pause_process.py
+++ b/spinn_front_end_common/utilities/scp/send_pause_process.py
@@ -59,10 +59,10 @@ class SendPauseProcess(AbstractMultiConnectionProcess[CheckOKResponse]):
     __slots__ = ()
 
     def __receive_response(
-            self, progress: ProgressBar, _response: CheckOKResponse):
+            self, progress: ProgressBar, _response: CheckOKResponse) -> None:
         progress.update()
 
-    def send_pause(self, core_subsets: CoreSubsets, n_cores: int):
+    def send_pause(self, core_subsets: CoreSubsets, n_cores: int) -> None:
         """
         :param ~spinn_machine.CoreSubsets core_subsets:
         :param int n_cores: Number of cores being updated

--- a/spinn_front_end_common/utilities/scp/update_runtime_process.py
+++ b/spinn_front_end_common/utilities/scp/update_runtime_process.py
@@ -69,12 +69,12 @@ class UpdateRuntimeProcess(AbstractMultiConnectionProcess[CheckOKResponse]):
     __slots__ = ()
 
     def __receive_response(
-            self, progress: ProgressBar, _response: CheckOKResponse):
+            self, progress: ProgressBar, _response: CheckOKResponse) -> None:
         progress.update()
 
-    def update_runtime(
-            self, current_time: int, run_time: int, infinite_run: bool,
-            core_subsets: CoreSubsets, n_cores: int, n_sync_steps: int):
+    def update_runtime(self, current_time: int, run_time: int,
+                       infinite_run: bool, core_subsets: CoreSubsets,
+                       n_cores: int, n_sync_steps: int) -> None:
         """
         :param int current_time:
         :param int run_time:

--- a/spinn_front_end_common/utilities/system_control_logic.py
+++ b/spinn_front_end_common/utilities/system_control_logic.py
@@ -33,7 +33,7 @@ def run_system_application(
         filename_template: str, binaries_to_track: Optional[List[str]] = None,
         progress_bar: Optional[ProgressBar] = None,
         logger: Optional[FormatAdapter] = None,
-        timeout: Optional[float] = None):
+        timeout: Optional[float] = None) -> None:
     """
     Executes the given _system_ application.
     Used for on-chip expander, compressors, etc.
@@ -124,7 +124,7 @@ def run_system_application(
 
 def _report_iobuf_messages(
         cores: ExecutableTargets, logger: Optional[FormatAdapter],
-        filename_template: str):
+        filename_template: str) -> None:
     """
     :param ~spinnman.model.ExecutableTargets cores:
     :param ~logging.Logger logger:
@@ -142,7 +142,8 @@ def _report_iobuf_messages(
             logger.error("{}", entry)
 
 
-def _load_application(executable_targets: ExecutableTargets, app_id: int):
+def _load_application(
+        executable_targets: ExecutableTargets, app_id: int) -> None:
     """
     Execute a set of binaries that make up a complete application on
     specified cores, wait for them to be ready and then start all of the

--- a/spinn_front_end_common/utilities/utility_calls.py
+++ b/spinn_front_end_common/utilities/utility_calls.py
@@ -38,7 +38,7 @@ _lock_condition = threading.Condition()
 T = TypeVar("T")
 
 
-def _mkdir(directory: str):
+def _mkdir(directory: str) -> None:
     """
     Make a directory if it doesn't exist.
 
@@ -141,7 +141,7 @@ def parse_old_spalloc(
 def retarget_tag(
         connection: Union[SpallocEIEIOListener, SpallocEIEIOConnection,
                           SCAMPConnection], x: int, y: int, tag: int,
-        ip_address: Optional[str] = None, strip: bool = True):
+        ip_address: Optional[str] = None, strip: bool = True) -> None:
     """
     Make a tag deliver to the given connection.
 

--- a/spinn_front_end_common/utilities/utility_objs/extra_monitor_scp_messages/get_reinjection_status_message.py
+++ b/spinn_front_end_common/utilities/utility_objs/extra_monitor_scp_messages/get_reinjection_status_message.py
@@ -70,8 +70,8 @@ class GetReinjectionStatusMessageResponse(AbstractSCPResponse):
         result = self.scp_response_header.result
         if result != SCPResult.RC_OK:
             raise SpinnmanUnexpectedResponseCodeException(
-                "Get packet reinjection status", self._command_code,
-                result.name)
+                "Get packet reinjection status",
+                str(self._command_code), result.name)
         self._reinjection_status = ReInjectionStatus(data, offset)
 
     @property

--- a/spinn_front_end_common/utilities/utility_objs/extra_monitor_scp_messages/get_reinjection_status_message.py
+++ b/spinn_front_end_common/utilities/utility_objs/extra_monitor_scp_messages/get_reinjection_status_message.py
@@ -32,7 +32,7 @@ class GetReinjectionStatusMessage(
     """
     __slots__ = ()
 
-    def __init__(self, x: int, y: int, p: int):
+    def __init__(self, x: int, y: int, p: int) -> None:
         """
         :param int x: The x-coordinate of a chip, between 0 and 255
         :param int y: The y-coordinate of a chip, between 0 and 255
@@ -66,7 +66,7 @@ class GetReinjectionStatusMessageResponse(AbstractSCPResponse):
         self._command_code = command_code
 
     @overrides(AbstractSCPResponse.read_data_bytestring)
-    def read_data_bytestring(self, data: bytes, offset: int):
+    def read_data_bytestring(self, data: bytes, offset: int) -> None:
         result = self.scp_response_header.result
         if result != SCPResult.RC_OK:
             raise SpinnmanUnexpectedResponseCodeException(

--- a/spinn_front_end_common/utilities/utility_objs/live_packet_gather_parameters.py
+++ b/spinn_front_end_common/utilities/utility_objs/live_packet_gather_parameters.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional
+from typing import Any, Optional
 from spinnman.messages.eieio import EIEIOType, EIEIOPrefix
 from pacman.model.resources.iptag_resource import IPtagResource
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
@@ -36,14 +36,20 @@ class LivePacketGatherParameters(object):
         "_received_key_mask", "_translate_keys", "_translated_key_right_shift")
 
     def __init__(
-            self, port: int, hostname: str, tag=None, strip_sdp=True,
-            use_prefix=False, key_prefix=None, prefix_type=None,
-            message_type=EIEIOType.KEY_32_BIT, right_shift=0,
-            payload_as_time_stamps=True, use_payload_prefix=True,
-            payload_prefix=None, payload_right_shift=0,
-            number_of_packets_sent_per_time_step=0, label=None,
-            received_key_mask=0xFFFFFFFF,
-            translate_keys=False, translated_key_right_shift=0) -> None:
+            self, port: int, hostname: str, tag: Optional[int] = None,
+            strip_sdp: bool = True, use_prefix: bool = False,
+            key_prefix: Optional[int] = None,
+            prefix_type: Optional[EIEIOPrefix] = None,
+            message_type: EIEIOType = EIEIOType.KEY_32_BIT,
+            right_shift: int = 0,
+            payload_as_time_stamps: bool = True,
+            use_payload_prefix: bool = True,
+            payload_prefix: Optional[int] = None, payload_right_shift: int = 0,
+            number_of_packets_sent_per_time_step: int = 0,
+            label: Optional[str] = None,
+            received_key_mask: int = 0xFFFFFFFF,
+            translate_keys: bool = False,
+            translated_key_right_shift: int = 0) -> None:
         """
         :raises ConfigurationException:
             If the parameters passed are known to be an invalid combination.
@@ -135,11 +141,9 @@ class LivePacketGatherParameters(object):
         return self._use_prefix
 
     @property
-    def key_prefix(self) -> int:
+    def key_prefix(self) -> Optional[int]:
         """
         The EIEIO key prefix to remove from messages.
-
-        :rtype: int
         """
         return self._key_prefix
 
@@ -189,11 +193,9 @@ class LivePacketGatherParameters(object):
         return self._use_payload_prefix
 
     @property
-    def payload_prefix(self) -> int:
+    def payload_prefix(self) -> Optional[int]:
         """
         The payload prefix to remove if applying compaction.
-
-        :rtype: int
         """
         return self._payload_prefix
 
@@ -216,11 +218,9 @@ class LivePacketGatherParameters(object):
         return self._n_packets_per_time_step
 
     @property
-    def label(self) -> str:
+    def label(self) -> Optional[str]:
         """
         A label.
-
-        :rtype: str
         """
         return self._label
 
@@ -263,7 +263,9 @@ class LivePacketGatherParameters(object):
             strip_sdp=self.strip_sdp, tag=self.tag,
             traffic_identifier=TRAFFIC_IDENTIFIER)
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, LivePacketGatherParameters):
+            return False
         return (self._port == other.port and
                 self._hostname == other.hostname and
                 self._tag == other.tag and
@@ -286,10 +288,10 @@ class LivePacketGatherParameters(object):
                 self._translated_key_right_shift ==
                 other.translated_key_right_shift)
 
-    def __ne__(self, other):
+    def __ne__(self, other: Any) -> bool:
         return not self.__eq__(other)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         data = (
             self._port, self._tag, self._strip_sdp, self._use_prefix,
             self._key_prefix, self._prefix_type, self._message_type,

--- a/spinn_front_end_common/utility_models/chip_power_monitor_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/chip_power_monitor_machine_vertex.py
@@ -122,8 +122,8 @@ class ChipPowerMonitorMachineVertex(
         return BINARY_FILE_NAME
 
     @overrides(AbstractGeneratesDataSpecification.generate_data_specification)
-    def generate_data_specification(
-            self, spec: DataSpecificationGenerator, placement: Placement):
+    def generate_data_specification(self, spec: DataSpecificationGenerator,
+                                    placement: Placement) -> None:
         spec.comment("\n*** Spec for ChipPowerMonitor Instance ***\n\n")
 
         # Construct the data images needed for the Neuron:
@@ -136,7 +136,8 @@ class ChipPowerMonitorMachineVertex(
 
         self.__write_recording_metadata(placement)
 
-    def _write_configuration_region(self, spec: DataSpecificationGenerator):
+    def _write_configuration_region(
+            self, spec: DataSpecificationGenerator) -> None:
         """
         Write the data needed by the C code to configure itself.
 
@@ -147,7 +148,7 @@ class ChipPowerMonitorMachineVertex(
         spec.write_value(self.__n_samples_per_recording)
         spec.write_value(self.__sampling_frequency)
 
-    def _write_setup_info(self, spec):
+    def _write_setup_info(self, spec: DataSpecificationGenerator) -> None:
         """
         Writes the system data as required.
 
@@ -165,7 +166,8 @@ class ChipPowerMonitorMachineVertex(
         spec.write_array(recording_utilities.get_recording_header_array(
             recorded_region_sizes))
 
-    def _reserve_memory_regions(self, spec):
+    def _reserve_memory_regions(
+            self, spec: DataSpecificationGenerator) -> None:
         """
         Reserve the DSG memory regions as required.
 

--- a/spinn_front_end_common/utility_models/command_sender.py
+++ b/spinn_front_end_common/utility_models/command_sender.py
@@ -45,7 +45,7 @@ class CommandSender(
             self, start_resume_commands: Iterable[MultiCastCommand],
             pause_stop_commands: Iterable[MultiCastCommand],
             timed_commands: Iterable[MultiCastCommand],
-            vertex_to_send_to: AbstractVertex):
+            vertex_to_send_to: AbstractVertex) -> None:
         """
         Add commands to be sent down a given edge.
 

--- a/spinn_front_end_common/utility_models/command_sender_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/command_sender_machine_vertex.py
@@ -116,7 +116,7 @@ class CommandSenderMachineVertex(
             self, start_resume_commands: Iterable[MultiCastCommand],
             pause_stop_commands: Iterable[MultiCastCommand],
             timed_commands: Iterable[MultiCastCommand],
-            vertex_to_send_to: AbstractVertex):
+            vertex_to_send_to: AbstractVertex) -> None:
         """
         Add commands to be sent down a given edge.
 
@@ -191,7 +191,8 @@ class CommandSenderMachineVertex(
     @overrides(
         AbstractGeneratesDataSpecification.generate_data_specification)
     def generate_data_specification(
-            self, spec: DataSpecificationGenerator, placement: Placement):
+            self, spec: DataSpecificationGenerator,
+            placement: Placement) -> None:
         routing_infos = FecDataView.get_routing_infos()
         av = self.app_vertex
         assert av is not None
@@ -242,7 +243,7 @@ class CommandSenderMachineVertex(
 
     def _write_basic_commands(
             self, commands: List[MultiCastCommand],
-            spec: DataSpecificationGenerator):
+            spec: DataSpecificationGenerator) -> None:
         """
         :param list(MultiCastCommand) commands:
         :param ~data_specification.DataSpecificationGenerator spec:
@@ -256,7 +257,7 @@ class CommandSenderMachineVertex(
 
     def _write_timed_commands(
             self, timed_commands: List[MultiCastCommand],
-            spec: DataSpecificationGenerator):
+            spec: DataSpecificationGenerator) -> None:
         """
         :param list(MultiCastCommand) timed_commands:
         :param ~data_specification.DataSpecificationGenerator spec:
@@ -271,7 +272,7 @@ class CommandSenderMachineVertex(
     @classmethod
     def __write_command(
             cls, command: MultiCastCommand,
-            spec: DataSpecificationGenerator):
+            spec: DataSpecificationGenerator) -> None:
         """
         :param MultiCastCommand command:
         :param ~data_specification.DataSpecificationGenerator spec:
@@ -287,7 +288,7 @@ class CommandSenderMachineVertex(
 
     def _reserve_memory_regions(
             self, spec: DataSpecificationGenerator, time_command_size: int,
-            start_command_size: int, end_command_size: int):
+            start_command_size: int, end_command_size: int) -> None:
         """
         Reserve SDRAM space for memory areas:
 
@@ -399,7 +400,7 @@ class CommandSenderMachineVertex(
                parse_extra_provenance_items)
     def parse_extra_provenance_items(
             self, label: str, x: int, y: int, p: int,
-            provenance_data: Sequence[int]):
+            provenance_data: Sequence[int]) -> None:
         # pylint: disable=unused-argument
         n_commands_sent, = provenance_data
         with ProvenanceWriter() as db:

--- a/spinn_front_end_common/utility_models/extra_monitor_support_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/extra_monitor_support_machine_vertex.py
@@ -16,7 +16,8 @@ from enum import Enum, IntEnum
 import logging
 import struct
 # pylint: disable=no-name-in-module
-from typing import Dict, Iterable, Optional, ContextManager
+from typing import Dict, Iterable, Optional, ContextManager, Type
+from types import TracebackType
 
 from typing_extensions import Literal
 
@@ -263,8 +264,8 @@ class ExtraMonitorSupportMachineVertex(
         return "extra_monitor_support.aplx"
 
     @overrides(AbstractGeneratesDataSpecification.generate_data_specification)
-    def generate_data_specification(
-            self, spec: DataSpecificationGenerator, placement: Placement):
+    def generate_data_specification(self, spec: DataSpecificationGenerator,
+                                    placement: Placement) -> None:
         # storing for future usage
         self.__placement = placement
         chip = placement.chip
@@ -279,7 +280,7 @@ class ExtraMonitorSupportMachineVertex(
         spec.end_specification()
 
     def _generate_data_speed_up_out_config(
-            self, spec: DataSpecificationGenerator):
+            self, spec: DataSpecificationGenerator) -> None:
         """
         :param ~.DataSpecificationGenerator spec: spec file
         """
@@ -295,7 +296,7 @@ class ExtraMonitorSupportMachineVertex(
         spec.write_value(Gatherer.END_FLAG_KEY)
 
     def _generate_reinjection_config(
-            self, spec: DataSpecificationGenerator, chip: Chip):
+            self, spec: DataSpecificationGenerator, chip: Chip) -> None:
         """
         :param ~.DataSpecificationGenerator spec: spec file
         :param ~.Chip chip:
@@ -322,7 +323,7 @@ class ExtraMonitorSupportMachineVertex(
             chip.nearest_ethernet_x, chip.nearest_ethernet_y])
 
     def _generate_data_speed_up_in_config(
-            self, spec: DataSpecificationGenerator, chip: Chip):
+            self, spec: DataSpecificationGenerator, chip: Chip) -> None:
         """
         :param ~.DataSpecificationGenerator spec: spec file
         :param ~.Chip chip: the chip where this monitor will run
@@ -365,7 +366,8 @@ class ExtraMonitorSupportMachineVertex(
         route |= Router.convert_routing_table_entry_to_spinnaker_route(entry)
         return route
 
-    def _generate_provenance_area(self, spec: DataSpecificationGenerator):
+    def _generate_provenance_area(
+            self, spec: DataSpecificationGenerator) -> None:
         """
         :param ~.DataSpecificationGenerator spec: spec file
         """
@@ -392,7 +394,7 @@ class ExtraMonitorSupportMachineVertex(
 
     @overrides(AbstractProvidesProvenanceDataFromMachine.
                get_provenance_data_from_machine)
-    def get_provenance_data_from_machine(self, placement: Placement):
+    def get_provenance_data_from_machine(self, placement: Placement) -> None:
         # No standard provenance region, so no standard provenance data
         # But we do have our own.
         x, y = placement.x, placement.y
@@ -415,7 +417,7 @@ class ExtraMonitorSupportMachineVertex(
         return _Recoverer(self, self.placement)
 
     def reset_reinjection_counters(self, extra_monitor_cores_to_set: Iterable[
-            ExtraMonitorSupportMachineVertex]):
+            ExtraMonitorSupportMachineVertex]) -> None:
         """
         Resets the counters for reinjection.
 
@@ -463,7 +465,7 @@ class ExtraMonitorSupportMachineVertex(
             self, point_to_point: Optional[bool] = None,
             multicast: Optional[bool] = None,
             nearest_neighbour: Optional[bool] = None,
-            fixed_route: Optional[bool] = None):
+            fixed_route: Optional[bool] = None) -> None:
         """
         :param point_to_point:
             If point to point should be set, or `None` if left as before
@@ -547,7 +549,9 @@ class _Recoverer:
     def __enter__(self) -> Placement:
         return self.__placement
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> Literal[False]:
+    def __exit__(self, exc_type: Optional[Type],
+                 exc_val: Optional[BaseException],
+                 exc_tb: Optional[TracebackType]) -> Literal[False]:
         if exc_val:
             emergency_recover_state_from_failure(self.__vtx, self.__placement)
         return False

--- a/spinn_front_end_common/utility_models/live_packet_gather.py
+++ b/spinn_front_end_common/utility_models/live_packet_gather.py
@@ -47,7 +47,7 @@ class _LPGSplitter(AbstractSplitterCommon["LivePacketGather"]):
         self.__targeted_lpgs: Set[Tuple[
             LivePacketGatherMachineVertex, MachineVertex, str]] = set()
 
-    def create_sys_vertices(self, system_placements: Placements):
+    def create_sys_vertices(self, system_placements: Placements) -> None:
         """
         Special way of making LPG machine vertices, where one is placed
         on each Ethernet-enabled chip.
@@ -66,7 +66,7 @@ class _LPGSplitter(AbstractSplitterCommon["LivePacketGather"]):
             self.__m_vertices_by_ethernet[eth.x, eth.y] = lpg_vtx
 
     @overrides(AbstractSplitterCommon.create_machine_vertices)
-    def create_machine_vertices(self, chip_counter: ChipCounter):
+    def create_machine_vertices(self, chip_counter: ChipCounter) -> None:
         # Skip here, and do later!  This is a special case...
         pass
 

--- a/spinn_front_end_common/utility_models/live_packet_gather_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/live_packet_gather_machine_vertex.py
@@ -85,7 +85,8 @@ class LivePacketGatherMachineVertex(
         self._lpg_params = lpg_params
         self._incoming_sources: List[Tuple[MachineVertex, str]] = list()
 
-    def add_incoming_source(self, m_vertex: MachineVertex, partition_id: str):
+    def add_incoming_source(
+            self, m_vertex: MachineVertex, partition_id: str) -> None:
         """
         Add a machine vertex source incoming into this gatherer.
 
@@ -130,7 +131,7 @@ class LivePacketGatherMachineVertex(
         ProvidesProvenanceDataFromMachineImpl.parse_extra_provenance_items)
     def parse_extra_provenance_items(
             self, label: str, x: int, y: int, p: int,
-            provenance_data: Sequence[int]):
+            provenance_data: Sequence[int]) -> None:
         (lost, lost_payload, events, messages) = provenance_data
 
         with ProvenanceWriter() as db:
@@ -168,8 +169,8 @@ class LivePacketGatherMachineVertex(
 
     @overrides(
         AbstractGeneratesDataSpecification.generate_data_specification)
-    def generate_data_specification(
-            self, spec: DataSpecificationGenerator, placement: Placement):
+    def generate_data_specification(self, spec: DataSpecificationGenerator,
+                                    placement: Placement) -> None:
         tags = FecDataView.get_tags().get_ip_tags_for_vertex(self)
         assert tags is not None
 
@@ -183,7 +184,8 @@ class LivePacketGatherMachineVertex(
         # End-of-Spec:
         spec.end_specification()
 
-    def _reserve_memory_regions(self, spec: DataSpecificationGenerator):
+    def _reserve_memory_regions(
+            self, spec: DataSpecificationGenerator) -> None:
         """
         Reserve SDRAM space for memory areas.
 
@@ -201,8 +203,8 @@ class LivePacketGatherMachineVertex(
             label='config')
         self.reserve_provenance_data_region(spec)
 
-    def _write_configuration_region(
-            self, spec: DataSpecificationGenerator, iptags: List[IPTag]):
+    def _write_configuration_region(self, spec: DataSpecificationGenerator,
+                                    iptags: List[IPTag]) -> None:
         """
         Write the configuration region to the spec.
 
@@ -258,7 +260,7 @@ class LivePacketGatherMachineVertex(
                 spec.write_value(r_info.mask)
                 spec.write_value(vertex.vertex_slice.lo_atom)
 
-    def _write_setup_info(self, spec):
+    def _write_setup_info(self, spec: DataSpecificationGenerator) -> None:
         """
         Write basic info to the system region.
 

--- a/spinn_front_end_common/utility_models/reverse_ip_tag_multi_cast_source.py
+++ b/spinn_front_end_common/utility_models/reverse_ip_tag_multi_cast_source.py
@@ -173,7 +173,7 @@ class ReverseIpTagMultiCastSource(ApplicationVertex, LegacyPartitionerAPI):
         return self.__send_buffer_times
 
     @send_buffer_times.setter
-    def send_buffer_times(self, send_buffer_times: _SendBufferTimes):
+    def send_buffer_times(self, send_buffer_times: _SendBufferTimes) -> None:
         self.__send_buffer_times = send_buffer_times
         for vertex in self.machine_vertices:
             send_buffer_times_to_set = self.__send_buffer_times
@@ -183,7 +183,7 @@ class ReverseIpTagMultiCastSource(ApplicationVertex, LegacyPartitionerAPI):
                     vertex_slice.get_raster_ids()]
             vertex.send_buffer_times = send_buffer_times_to_set
 
-    def enable_recording(self, new_state: bool = True):
+    def enable_recording(self, new_state: bool = True) -> None:
         """
         Turns on or of the recording for this vertex.
 

--- a/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
@@ -255,12 +255,12 @@ class ReverseIPTagMulticastSourceMachineVertex(
             counts = numpy.bincount(
                 numpy.concatenate(send_buffer_times).astype("int"))
             if len(counts):
-                return max(counts)
+                return int(numpy.max(counts))
             return 0
         if len(send_buffer_times):
             counts = numpy.bincount(send_buffer_times)
             if len(counts):
-                return n_keys * max(counts)
+                return n_keys * int(numpy.max(counts))
             return 0
         return 0
 

--- a/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/reverse_ip_tag_multicast_source_machine_vertex.py
@@ -317,7 +317,7 @@ class ReverseIPTagMulticastSourceMachineVertex(
         return ((header_size + EIEIOType.KEY_32_BIT.key_bytes) *
                 keys_per_timestep)
 
-    def _install_send_buffer(self, send_buffer_times: _SBT):
+    def _install_send_buffer(self, send_buffer_times: _SBT) -> None:
         """
         :param ~numpy.ndarray send_buffer_times:
         """
@@ -339,7 +339,7 @@ class ReverseIPTagMulticastSourceMachineVertex(
         self._send_buffer_times = None
         self._send_buffers = {}
 
-    def _install_virtual_key(self, n_keys: int):
+    def _install_virtual_key(self, n_keys: int) -> None:
         """
         :param int n_keys:
         """
@@ -443,7 +443,7 @@ class ReverseIPTagMulticastSourceMachineVertex(
         return self._send_buffer_times
 
     @send_buffer_times.setter
-    def send_buffer_times(self, send_buffer_times: _SendBufferTimes):
+    def send_buffer_times(self, send_buffer_times: _SendBufferTimes) -> None:
         """
         :type send_buffer_times:
             ~numpy.ndarray(~numpy.ndarray(numpy.int32)) or
@@ -477,7 +477,7 @@ class ReverseIPTagMulticastSourceMachineVertex(
                 # Work with a single list
                 self._fill_send_buffer_1d(key_to_send)
 
-    def _fill_send_buffer_2d(self, key_base: int):
+    def _fill_send_buffer_2d(self, key_base: int) -> None:
         """
         Add the keys with different times for each atom.
         Can be overridden to override keys.
@@ -497,7 +497,7 @@ class ReverseIPTagMulticastSourceMachineVertex(
                 if first_time_step <= tick < end_time_step:
                     self._send_buffer.add_key(tick, keys[atom])
 
-    def _fill_send_buffer_1d(self, key_base: int):
+    def _fill_send_buffer_1d(self, key_base: int) -> None:
         """
         Add the keys from the given vertex slice within the given time
         range into the given send buffer, with the same times for each
@@ -539,7 +539,7 @@ class ReverseIPTagMulticastSourceMachineVertex(
         mask = 0xFFFFFFFF - max_key
         return mask
 
-    def enable_recording(self, new_state: bool = True):
+    def enable_recording(self, new_state: bool = True) -> None:
         """
         Enable recording of the keys sent.
 
@@ -547,7 +547,7 @@ class ReverseIPTagMulticastSourceMachineVertex(
         """
         self._is_recording = new_state
 
-    def _reserve_regions(self, spec: DataSpecificationGenerator):
+    def _reserve_regions(self, spec: DataSpecificationGenerator) -> None:
         """
         :param ~.DataSpecificationGenerator spec:
         """
@@ -595,7 +595,7 @@ class ReverseIPTagMulticastSourceMachineVertex(
             self._prefix_type = EIEIOPrefix.UPPER_HALF_WORD
             self._prefix = self._virtual_key
 
-    def _write_configuration(self, spec: DataSpecificationGenerator):
+    def _write_configuration(self, spec: DataSpecificationGenerator) -> None:
         """
         :param ~.DataSpecificationGenerator spec:
         """
@@ -657,8 +657,8 @@ class ReverseIPTagMulticastSourceMachineVertex(
         ReverseIPTagMulticastSourceMachineVertex._n_data_specs += 1
 
     @overrides(AbstractGeneratesDataSpecification.generate_data_specification)
-    def generate_data_specification(
-            self, spec: DataSpecificationGenerator, placement: Placement):
+    def generate_data_specification(self, spec: DataSpecificationGenerator,
+                                    placement: Placement) -> None:
         self.update_virtual_key()
 
         # Reserve regions
@@ -753,7 +753,7 @@ class ReverseIPTagMulticastSourceMachineVertex(
         return self._send_buffers
 
     @send_buffers.setter
-    def send_buffers(self, value: Dict[int, BufferedSendingRegion]):
+    def send_buffers(self, value: Dict[int, BufferedSendingRegion]) -> None:
         self._send_buffers = value
 
     @overrides(SendsBuffersFromHostPreBufferedImpl.get_regions)
@@ -764,7 +764,7 @@ class ReverseIPTagMulticastSourceMachineVertex(
         return self._send_buffers.keys()
 
     @overrides(SendsBuffersFromHostPreBufferedImpl.rewind)
-    def rewind(self, region: int):
+    def rewind(self, region: int) -> None:
         # reset theses so fill send buffer will run when send_buffers called
         self._first_machine_time_step = None
         self._run_until_timesteps = None
@@ -790,7 +790,7 @@ class ReverseIPTagMulticastSourceMachineVertex(
         ProvidesProvenanceDataFromMachineImpl.parse_extra_provenance_items)
     def parse_extra_provenance_items(
             self, label: str, x: int, y: int, p: int,
-            provenance_data: Sequence[int]):
+            provenance_data: Sequence[int]) -> None:
         n_rcv, n_snt, bad_key, bad_pkt, late = provenance_data
 
         with ProvenanceWriter() as db:

--- a/spinn_front_end_common/utility_models/streaming_context_manager.py
+++ b/spinn_front_end_common/utility_models/streaming_context_manager.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 from __future__ import annotations
 # pylint: disable=no-name-in-module
-from typing import ContextManager, Iterable, TYPE_CHECKING
+from types import TracebackType
+from typing import ContextManager, Iterable, Optional, Type, TYPE_CHECKING
 from typing_extensions import Literal
 if TYPE_CHECKING:
     from .data_speed_up_packet_gatherer_machine_vertex import (
@@ -40,7 +41,9 @@ class StreamingContextManager(ContextManager[None]):
         for gatherer in self._gatherers:
             gatherer.set_cores_for_data_streaming()
 
-    def __exit__(self, _type, _value, _tb) -> Literal[False]:
+    def __exit__(self, exc_type: Optional[Type],
+                 exc_val: Optional[BaseException],
+                 exc_tb: Optional[TracebackType]) -> Literal[False]:
         for gatherer in self._gatherers:
             gatherer.unset_cores_for_data_streaming()
         for gatherer in self._gatherers:

--- a/unittests/interface/interface_functions/test_front_end_common_dsg_region_reloader.py
+++ b/unittests/interface/interface_functions/test_front_end_common_dsg_region_reloader.py
@@ -91,8 +91,8 @@ class _TestMachineVertex(
         return ExecutableType.USES_SIMULATION_INTERFACE
 
     @overrides(AbstractGeneratesDataSpecification.generate_data_specification)
-    def generate_data_specification(
-            self, spec: DataSpecificationGenerator, placement: Placement):
+    def generate_data_specification(self, spec: DataSpecificationGenerator,
+                                    placement: Placement) -> None:
         raise NotImplementedError()
 
 

--- a/unittests/interface/interface_functions/test_front_end_common_dsg_region_reloader.py
+++ b/unittests/interface/interface_functions/test_front_end_common_dsg_region_reloader.py
@@ -68,12 +68,12 @@ class _TestMachineVertex(
         return self._requires_regions_to_be_reloaded
 
     @overrides(AbstractRewritesDataSpecification.set_reload_required)
-    def set_reload_required(self, new_value: bool):
+    def set_reload_required(self, new_value: bool) -> None:
         self._requires_regions_to_be_reloaded = new_value
 
     @overrides(AbstractRewritesDataSpecification.regenerate_data_specification)
-    def regenerate_data_specification(
-            self, spec: DataSpecificationReloader, placement: Placement):
+    def regenerate_data_specification(self, spec: DataSpecificationReloader,
+                                      placement: Placement) -> None:
         global regenerate_call_count
         for region_id, size, data in reload_region_data[placement.p]:
             spec.reserve_memory_region(region_id, size)


### PR DESCRIPTION
Includes some small code changes:

 LiveEventConnection.__do_receive_packet now only returns None

FecDataWriter.set_live_packet_gatherer_parameters( removed as unused
    - view has an add method
    - 
graph_data_specification_writer no longer tires ApplicationVertices as they can not be AbstractGeneratesDataSpecification

AbstractGeneratesDataSpecification has abstract sdram_required
It had it indirectly via require_subclass stack

database_writer.py _extract_int method removed as unused

DataSpeedUpPacketGatherMachineVertex removed the pass in of a self variable to a private method called once

SQLiteDB methods execute and execute_many removed as kwargs methods
Replaced with 
cursor()
and then the calls are
self.cursor().execute(...


Includes https://github.com/SpiNNakerManchester/sPyNNaker/pull/1514
https://github.com/SpiNNakerManchester/SpiNNakerGraphFrontEnd/pull/289
https://github.com/SpiNNakerManchester/SpiNNGym/pull/97
https://github.com/SpiNNakerManchester/BitBrainDemo/pull/66
https://github.com/SpiNNakerManchester/TSPonSpiNNaker/pull/51
https://github.com/SpiNNakerManchester/MarkovChainMonteCarlo/pull/73
https://github.com/SpiNNakerManchester/SpiNNaker_PDP2/pull/90


