### PR TITLE
Configs loaded

### DIFF
--- a/spinn_front_end_common/interface/provenance/log_store_db.py
+++ b/spinn_front_end_common/interface/provenance/log_store_db.py
@@ -43,6 +43,9 @@ class LogStoreDB(LogStore):
                     return
                 # all others are bad
                 raise
+        else:
+            # Only expected to happen when running parallel tests
+            print("store logs skipped as configs not loaded.")
 
     @overrides(LogStore.retreive_log_messages)
     def retreive_log_messages(


### PR DESCRIPTION
In rare cases when running tests in parallel the logs code gets confused.

The using catch Exception style stopped working for some reason

This does a clear approach by just checking if configs are loaed.

depends on:
