### PR TITLE
Only buld changes

### DIFF
--- a/c_common/front_end_common_lib/make/fec.mk
+++ b/c_common/front_end_common_lib/make/fec.mk
@@ -136,6 +136,8 @@ $(foreach d, $(SOURCE_DIRS), \
     $(eval $(call add_source_dir, $(d))))
 OBJECTS += $(_OBJS)
 
+.SECONDARY: $(OBJECTS)
+
 SPINN_COMMON_INSTALL_DIR := $(strip $(if $(SPINN_COMMON_INSTALL_DIR), $(SPINN_COMMON_INSTALL_DIR), $(abspath $(FEC_DIR)/../../../spinn_common)))
 
 # Bring in the common makefile


### PR DESCRIPTION
This, along with the matching branch of SpiNNUtils, means that when you change a single file, and call ```make```, it will only make the changes you have made, rather than everything.  This speeds up the development process.  Note that ```make clean``` will still clean everything, though I suppose you might want to add the ```modified_src``` folder to the clean process to be certain.

This part of the change keeps the object files around after the build.  This means that a binary that needs multiple object files can just build the object files that have a dependency on a changed file somewhere.