### PR TITLE
call python3

### DIFF
--- a/c_common/front_end_common_lib/Makefile
+++ b/c_common/front_end_common_lib/Makefile
@@ -60,7 +60,7 @@ APP_OUTPUT_DIR := $(FEC_DIR)../../spinn_front_end_common/common_model_binaries/
 # key for the database in this APP_OUTPUT_DIR
 DATABASE_KEY = C
 $(MODIFIED_DIR)%.c: $(RAW_DIR)
-	python -m spinn_utilities.make_tools.converter $(SRC_DIR) $(MODIFIED_DIR) $(APP_OUTPUT_DIR) $(DATABASE_KEY)
+	python3 -m spinn_utilities.make_tools.converter $(SRC_DIR) $(MODIFIED_DIR) $(APP_OUTPUT_DIR) $(DATABASE_KEY)
 
 $(FEC_BUILD)/%.o: $(MODIFIED_DIR)/%.c
 	$(CC) $(CFLAGS) -o $@ $<

--- a/c_common/front_end_common_lib/make/fec.mk
+++ b/c_common/front_end_common_lib/make/fec.mk
@@ -70,12 +70,12 @@ get_path = $(abspath $(word $2, $(subst :, ,$1)))/
 # directory pair
 define add_source_dir#(src_dir)
 $(call get_path,$(1),2): $(wildcard $(call get_path,$(1),1)/**/*)
-	python -m spinn_utilities.make_tools.converter $(call get_path,$(1),1) $(call get_path,$(1),2) $(APP_OUTPUT_DIR) $(DATABASE_KEY)
+	python3 -m spinn_utilities.make_tools.converter $(call get_path,$(1),1) $(call get_path,$(1),2) $(APP_OUTPUT_DIR) $(DATABASE_KEY)
 
 $(call get_path,$(1), 2)%.c: $(call get_path,$(1), 1)%.c
-	python -m spinn_utilities.make_tools.converter $(call get_path,$(1),1) $(call get_path,$(1),2) $(APP_OUTPUT_DIR) $(DATABASE_KEY)
+	python3 -m spinn_utilities.make_tools.converter $(call get_path,$(1),1) $(call get_path,$(1),2) $(APP_OUTPUT_DIR) $(DATABASE_KEY)
 $(call get_path,$(1), 2)%.h: $(call get_path,$(1), 1)%.h
-	python -m spinn_utilities.make_tools.converter $(call get_path,$(1),1) $(call get_path,$(1),2) $(APP_OUTPUT_DIR) $(DATABASE_KEY)
+	python3 -m spinn_utilities.make_tools.converter $(call get_path,$(1),1) $(call get_path,$(1),2) $(APP_OUTPUT_DIR) $(DATABASE_KEY)
 
 # Build the o files from the modified sources
 $$(BUILD_DIR)%.o: $(call get_path,$(1),2)%.c


### PR DESCRIPTION
In newly installed ubuntu the python call does not work.

Yes we could get python to point to python3 but this is cleaner