### PR TITLE
timer data error is not critical

### DIFF
--- a/spinn_front_end_common/interface/provenance/fec_timer.py
+++ b/spinn_front_end_common/interface/provenance/fec_timer.py
@@ -346,7 +346,8 @@ class FecTimer(object):
         time_now = cls.__stop_category()
         try:
             with GlobalProvenance() as db:
-                cls._category_id = db.insert_category(category, cls._machine_on)
+                cls._category_id = db.insert_category(
+                    category, cls._machine_on)
         except DatabaseError as ex:
             logger.error(f"Timer data error {ex}")
         cls._category = category

--- a/spinn_front_end_common/interface/provenance/fec_timer.py
+++ b/spinn_front_end_common/interface/provenance/fec_timer.py
@@ -19,8 +19,10 @@ import time
 from datetime import timedelta
 from typing import List, Optional, Tuple, Type, Union, TYPE_CHECKING
 from types import TracebackType
-
 from typing_extensions import Literal, Self
+
+from sqlite3 import DatabaseError
+
 from spinn_utilities.config_holder import (get_config_bool)
 from spinn_utilities.log import FormatAdapter
 from spinn_front_end_common.data import FecDataView
@@ -98,10 +100,13 @@ class FecTimer(object):
     def _insert_timing(
             self, time_taken: timedelta, skip_reason: Optional[str]) -> None:
         if self._category_id is not None:
-            with GlobalProvenance() as db:
-                db.insert_timing(
-                    self._category_id, self._algorithm, self._work,
-                    time_taken, skip_reason)
+            try:
+                with GlobalProvenance() as db:
+                    db.insert_timing(
+                        self._category_id, self._algorithm, self._work,
+                        time_taken, skip_reason)
+            except DatabaseError as ex:
+                logger.error(f"Timer data error {ex}")
 
     def skip(self, reason: str) -> None:
         """
@@ -322,10 +327,13 @@ class FecTimer(object):
         """
         time_now = time.perf_counter_ns()
         if cls._category_id:
-            with GlobalProvenance() as db:
-                diff = cls.__convert_to_timedelta(
-                    time_now - cls._category_time)
-                db.insert_category_timing(cls._category_id, diff)
+            try:
+                with GlobalProvenance() as db:
+                    diff = cls.__convert_to_timedelta(
+                        time_now - cls._category_time)
+                    db.insert_category_timing(cls._category_id, diff)
+            except DatabaseError as ex:
+                logger.error(f"Timer data error {ex}")
         return time_now
 
     @classmethod
@@ -336,8 +344,11 @@ class FecTimer(object):
         :param TimerCategory category: Category to switch to
         """
         time_now = cls.__stop_category()
-        with GlobalProvenance() as db:
-            cls._category_id = db.insert_category(category, cls._machine_on)
+        try:
+            with GlobalProvenance() as db:
+                cls._category_id = db.insert_category(category, cls._machine_on)
+        except DatabaseError as ex:
+            logger.error(f"Timer data error {ex}")
         cls._category = category
         cls._category_time = time_now
 

--- a/spinn_front_end_common/interface/provenance/fec_timer.py
+++ b/spinn_front_end_common/interface/provenance/fec_timer.py
@@ -19,9 +19,9 @@ import time
 from datetime import timedelta
 from typing import List, Optional, Tuple, Type, Union, TYPE_CHECKING
 from types import TracebackType
-from typing_extensions import Literal, Self
-
 from sqlite3 import DatabaseError
+
+from typing_extensions import Literal, Self
 
 from spinn_utilities.config_holder import (get_config_bool)
 from spinn_utilities.log import FormatAdapter


### PR DESCRIPTION
The FecTimer is typically used in the with pattern.

On it exit which is also called on an error it tries to insert the timing.

If the error occurred while something else had the database open this will give a locked error.

This then hides the real error