### PR TITLE
Move all report paths to cfg

### DIFF
--- a/spinn_front_end_common/data/fec_data_view.py
+++ b/spinn_front_end_common/data/fec_data_view.py
@@ -103,7 +103,6 @@ class _FecDataModel(object):
         "_max_run_time_steps",
         "_monitor_map",
         "_reset_number",
-        "_run_number",
         "_run_step",
         "_simulation_time_step_ms",
         "_simulation_time_step_per_ms",
@@ -143,7 +142,6 @@ class _FecDataModel(object):
         self._java_caller: Optional[JavaCaller] = None
         self._none_labelled_edge_count = 0
         self._reset_number = 0
-        self._run_number: Optional[int] = None
         self._simulation_time_step_ms: Optional[float] = None
         self._simulation_time_step_per_ms: Optional[float] = None
         self._simulation_time_step_per_s: Optional[float] = None
@@ -538,23 +536,6 @@ class FecDataView(PacmanDataView, SpiNNManDataView):
             return str(cls.__fec_data._reset_number)
         else:
             return ""
-
-    #  run number
-
-    @classmethod
-    def get_run_number(cls) -> int:
-        """
-        Get the number of this or the next run.
-
-        Run numbers start at 1
-
-        :rtype: int
-        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
-            If the run_number is currently unavailable
-        """
-        if cls.__fec_data._run_number is None:
-            raise cls._exception("run_number")
-        return cls.__fec_data._run_number
 
     @classmethod
     def get_run_step(cls) -> Optional[int]:

--- a/spinn_front_end_common/data/fec_data_writer.py
+++ b/spinn_front_end_common/data/fec_data_writer.py
@@ -70,8 +70,6 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
         PacmanDataWriter._mock(self)
         self._spinnman_mock()
         self.__fec_data._clear()
-        # run numbers start at 1 and when not running this is the next one
-        self.__fec_data._run_number = 1
         self.set_up_timings(1000, 1)
 
     @overrides(PacmanDataWriter._setup)
@@ -79,17 +77,9 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
         PacmanDataWriter._setup(self)
         self._spinnman_setup()
         self.__fec_data._clear()
-        # run numbers start at 1 and when not running this is the next one
-        self.__fec_data._run_number = 1
         self.__create_reports_directory()
         self.__create_timestamp_directory()
         self.__create_run_dir_path()
-
-    @overrides(PacmanDataWriter.finish_run)
-    def finish_run(self) -> None:
-        PacmanDataWriter.finish_run(self)
-        assert self.__fec_data._run_number is not None
-        self.__fec_data._run_number += 1
 
     @overrides(PacmanDataWriter._hard_reset)
     def _hard_reset(self) -> None:
@@ -111,7 +101,7 @@ class FecDataWriter(PacmanDataWriter, SpiNNManDataWriter, FecDataView):
     def __create_run_dir_path(self) -> None:
         self.set_run_dir_path(self._child_folder(
             self.get_timestamp_dir_path(),
-            f"run_{self.__fec_data._run_number}"))
+            f"run_{self.get_run_number()}"))
 
     def __create_reports_directory(self) -> None:
         default_report_file_path = get_config_str(

--- a/spinn_front_end_common/interface/spinnaker.cfg
+++ b/spinn_front_end_common/interface/spinnaker.cfg
@@ -26,7 +26,7 @@ path_application_graph_placer_report_vertex = placement_by_vertex_using_graph.rp
 path_application_graph_placer_report_core = placement_by_core_using_graph.rpt
 
 write_router_info_report = Info
-path_router_info_report= virtual_key_space_information_report.rpt
+path_router_info_report = virtual_key_space_information_report.rpt
 
 write_uncompressed = Debug
 path_uncompressed = routing_tables_generated

--- a/spinn_front_end_common/interface/spinnaker.cfg
+++ b/spinn_front_end_common/interface/spinnaker.cfg
@@ -10,18 +10,39 @@
 [Reports]
 # Energy report adds placements so off by default even in debug mode
 write_energy_report = False
+path_energy_report = energy_report_(n_run).rpt
+
 # write_router_reports: If True, each router file is written in
 #                 text format to reports/routers
 write_router_reports = Debug
+path_router_reports = edge_routing_info.rpt
+
 write_router_summary_report = Debug
 write_partitioner_reports = Info
+path_partitioner_reports = partitioned_by_vertex.rpt
+
 write_application_graph_placer_report = Info
+path_application_graph_placer_report_vertex = placement_by_vertex_using_graph.rpt
+path_application_graph_placer_report_core = placement_by_core_using_graph.rpt
+
 write_router_info_report = Info
+path_router_info_report= virtual_key_space_information_report.rpt
+
 write_uncompressed = Debug
+path_uncompressed = routing_tables_generated
+
 write_compressed = Debug
+path_compressed = compressed_routing_tables_generated
+
 write_compression_comparison = Debug
+path_compression_comparison = comparison_of_compressed_uncompressed_routing_tables.rpt
+
 write_compression_summary = Debug
+path_compression_summary = routing_summary.rpt
+
 write_memory_map_report = Debug
+path_memory_map_report = memory_map_from_processor_to_address_space
+
 write_network_specification_report = Info
 read_router_provenance_data = Debug
 read_graph_provenance_data = Debug
@@ -29,11 +50,17 @@ read_placements_provenance_data = Debug
 read_profile_data = Debug
 read_provenance_data_on_end = Debug
 write_provenance = Info
+
 write_tag_allocation_reports = Debug
+path_tag_allocation_reports = tags.rpt
+
 write_algorithm_timings = Debug
 write_board_chip_report = Debug
 write_data_speed_up_reports = Debug
+
 write_sdram_usage_report_per_chip = Info
+path_sdram_usage_report_per_chip = chip_sdram_usage_by_core.rpt"
+
 write_json_machine = Debug
 write_json_placements = Debug
 write_json_routing_tables = Debug

--- a/spinn_front_end_common/utilities/report_functions/energy_report.py
+++ b/spinn_front_end_common/utilities/report_functions/energy_report.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 import logging
-import os
 from typing import TextIO
+
+from spinn_utilities.config_holder import get_report_path
 from spinn_utilities.log import FormatAdapter
-from spinn_front_end_common.data import FecDataView
+
 from spinn_front_end_common.utilities.utility_objs import PowerUsed
 
 logger = FormatAdapter(logging.getLogger(__name__))
@@ -42,11 +43,8 @@ class EnergyReport(object):
         :param ~spinn_machine.Machine machine: the machine
         :param PowerUsed power_used:
         """
-        report_dir = FecDataView.get_run_dir_path()
-
         # summary report path
-        summary_report = os.path.join(
-            report_dir, self.file_name(FecDataView.get_run_number()))
+        summary_report = get_report_path("path_energy_report")
 
         # create summary report
         with open(summary_report, "w", encoding="utf-8") as f:

--- a/spinn_front_end_common/utilities/report_functions/energy_report.py
+++ b/spinn_front_end_common/utilities/report_functions/energy_report.py
@@ -31,11 +31,6 @@ class EnergyReport(object):
 
     __slots__ = ()
 
-    @classmethod
-    def file_name(cls, n_run: int) -> str:
-        """ Name of the Energy report file for this run """
-        return f"energy_report_{n_run}.rpt"
-
     def write_energy_report(self, power_used: PowerUsed) -> None:
         """
         Writes the report.

--- a/spinn_front_end_common/utilities/report_functions/memory_map_on_host_report.py
+++ b/spinn_front_end_common/utilities/report_functions/memory_map_on_host_report.py
@@ -13,20 +13,20 @@
 # limitations under the License.
 
 import logging
-import os
-from spinn_utilities.log import FormatAdapter
-from spinn_front_end_common.data import FecDataView
-from spinn_front_end_common.interface.ds import DsSqlliteDatabase
-logger = FormatAdapter(logging.getLogger(__name__))
 
-_FOLDER_NAME = "memory_map_from_processor_to_address_space"
+from spinn_utilities.config_holder import get_report_path
+from spinn_utilities.log import FormatAdapter
+
+from spinn_front_end_common.interface.ds import DsSqlliteDatabase
+
+logger = FormatAdapter(logging.getLogger(__name__))
 
 
 def memory_map_on_host_report() -> None:
     """
     Report on memory usage.
     """
-    file_name = os.path.join(FecDataView.get_run_dir_path(), _FOLDER_NAME)
+    file_name = get_report_path("path_memory_map_report")
     try:
         with open(file_name, "w", encoding="utf-8") as f:
             f.write("On host data specification executor\n")

--- a/spinn_front_end_common/utilities/report_functions/reports.py
+++ b/spinn_front_end_common/utilities/report_functions/reports.py
@@ -17,6 +17,7 @@ import os
 import time
 from typing import Iterable, Optional, TextIO, Tuple
 
+from spinn_utilities.config_holder import get_report_path
 from spinn_utilities.ordered_set import OrderedSet
 from spinn_utilities.progress_bar import ProgressBar
 from spinn_utilities.log import FormatAdapter
@@ -41,21 +42,6 @@ logger = FormatAdapter(logging.getLogger(__name__))
 
 _LINK_LABELS = {0: 'E', 1: 'NE', 2: 'N', 3: 'W', 4: 'SW', 5: 'S'}
 
-_C_ROUTING_TABLE_DIR = "compressed_routing_tables_generated"
-_COMPARED_FILENAME = "comparison_of_compressed_uncompressed_routing_tables.rpt"
-_COMPRESSED_ROUTING_SUMMARY_FILENAME = "compressed_routing_summary.rpt"
-_PARTITIONING_FILENAME = "partitioned_by_vertex.rpt"
-_PLACEMENT_VTX_GRAPH_FILENAME = "placement_by_vertex_using_graph.rpt"
-_PLACEMENT_VTX_SIMPLE_FILENAME = "placement_by_vertex_without_graph.rpt"
-_PLACEMENT_CORE_GRAPH_FILENAME = "placement_by_core_using_graph.rpt"
-_PLACEMENT_CORE_SIMPLE_FILENAME = "placement_by_core_without_graph.rpt"
-_ROUTING_FILENAME = "edge_routing_info.rpt"
-_ROUTING_SUMMARY_FILENAME = "routing_summary.rpt"
-_ROUTING_TABLE_DIR = "routing_tables_generated"
-_SDRAM_FILENAME = "chip_sdram_usage_by_core.rpt"
-_TAGS_FILENAME = "tags.rpt"
-_VIRTKEY_FILENAME = "virtual_key_space_information_report.rpt"
-
 _LOWER_16_BITS = 0xFFFF
 
 
@@ -65,7 +51,7 @@ def tag_allocator_report() -> None:
     simulation.
     """
     tag_infos = FecDataView.get_tags()
-    file_name = os.path.join(FecDataView.get_run_dir_path(), _TAGS_FILENAME)
+    file_name = get_report_path("path_tag_allocation_reports")
     try:
         with open(file_name, "w", encoding="utf-8") as f:
             progress = ProgressBar(
@@ -96,8 +82,7 @@ def router_summary_report() -> Optional[RouterSummary]:
 
     :rtype: RouterSummary
     """
-    file_name = os.path.join(
-        FecDataView.get_run_dir_path(), _ROUTING_SUMMARY_FILENAME)
+    file_name = get_report_path("path_compression_summary")
     progress = ProgressBar(FecDataView.get_machine().n_chips,
                            "Generating Routing summary report")
     routing_tables = FecDataView.get_uncompressed()
@@ -113,8 +98,7 @@ def router_compressed_summary_report(
         The in-operation COMPRESSED routing tables.
     :rtype: RouterSummary
     """
-    file_name = os.path.join(
-        FecDataView.get_run_dir_path(), _COMPRESSED_ROUTING_SUMMARY_FILENAME)
+    file_name = get_report_path("path_compression_summary")
     progress = ProgressBar(FecDataView.get_machine().n_chips,
                            "Generating Routing summary report")
     return _do_router_summary_report(file_name, progress, routing_tables)
@@ -189,7 +173,7 @@ def router_report_from_paths() -> None:
     """
     Generates a text file of routing paths.
     """
-    file_name = os.path.join(FecDataView.get_run_dir_path(), _ROUTING_FILENAME)
+    file_name = get_report_path("path_router_reports")
     time_date_string = time.strftime("%c")
     partitions = get_app_partitions()
     try:
@@ -242,8 +226,7 @@ def partitioner_report() -> None:
     """
     # Cycle through all vertices, and for each cycle through its vertices.
     # For each vertex, describe its core mapping.
-    file_name = os.path.join(
-        FecDataView.get_run_dir_path(), _PARTITIONING_FILENAME)
+    file_name = get_report_path("path_partitioner_reports")
     time_date_string = time.strftime("%c")
     try:
         with open(file_name, "w", encoding="utf-8") as f:
@@ -292,8 +275,7 @@ def placement_report_with_application_graph_by_vertex() -> None:
     """
     # Cycle through all vertices, and for each cycle through its vertices.
     # For each vertex, describe its core mapping.
-    file_name = os.path.join(
-        FecDataView.get_run_dir_path(), _PLACEMENT_VTX_GRAPH_FILENAME)
+    file_name = get_report_path("path_application_graph_placer_report_vertex")
     time_date_string = time.strftime("%c")
     try:
         with open(file_name, "w", encoding="utf-8") as f:
@@ -357,8 +339,7 @@ def placement_report_with_application_graph_by_core() -> None:
     # File 2: Placement by core.
     # Cycle through all chips and by all cores within each chip.
     # For each core, display what is held on it.
-    file_name = os.path.join(
-        FecDataView.get_run_dir_path(), _PLACEMENT_CORE_GRAPH_FILENAME)
+    file_name = get_report_path("path_application_graph_placer_report_core")
     time_date_string = time.strftime("%c")
     try:
         machine = FecDataView.get_machine()
@@ -425,7 +406,7 @@ def sdram_usage_report_per_chip() -> None:
     """
     Reports the SDRAM used per chip.
     """
-    file_name = os.path.join(FecDataView.get_run_dir_path(), _SDRAM_FILENAME)
+    file_name = get_report_path("path_sdram_usage_report_per_chip")
     n_placements = FecDataView.get_n_placements()
     time_date_string = time.strftime("%c")
     progress = ProgressBar(
@@ -513,7 +494,7 @@ def routing_info_report(extra_allocations: Iterable[
     :type extra_allocations:
         iterable(tuple(~pacman.model.graphs.application.ApplicationVertex,str))
     """
-    file_name = os.path.join(FecDataView.get_run_dir_path(), _VIRTKEY_FILENAME)
+    file_name = get_report_path("path_router_info_report")
     routing_infos = FecDataView.get_routing_infos()
     try:
         with open(file_name, "w", encoding="utf-8") as f:
@@ -560,8 +541,7 @@ def router_report_from_router_tables() -> None:
     """
     Report the uncompressed routing tables.
     """
-    top_level_folder = os.path.join(
-        FecDataView.get_run_dir_path(), _ROUTING_TABLE_DIR)
+    top_level_folder = get_report_path("path_uncompressed")
     routing_tables = FecDataView.get_uncompressed().routing_tables
     if not os.path.exists(top_level_folder):
         os.mkdir(top_level_folder)
@@ -579,8 +559,7 @@ def router_report_from_compressed_router_tables(
     :param ~pacman.model.routing_tables.MulticastRoutingTables routing_tables:
         the compressed routing tables
     """
-    top_level_folder = os.path.join(
-        FecDataView.get_run_dir_path(), _C_ROUTING_TABLE_DIR)
+    top_level_folder = get_report_path("path_compressed")
     if not os.path.exists(top_level_folder):
         os.mkdir(top_level_folder)
     progress = ProgressBar(routing_tables.routing_tables,
@@ -651,8 +630,7 @@ def generate_comparison_router_report(
         ~pacman.model.routing_tables.MulticastRoutingTables
     """
     routing_tables = FecDataView.get_uncompressed().routing_tables
-    file_name = os.path.join(
-        FecDataView.get_run_dir_path(), _COMPARED_FILENAME)
+    file_name = get_report_path("path_compression_comparison")
     try:
         with open(file_name, "w", encoding="utf-8") as f:
             progress = ProgressBar(


### PR DESCRIPTION
replaces https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1274

This pr moves the paths for reports to cfg files.

This for a number of reasons.

1. https://github.com/SpiNNakerManchester/SpiNNakerJupyterExamples/issues/13
2. Put all report files paths in a single place. (or a few cfg files)
3. Support absolute paths if desired
4. Easier to support other path patterns like ebrains (future work)
5. Allow debug integration checks to auto find all file/directories that could be there 

run_number moved to in View to Utils level
depends on:
https://github.com/SpiNNakerManchester/SpiNNUtils/pull/297
requires:
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1555