### PR TITLE
Reallocate on boot failure

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -49,7 +49,7 @@ from spinn_machine import CoreSubsets
 
 from spinnman import __version__ as spinnman_version
 from spinnman.exceptions import (
-    SpinnmanBootException, SpiNNManCoresNotInStateException)
+    SpiNNManCoresNotInStateException)
 from spinnman.model.cpu_infos import CPUInfos
 from spinnman.model.enums import CPUState, ExecutableType
 
@@ -759,7 +759,7 @@ class AbstractSpinnakerBase(ConfigHandler):
         except Exception as ex:  # pylint: disable=broad-except
             logger.exception("Error on machine_generation")
             logger.exception(ex)
-            path =  self._data_writer.get_error_file()
+            path = self._data_writer.get_error_file()
             with open(path, "a", encoding="utf-8") as f:
                 f.write("Error on machine_generation\n")
                 f.write(traceback.format_exc())

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -754,9 +754,6 @@ class AbstractSpinnakerBase(ConfigHandler):
             return
         allocator_data = self._execute_allocator(total_run_time)
         try:
-            # hack to be removed
-            if retry < 2:
-                pop = 1/0
             self._execute_machine_generator(allocator_data)
             return
         except Exception as ex:  # pylint: disable=broad-except

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -750,6 +750,7 @@ class AbstractSpinnakerBase(ConfigHandler):
 
         :param total_run_time: The total run time to request
         """
+
         if self._data_writer.has_machine():
             return
         allocator_data = self._execute_allocator(total_run_time)
@@ -763,17 +764,16 @@ class AbstractSpinnakerBase(ConfigHandler):
             with open(path, "a", encoding="utf-8") as f:
                 f.write("Error on machine_generation\n")
                 f.write(traceback.format_exc())
+            max_retry = get_config_int("Machine", "spalloc_retry")
+            if retry >= max_retry:
+                raise
         # retry but outside of except so errors do not stack
         if allocator_data is not None:
             logger.exception(f"{allocator_data=}")
             with open(path, "a", encoding="utf-8") as f:
                 f.write(f"{allocator_data=}\n")
-            max_retry = get_config_int("Machine", "spalloc_retry")
-            if retry < max_retry:
-                logger.info("retrying allocate and get machine")
-                self._do_allocate_machine(total_run_time, retry + 1)
-            else:
-                raise
+            logger.info("retrying allocate and get machine")
+            self._do_allocate_machine(total_run_time, retry + 1)
 
     def _execute_allocator(self, total_run_time: Optional[float]) -> Optional[
             Tuple[str, int, Optional[str], bool, bool, Optional[Dict[XY, str]],

--- a/spinn_front_end_common/interface/spinnaker.cfg
+++ b/spinn_front_end_common/interface/spinnaker.cfg
@@ -248,6 +248,8 @@ spalloc_use_proxy = True
 spalloc_avoid_boards = None
 @spalloc_avoid_boards = An (optional) comma seperated list of ip addresses to avoid.
    This is a mainly for temporarily disabling boards that need to be blacklisted/ repaired.
+spalloc_retry = 3
+@spalloc_retry = Maximumn number of spalloc jobs to try on board boor error
 
 simulation_time_step = 1000
 @simulation_time_step = The time step of the simulations in microseconds.

--- a/spinn_front_end_common/interface/spinnaker.cfg
+++ b/spinn_front_end_common/interface/spinnaker.cfg
@@ -249,7 +249,7 @@ spalloc_avoid_boards = None
 @spalloc_avoid_boards = An (optional) comma seperated list of ip addresses to avoid.
    This is a mainly for temporarily disabling boards that need to be blacklisted/ repaired.
 spalloc_retry = 3
-@spalloc_retry = Maximumn number of spalloc jobs to try on board boor error
+@spalloc_retry = Maximum number of times to retry getting spalloc jobs on board boor errors
 
 simulation_time_step = 1000
 @simulation_time_step = The time step of the simulations in microseconds.


### PR DESCRIPTION
merges execute_allocator and execute_machine_generator into a wrapper method.

if this detects an exception in spalloc boot it tries to create a new job a few times.

fixes https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/issues/1296

should be easier to do https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/issues/1297 when this is in