### PR TITLE
Move all report paths to cfg

### DIFF
--- a/spinn_front_end_common/interface/spinnaker.cfg
+++ b/spinn_front_end_common/interface/spinnaker.cfg
@@ -10,6 +10,7 @@
 [Reports]
 # Energy report adds placements so off by default even in debug mode
 write_energy_report = False
+path_energy_report = energy_report_{n_run}.rpt
 # write_router_reports: If True, each router file is written in
 #                 text format to reports/routers
 write_router_reports = Debug

--- a/spinn_front_end_common/interface/spinnaker.cfg
+++ b/spinn_front_end_common/interface/spinnaker.cfg
@@ -14,6 +14,7 @@ path_energy_report = energy_report_{n_run}.rpt
 # write_router_reports: If True, each router file is written in
 #                 text format to reports/routers
 write_router_reports = Debug
+path_router_reports = edge_routing_info.rpt
 write_router_summary_report = Debug
 write_partitioner_reports = Info
 write_application_graph_placer_report = Info

--- a/spinn_front_end_common/utilities/report_functions/energy_report.py
+++ b/spinn_front_end_common/utilities/report_functions/energy_report.py
@@ -15,6 +15,7 @@
 import logging
 import os
 from typing import TextIO
+from spinn_utilities.config_holder import get_config_str
 from spinn_utilities.log import FormatAdapter
 from spinn_front_end_common.data import FecDataView
 from spinn_front_end_common.utilities.utility_objs import PowerUsed
@@ -33,7 +34,10 @@ class EnergyReport(object):
     @classmethod
     def file_name(cls, n_run: int) -> str:
         """ Name of the Energy report file for this run """
-        return f"energy_report_{n_run}.rpt"
+        path = get_config_str("Reports", "path_energy_report")
+        assert "{n_run}" in path,\
+            "cfg value: path_energy_report needs to include {n_run}"
+        return path.replace("{n_run}", str(n_run))
 
     def write_energy_report(self, power_used: PowerUsed) -> None:
         """

--- a/spinn_front_end_common/utilities/report_functions/reports.py
+++ b/spinn_front_end_common/utilities/report_functions/reports.py
@@ -17,6 +17,7 @@ import os
 import time
 from typing import Iterable, Optional, TextIO, Tuple
 
+from spinn_utilities.config_holder import get_config_str
 from spinn_utilities.ordered_set import OrderedSet
 from spinn_utilities.progress_bar import ProgressBar
 from spinn_utilities.log import FormatAdapter
@@ -49,7 +50,6 @@ _PLACEMENT_VTX_GRAPH_FILENAME = "placement_by_vertex_using_graph.rpt"
 _PLACEMENT_VTX_SIMPLE_FILENAME = "placement_by_vertex_without_graph.rpt"
 _PLACEMENT_CORE_GRAPH_FILENAME = "placement_by_core_using_graph.rpt"
 _PLACEMENT_CORE_SIMPLE_FILENAME = "placement_by_core_without_graph.rpt"
-_ROUTING_FILENAME = "edge_routing_info.rpt"
 _ROUTING_SUMMARY_FILENAME = "routing_summary.rpt"
 _ROUTING_TABLE_DIR = "routing_tables_generated"
 _SDRAM_FILENAME = "chip_sdram_usage_by_core.rpt"
@@ -185,11 +185,15 @@ def _do_router_summary_report(
         return None
 
 
+def get_path_router_reports() -> str:
+    return get_config_str("Reports", "path_router_reports")
+
 def router_report_from_paths() -> None:
     """
     Generates a text file of routing paths.
     """
-    file_name = os.path.join(FecDataView.get_run_dir_path(), _ROUTING_FILENAME)
+    file_name = os.path.join(FecDataView.get_run_dir_path(),
+                             get_path_router_reports())
     time_date_string = time.strftime("%c")
     partitions = get_app_partitions()
     try:


### PR DESCRIPTION
This pr moves the paths for reports to cfg files.

This for a number of reasons.
1. https://github.com/SpiNNakerManchester/SpiNNakerJupyterExamples/issues/13
2. Put all report files paths in a single place. (or a few cfg files)
