### PR TITLE
Profile using energy report

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -230,6 +230,8 @@ class AbstractSpinnakerBase(ConfigHandler):
 
         self._data_writer.set_up_timings(timestep, time_scale_factor)
 
+        self._reserve_system_vertices()
+
         external_binaries = get_config_str_or_none(
             "Mapping", "external_binaries")
         if external_binaries is not None:

--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -126,7 +126,7 @@ from spinn_front_end_common.utilities.report_functions import (
     memory_map_on_host_chip_report, network_specification,
     tags_from_machine_report,
     write_json_machine, write_json_placements,
-    write_json_routing_tables, drift_report)
+    write_json_routing_tables, drift_report, write_sample_profile_report)
 from spinn_front_end_common.utilities.iobuf_extractor import IOBufExtractor
 from spinn_front_end_common.utility_models import (
     DataSpeedUpPacketGatherMachineVertex)
@@ -832,7 +832,9 @@ class AbstractSpinnakerBase(ConfigHandler):
 
         """
         with FecTimer("Insert chip power monitors", TimerWork.OTHER) as timer:
-            if timer.skip_if_cfg_false("Reports", "write_energy_report"):
+            if timer.skip_if_cfgs_false(
+                    "Reports", "write_energy_report",
+                    "write_sample_profile_report"):
                 return
             insert_chip_power_monitors(system_placements)
 
@@ -1820,6 +1822,19 @@ class AbstractSpinnakerBase(ConfigHandler):
             # run energy report
             energy_reporter.write_energy_report(power_used)
 
+    def _report_sample_profile(self) -> None:
+        """
+        Runs, times and logs the sample profile report if requested.
+        """
+        with FecTimer("Sample profile report", TimerWork.REPORT) as timer:
+            if timer.skip_if_cfg_false(
+                    "Reports", "write_sample_profile_report"):
+                return
+            if timer.skip_if_virtual_board():
+                return
+
+            write_sample_profile_report()
+
     def _do_provenance_reports(self) -> None:
         """
          Runs, times and logs any reports based on provenance.
@@ -2218,6 +2233,7 @@ class AbstractSpinnakerBase(ConfigHandler):
         # If we have run forever, stop the binaries
 
         self._report_energy()
+        self._report_sample_profile()
         try:
             if (self._data_writer.is_ran_ever()
                     and self._data_writer.get_current_run_timesteps() is None

--- a/spinn_front_end_common/interface/config_handler.py
+++ b/spinn_front_end_common/interface/config_handler.py
@@ -169,7 +169,8 @@ class ConfigHandler(AbstractSpiNNManSimulation):
         """
         Reserves the sizes for the system vertices
         """
-        if get_config_bool("Reports", "write_energy_report"):
+        if (get_config_bool("Reports", "write_energy_report") or
+                get_config_bool("Reports", "write_chip_power_reports")):
             self._data_writer.add_sample_monitor_vertex(
                 sample_chip_power_monitor(), True)
         if (get_config_bool("Machine", "enable_advanced_monitor_support")

--- a/spinn_front_end_common/interface/config_handler.py
+++ b/spinn_front_end_common/interface/config_handler.py
@@ -67,7 +67,6 @@ class ConfigHandler(AbstractSpiNNManSimulation):
         # set up machine targeted data
         self._debug_configs()
         self._previous_handler()
-        self._reserve_system_vertices()
         self._ensure_provenance_for_energy_report()
 
     @property
@@ -170,7 +169,7 @@ class ConfigHandler(AbstractSpiNNManSimulation):
         Reserves the sizes for the system vertices
         """
         if (get_config_bool("Reports", "write_energy_report") or
-                get_config_bool("Reports", "write_chip_power_reports")):
+                get_config_bool("Reports", "write_sample_profile_report")):
             self._data_writer.add_sample_monitor_vertex(
                 sample_chip_power_monitor(), True)
         if (get_config_bool("Machine", "enable_advanced_monitor_support")

--- a/spinn_front_end_common/interface/config_setup.py
+++ b/spinn_front_end_common/interface/config_setup.py
@@ -75,6 +75,8 @@ def fec_cfg_paths_skipped() -> Set[str]:
     skipped.update(packman_cfg_paths_skipped())
     if not get_config_bool("Reports", "write_energy_report"):
         skipped.add(optionxform("path_energy_report"))
+    if not get_config_bool("Reports", "write_sample_profile_report"):
+        skipped.add(optionxform("path_sample_profile_report"))
 
     if get_config_bool("Machine", "virtual_board"):
         skipped.add(optionxform("path_data_speed_up_reports_routers"))

--- a/spinn_front_end_common/interface/spinnaker.cfg
+++ b/spinn_front_end_common/interface/spinnaker.cfg
@@ -13,11 +13,11 @@ write_energy_report = False
   This will generate a report that estimates the energy used using previous
   measurements of idle and active SpiNNaker boards of various sizes.  The core
   idle and active times will be sampled using values in the [EnergyMonitor]
-  section, which controls the frequency an pooling of sample values to avoid
+  section, which controls the frequency and pooling of sample values to avoid
   over-recording, but also overflowing the space for each sample.
   This includes adding energy monitor cores which will change placements.
   Therefore the default value is not [Info or Debug](Mode).
-  Note this is compatible with write_energy_report, however the highest sample
+  Note this is compatible with write_sample_profile_report, however the highest sample
   frequency and lowest sample count will be used in this case.
 path_energy_report = energy_report(reset_str).rpt
 
@@ -411,7 +411,7 @@ n_samples_per_recording_entry = 100
 @ = Setting for the [Sample Monitor](write_sample_profile_report)
 profile_sampling_frequency = 4
 @profile_sampling_frequency = How often [Sample Monitor](write_sample_profile_report) will sample, in microseconds.
-  By default this is 1 to sample as fast as possible (we can't hope to sample
+  By default this is 4 to sample as fast as possible (we can't hope to sample
   once per clock cycle as we would have no time to store anything)
 profile_n_samples_per_recording_entry = @timestep
 @profile_n_samples_per_recording_entry = The number of samples taken in each recording of the [Sample Monitor](write_sample_profile_report).

--- a/spinn_front_end_common/interface/spinnaker.cfg
+++ b/spinn_front_end_common/interface/spinnaker.cfg
@@ -10,9 +10,30 @@
 [Reports]
 write_energy_report = False
 @write_energy_report = Runs the energy reports.
+  This will generate a report that estimates the energy used using previous
+  measurements of idle and active SpiNNaker boards of various sizes.  The core
+  idle and active times will be sampled using values in the [EnergyMonitor]
+  section, which controls the frequency an pooling of sample values to avoid
+  over-recording, but also overflowing the space for each sample.
   This includes adding energy monitor cores which will change placements.
-  Therefor the default value is not [Info or Debug](Mode)
+  Therefore the default value is not [Info or Debug](Mode).
+  Note this is compatible with write_energy_report, however the highest sample
+  frequency and lowest sample count will be used in this case.
 path_energy_report = energy_report(reset_str).rpt
+
+write_sample_profile_report = False
+@write_sample_profile_report = Runs the profile report.
+  This will generate a report that profiles each core over the duration of
+  the simulation by sampling the awake or sleep time of each core.  The sample
+  frequency and pooling is controlled by values in the [SampleMonitor] section.
+  Additionally it is possible to limit the SDRAM used by the reporting
+  measurement, at the cost that later samples will then not be recorded and so
+  will not factor into the statistics.
+  This includes adding profile monitor cores which will change placements.
+  Therefore the default value is not [Info or Debug](Mode).
+  Note this is compatible with write_energy_report, however the highest sample
+  frequency and lowest sample count will be used in this case.
+@path_sample_profile_report = sample_profile(reset_str).rpt
 
 write_router_reports = Debug
 @write_router_reports = Reports the routes used for each partition.
@@ -384,7 +405,18 @@ create_routing_info_to_neuron_id_mapping = True
 sampling_frequency = 10
 @sampling_frequency = How often [Energy Monitor](write_energy_report) will sample, in microseconds
 n_samples_per_recording_entry = 100
-@n_samples_per_recording_entry = The number of smaples taken in each recording of the [Energy Monitor](write_energy_report).
+@n_samples_per_recording_entry = The number of samples taken in each recording of the [Energy Monitor](write_energy_report).
+
+[SampleMonitor]
+@ = Setting for the [Sample Monitor](write_sample_profile_report)
+sampling_frequency = 1
+@sampling_frequency = How often [Sample Monitor](write_sample_profile_report) will sample, in microseconds.
+  By default this is 1 to sample as fast as possible (we can't hope to sample
+  once per clock cycle as we would have no time to store anything)
+n_samples_per_recording_entry = @timestep
+@n_samples_per_recording_entry = The number of samples taken in each recording of the [Sample Monitor](write_sample_profile_report).
+  By default this is @timestep, meaning that there is one sum of times per timestep.
+
 
 [Java]
 @ = This section controls the seetting to active the use of Java

--- a/spinn_front_end_common/interface/spinnaker.cfg
+++ b/spinn_front_end_common/interface/spinnaker.cfg
@@ -409,12 +409,12 @@ n_samples_per_recording_entry = 100
 
 [SampleMonitor]
 @ = Setting for the [Sample Monitor](write_sample_profile_report)
-sampling_frequency = 4
-@sampling_frequency = How often [Sample Monitor](write_sample_profile_report) will sample, in microseconds.
+profile_sampling_frequency = 4
+@profile_sampling_frequency = How often [Sample Monitor](write_sample_profile_report) will sample, in microseconds.
   By default this is 1 to sample as fast as possible (we can't hope to sample
   once per clock cycle as we would have no time to store anything)
-n_samples_per_recording_entry = @timestep
-@n_samples_per_recording_entry = The number of samples taken in each recording of the [Sample Monitor](write_sample_profile_report).
+profile_n_samples_per_recording_entry = @timestep
+@profile_n_samples_per_recording_entry = The number of samples taken in each recording of the [Sample Monitor](write_sample_profile_report).
   By default this is @timestep, meaning that there is one sum of times per timestep.
 
 

--- a/spinn_front_end_common/interface/spinnaker.cfg
+++ b/spinn_front_end_common/interface/spinnaker.cfg
@@ -23,7 +23,7 @@ path_energy_report = energy_report(reset_str).rpt
 
 write_sample_profile_report = False
 @write_sample_profile_report = Runs the profile report.
-  This will generate a report that profiles each core over the duration of
+  This will generate a JSON report that profiles each core over the duration of
   the simulation by sampling the awake or sleep time of each core.  The sample
   frequency and pooling is controlled by values in the [SampleMonitor] section.
   Additionally it is possible to limit the SDRAM used by the reporting
@@ -33,7 +33,7 @@ write_sample_profile_report = False
   Therefore the default value is not [Info or Debug](Mode).
   Note this is compatible with write_energy_report, however the highest sample
   frequency and lowest sample count will be used in this case.
-@path_sample_profile_report = sample_profile(reset_str).rpt
+path_sample_profile_report = sample_profile(reset_str).json
 
 write_router_reports = Debug
 @write_router_reports = Reports the routes used for each partition.
@@ -409,7 +409,7 @@ n_samples_per_recording_entry = 100
 
 [SampleMonitor]
 @ = Setting for the [Sample Monitor](write_sample_profile_report)
-sampling_frequency = 1
+sampling_frequency = 4
 @sampling_frequency = How often [Sample Monitor](write_sample_profile_report) will sample, in microseconds.
   By default this is 1 to sample as fast as possible (we can't hope to sample
   once per clock cycle as we would have no time to store anything)

--- a/spinn_front_end_common/utilities/report_functions/__init__.py
+++ b/spinn_front_end_common/utilities/report_functions/__init__.py
@@ -25,6 +25,8 @@ from .write_json_machine import write_json_machine
 from .write_json_placements import write_json_placements
 from .write_json_routing_tables import write_json_routing_tables
 from .drift_report import drift_report
+from .sample_profile_report import write_sample_profile_report
+
 
 __all__ = (
     "board_chip_report",
@@ -38,4 +40,5 @@ __all__ = (
     "write_json_machine",
     "write_json_placements",
     "write_json_routing_tables",
-    "drift_report")
+    "drift_report",
+    "write_sample_profile_report")

--- a/spinn_front_end_common/utilities/report_functions/sample_profile_report.py
+++ b/spinn_front_end_common/utilities/report_functions/sample_profile_report.py
@@ -25,8 +25,8 @@ from spinn_front_end_common.data.fec_data_view import FecDataView
 from spinn_front_end_common.interface.buffer_management\
     .storage_objects import BufferDatabase
 from spinn_front_end_common.utility_models\
-    .chip_power_monitor_machine_vertex import RECORDING_CHANNEL,\
-    ChipPowerMonitorMachineVertex
+    .chip_power_monitor_machine_vertex import (
+        RECORDING_CHANNEL, ChipPowerMonitorMachineVertex)
 from spinn_front_end_common.abstract_models import AbstractHasAssociatedBinary
 from spinnman.model.enums.executable_type import ExecutableType
 import json
@@ -110,7 +110,7 @@ def get_power_cores() -> Dict[
                 active_cores[(pl.x, pl.y)].append(pl.p)
 
     return {xy: (power_cores[xy], active_cores[xy])
-             for xy in power_cores if xy in active_cores}
+            for xy in power_cores if xy in active_cores}
 
 
 def extract_core_activity(

--- a/spinn_front_end_common/utilities/report_functions/sample_profile_report.py
+++ b/spinn_front_end_common/utilities/report_functions/sample_profile_report.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2026 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import defaultdict
+from typing import Dict, Tuple, cast, Any
+import numpy
+
+from spinn_utilities.config_holder import get_report_path
+
+from spinn_machine.version.abstract_version import AbstractVersion
+
+from spinn_front_end_common.data.fec_data_view import FecDataView
+
+from spinn_front_end_common.interface.buffer_management\
+    .storage_objects import BufferDatabase
+from spinn_front_end_common.utility_models\
+    .chip_power_monitor_machine_vertex import RECORDING_CHANNEL,\
+    ChipPowerMonitorMachineVertex
+from spinn_front_end_common.abstract_models import AbstractHasAssociatedBinary
+from spinnman.model.enums.executable_type import ExecutableType
+import json
+
+
+def write_sample_profile_report() -> None:
+
+    report_path = get_report_path("path_sample_profile_report")
+    version = FecDataView.get_machine_version()
+
+    power_cores = get_power_cores()
+    chip_activity = extract_core_activity(power_cores, version)
+    timestep_us = FecDataView.get_simulation_time_step_us()
+
+    json_report_data: Dict[str, Any] = {}
+    json_report_data["timestep_us"] = timestep_us
+    for (x, y), activity in chip_activity.items():
+        p, active_cores = power_cores[(x, y)]
+        vertex = cast(
+            ChipPowerMonitorMachineVertex,
+            FecDataView.get_placement_on_processor(x, y, p).vertex)
+        min_active = numpy.min(activity, axis=0)
+        max_active = numpy.max(activity, axis=0)
+        mean_active = numpy.mean(activity, axis=0)
+        sample_us = vertex.sampling_frequency
+        n_samples = vertex.n_samples_per_recording
+        min_percent = (min_active / n_samples) * 100
+        max_percent = (max_active / n_samples) * 100
+        mean_percent = (mean_active / n_samples) * 100
+
+        json_report_chip: Dict[str, Any] = {}
+        json_report_data[f"chip_{x}_{y}"] = json_report_chip
+        json_report_chip["x"] = x
+        json_report_chip["y"] = y
+        json_report_chip["sample_frequency_us"] = sample_us
+        json_report_chip["n_samples_per_recording"] = n_samples
+        for v_id in active_cores:
+            placement = FecDataView.get_placement_on_processor(
+                x, y, v_id)
+            if placement is None:
+                continue
+            core_vertex = placement.vertex
+            p_id = FecDataView.get_physical_core_id((x, y), v_id)
+            json_report_chip[f"core_{v_id}"] = {
+                "vertex": type(core_vertex),
+                "vertex_label": core_vertex.label,
+                "min_count_active": min_active[p_id],
+                "max_count_active": max_active[p_id],
+                "mean_count_active": mean_active[p_id],
+                "min_percent_active": float(min_percent[p_id]),
+                "max_percent_active": float(max_percent[p_id]),
+                "mean_percent_active": float(mean_percent[p_id])
+            }
+
+    with open(report_path, "w") as report_file:
+        json.dump(json_report_data, report_file)
+
+
+def get_power_cores() -> Dict[
+        Tuple[int, int], Tuple[int, list[int]]]:
+    """
+    Get the power monitor cores, and the list of active cores
+
+    :return: a dictionary mapping (x, y) coordinates to a tuple of:
+          - the core ID of the power monitor core on that chip
+          - the list of cores that were active on that chip
+           (excluding the power monitor core)
+    """
+    power_cores: Dict[Tuple[int, int], int] = {}
+    active_cores: Dict[Tuple[int, int], list[int]] = defaultdict(list)
+    for pl in FecDataView.iterate_placemements():
+        if not isinstance(pl.vertex, AbstractHasAssociatedBinary):
+            continue
+        vertex: AbstractHasAssociatedBinary = cast(
+            AbstractHasAssociatedBinary, pl.vertex)
+        if vertex.get_binary_start_type() != ExecutableType.SYSTEM:
+            if isinstance(vertex, ChipPowerMonitorMachineVertex):
+                power_cores[(pl.x, pl.y)] = pl.p
+            else:
+                active_cores[(pl.x, pl.y)].append(pl.p)
+
+    return {xy: (power_cores[xy], active_cores[xy])
+             for xy in power_cores if xy in active_cores}
+
+
+def extract_core_activity(
+        power_cores: Dict[Tuple[int, int], Tuple[int, list[int]]],
+        version: AbstractVersion) -> Dict[Tuple[int, int], numpy.ndarray]:
+
+    chip_activity: Dict[Tuple[int, int], numpy.ndarray] = {}
+    with BufferDatabase() as buff_db:
+        for (x, y) in power_cores:
+            # Find the core that was used on this chip for power monitoring
+            p, _active_cores = power_cores[(x, y)]
+            # Get time per sample in seconds (frequency in microseconds)
+            data, _missing = buff_db.get_recording(x, y, p, RECORDING_CHANNEL)
+            results = numpy.frombuffer(data, dtype=numpy.uint32).reshape(
+                -1, version.max_cores_per_chip + 1)
+            # The remaining columns are the counts of active / inactive at
+            # each sample point
+            activity = results[:, 1:].astype(numpy.float64)
+            chip_activity[(x, y)] = activity
+    return chip_activity

--- a/spinn_front_end_common/utilities/report_functions/sample_profile_report.py
+++ b/spinn_front_end_common/utilities/report_functions/sample_profile_report.py
@@ -15,24 +15,26 @@
 from collections import defaultdict
 from typing import Dict, Tuple, cast, Any
 import numpy
+import json
 
 from spinn_utilities.config_holder import get_report_path
-
 from spinn_machine.version.abstract_version import AbstractVersion
-
+from spinnman.model.enums.executable_type import ExecutableType
 from spinn_front_end_common.data.fec_data_view import FecDataView
-
+from spinn_front_end_common.abstract_models import AbstractHasAssociatedBinary
 from spinn_front_end_common.interface.buffer_management\
     .storage_objects import BufferDatabase
 from spinn_front_end_common.utility_models\
     .chip_power_monitor_machine_vertex import (
         RECORDING_CHANNEL, ChipPowerMonitorMachineVertex)
-from spinn_front_end_common.abstract_models import AbstractHasAssociatedBinary
-from spinnman.model.enums.executable_type import ExecutableType
-import json
 
 
 def write_sample_profile_report() -> None:
+    """ Write a report of the profile data collected using the chip power
+        monitor to measure active time.  The report is then, per core,
+        the minimum, maximum and mean number of times the core was active when
+        sampled.
+    """
 
     report_path = get_report_path("path_sample_profile_report")
     version = FecDataView.get_machine_version()
@@ -82,7 +84,7 @@ def write_sample_profile_report() -> None:
                 "mean_percent_active": float(mean_percent[p_id])
             }
 
-    with open(report_path, "w") as report_file:
+    with open(report_path, "w", encoding="utf8") as report_file:
         json.dump(json_report_data, report_file, indent=4)
 
 
@@ -116,7 +118,21 @@ def get_power_cores() -> Dict[
 def extract_core_activity(
         power_cores: Dict[Tuple[int, int], Tuple[int, list[int]]],
         version: AbstractVersion) -> Dict[Tuple[int, int], numpy.ndarray]:
+    """ Extract the core activity data from the buffer database for each chip
+        that has a power monitor core.
 
+    :param power_cores: a dictionary mapping (x, y) coordinates to a tuple of:
+            - the core ID of the power monitor core on that chip
+            - the list of cores that were active on that chip
+             (excluding the power monitor core)
+    :param version: the machine version
+    :return: a dictionary mapping (x, y) coordinates to a numpy array of shape
+                (n_samples, n_cores) where n_samples is the number of samples
+                recorded by the power monitor core, and n_cores is the number of
+                cores on the chip.
+                Each entry in the array is the count of times that core was
+                active when sampled.
+    """
     chip_activity: Dict[Tuple[int, int], numpy.ndarray] = {}
     with BufferDatabase() as buff_db:
         for (x, y) in power_cores:

--- a/spinn_front_end_common/utilities/report_functions/sample_profile_report.py
+++ b/spinn_front_end_common/utilities/report_functions/sample_profile_report.py
@@ -71,7 +71,8 @@ def write_sample_profile_report() -> None:
             core_vertex = placement.vertex
             p_id = FecDataView.get_physical_core_id((x, y), v_id)
             json_report_chip[f"core_{v_id}"] = {
-                "vertex": type(core_vertex),
+                "vertex": core_vertex.app_vertex.__class__.__name__,
+                "vertex_slice": str(core_vertex.vertex_slice),
                 "vertex_label": core_vertex.label,
                 "min_count_active": min_active[p_id],
                 "max_count_active": max_active[p_id],
@@ -82,7 +83,7 @@ def write_sample_profile_report() -> None:
             }
 
     with open(report_path, "w") as report_file:
-        json.dump(json_report_data, report_file)
+        json.dump(json_report_data, report_file, indent=4)
 
 
 def get_power_cores() -> Dict[
@@ -121,11 +122,12 @@ def extract_core_activity(
         for (x, y) in power_cores:
             # Find the core that was used on this chip for power monitoring
             p, _active_cores = power_cores[(x, y)]
-            # Get time per sample in seconds (frequency in microseconds)
+            # Get data from the power monitor core on this chip
             data, _missing = buff_db.get_recording(x, y, p, RECORDING_CHANNEL)
             results = numpy.frombuffer(data, dtype=numpy.uint32).reshape(
                 -1, version.max_cores_per_chip + 1)
-            # The remaining columns are the counts of active / inactive at
+            # The first column is the time stamp of the recording,
+            # the remaining columns are the counts of active / inactive at
             # each sample point
             activity = results[:, 1:].astype(numpy.float64)
             chip_activity[(x, y)] = activity

--- a/spinn_front_end_common/utilities/report_functions/sample_profile_report.py
+++ b/spinn_front_end_common/utilities/report_functions/sample_profile_report.py
@@ -41,10 +41,12 @@ def write_sample_profile_report() -> None:
 
     power_cores = get_power_cores()
     chip_activity = extract_core_activity(power_cores, version)
-    timestep_us = FecDataView.get_simulation_time_step_us()
+    simulation_timestep_us = FecDataView.get_simulation_time_step_us()
+    hardware_timestep_us = FecDataView.get_hardware_time_step_us()
 
     json_report_data: Dict[str, Any] = {}
-    json_report_data["timestep_us"] = timestep_us
+    json_report_data["simulation_timestep_us"] = simulation_timestep_us
+    json_report_data["hardware_timestep_us"] = hardware_timestep_us
     for (x, y), activity in chip_activity.items():
         p, active_cores = power_cores[(x, y)]
         vertex = cast(

--- a/spinn_front_end_common/utilities/report_functions/sample_profile_report.py
+++ b/spinn_front_end_common/utilities/report_functions/sample_profile_report.py
@@ -128,8 +128,8 @@ def extract_core_activity(
     :param version: the machine version
     :return: a dictionary mapping (x, y) coordinates to a numpy array of shape
                 (n_samples, n_cores) where n_samples is the number of samples
-                recorded by the power monitor core, and n_cores is the number of
-                cores on the chip.
+                recorded by the power monitor core, and n_cores is the number
+                of cores on the chip.
                 Each entry in the array is the count of times that core was
                 active when sampled.
     """

--- a/spinn_front_end_common/utilities/report_functions/sample_profile_report.py
+++ b/spinn_front_end_common/utilities/report_functions/sample_profile_report.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 from collections import defaultdict
+import json
 from typing import Dict, Tuple, cast, Any
 import numpy
-import json
 
 from spinn_utilities.config_holder import get_report_path
 from spinn_machine.version.abstract_version import AbstractVersion

--- a/spinn_front_end_common/utility_models/chip_power_monitor_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/chip_power_monitor_machine_vertex.py
@@ -65,9 +65,9 @@ def _get_config_int_or_timestep(
     """
     value = get_config_str(config_section, config_key)
     if value == "@timestep":
-        return int(FecDataView.get_hardware_time_step_us() / sample_frequency)
-    else:
-        return int(value)
+        return max(1, int(math.ceil(
+            FecDataView.get_hardware_time_step_us() / sample_frequency)))
+    return int(value)
 
 
 class ChipPowerMonitorMachineVertex(
@@ -121,10 +121,10 @@ class ChipPowerMonitorMachineVertex(
             # The number of samples per recording entry is the lower value,
             # so as to ensure detail is not missed when required
             self.__n_samples_per_recording = min(
-                get_config_int("EnergyMonitor",
-                               "n_samples_per_recording_entry"),
-                get_config_int("SampleMonitor",
-                               "profile_n_samples_per_recording_entry"))
+                get_config_int("EnergyMonitor", "n_samples_per_recording_entry"),
+                _get_config_int_or_timestep(
+                    "SampleMonitor", "profile_n_samples_per_recording_entry",
+                    self.__sampling_frequency))
 
     @property
     def sampling_frequency(self) -> int:

--- a/spinn_front_end_common/utility_models/chip_power_monitor_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/chip_power_monitor_machine_vertex.py
@@ -52,18 +52,17 @@ DEFAULT_MALLOCS_USED = 3
 CONFIG_SIZE_IN_BYTES = 2 * BYTES_PER_WORD
 
 
-def _get_config_int_or_timestep(
-        config_section: str, config_key: str, sample_frequency: int) -> int:
-    """ Get a configuration integer value, unless the value is @timestep,
-        at which point the number of samples per hardware timestep is returned
-        instead.
+def _get_samples_per_recording_entry(sample_frequency: int) -> int:
+    """ Get the number of samples per recording entry
 
-    :param config_section: the section of the configuration file to read from
-    :param config_key: the key of the configuration value to read
+        If the value is @timestep, the number of samples per hardware timestep
+        is returned.
+
     :param sample_frequency: the sampling frequency to use in the calculation
     :return: the configuration value, or the number of samples per timestep
     """
-    value = get_config_str(config_section, config_key)
+    value = get_config_str(
+        "SampleMonitor", "profile_n_samples_per_recording_entry")
     if value == "@timestep":
         return max(1, int(math.ceil(
             FecDataView.get_hardware_time_step_us() / sample_frequency)))
@@ -109,8 +108,7 @@ class ChipPowerMonitorMachineVertex(
         elif sample_report and not energy_report:
             self.__sampling_frequency = get_config_int(
                 "SampleMonitor", "profile_sampling_frequency")
-            self.__n_samples_per_recording = _get_config_int_or_timestep(
-                "SampleMonitor", "profile_n_samples_per_recording_entry",
+            self.__n_samples_per_recording = _get_samples_per_recording_entry(
                 self.__sampling_frequency)
         else:
             # Sampling "frequency" is in microseconds, so the lower value is
@@ -123,9 +121,7 @@ class ChipPowerMonitorMachineVertex(
             self.__n_samples_per_recording = min(
                 get_config_int(
                     "EnergyMonitor", "n_samples_per_recording_entry"),
-                _get_config_int_or_timestep(
-                    "SampleMonitor", "profile_n_samples_per_recording_entry",
-                    self.__sampling_frequency))
+                _get_samples_per_recording_entry(self.__sampling_frequency))
 
     @property
     def sampling_frequency(self) -> int:

--- a/spinn_front_end_common/utility_models/chip_power_monitor_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/chip_power_monitor_machine_vertex.py
@@ -129,16 +129,12 @@ class ChipPowerMonitorMachineVertex(
     @property
     def sampling_frequency(self) -> int:
         """ The frequency at which samples are taken, in microseconds.
-
-        :return: the sampling frequency
         """
         return self.__sampling_frequency
 
     @property
     def n_samples_per_recording(self) -> int:
         """ The number of samples per recording entry.
-
-        :return: the number of samples per recording entry
         """
         return self.__n_samples_per_recording
 

--- a/spinn_front_end_common/utility_models/chip_power_monitor_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/chip_power_monitor_machine_vertex.py
@@ -121,7 +121,8 @@ class ChipPowerMonitorMachineVertex(
             # The number of samples per recording entry is the lower value,
             # so as to ensure detail is not missed when required
             self.__n_samples_per_recording = min(
-                get_config_int("EnergyMonitor", "n_samples_per_recording_entry"),
+                get_config_int(
+                    "EnergyMonitor", "n_samples_per_recording_entry"),
                 _get_config_int_or_timestep(
                     "SampleMonitor", "profile_n_samples_per_recording_entry",
                     self.__sampling_frequency))

--- a/spinn_front_end_common/utility_models/chip_power_monitor_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/chip_power_monitor_machine_vertex.py
@@ -108,23 +108,23 @@ class ChipPowerMonitorMachineVertex(
                 "EnergyMonitor", "n_samples_per_recording_entry")
         elif sample_report and not energy_report:
             self.__sampling_frequency = get_config_int(
-                "SampleMonitor", "sampling_frequency")
+                "SampleMonitor", "profile_sampling_frequency")
             self.__n_samples_per_recording = _get_config_int_or_timestep(
-                "SampleMonitor", "n_samples_per_recording_entry",
+                "SampleMonitor", "profile_n_samples_per_recording_entry",
                 self.__sampling_frequency)
         else:
             # Sampling "frequency" is in microseconds, so the lower value is
             # the higher frequency
             self.__sampling_frequency = min(
                 get_config_int("EnergyMonitor", "sampling_frequency"),
-                get_config_int("SampleMonitor", "sampling_frequency"))
+                get_config_int("SampleMonitor", "profile_sampling_frequency"))
             # The number of samples per recording entry is the lower value,
             # so as to ensure detail is not missed when required
             self.__n_samples_per_recording = min(
                 get_config_int("EnergyMonitor",
                                "n_samples_per_recording_entry"),
                 get_config_int("SampleMonitor",
-                               "n_samples_per_recording_entry"))
+                               "profile_n_samples_per_recording_entry"))
 
     @property
     def sampling_frequency(self) -> int:

--- a/spinn_front_end_common/utility_models/chip_power_monitor_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/chip_power_monitor_machine_vertex.py
@@ -17,7 +17,8 @@ import logging
 from enum import IntEnum
 from typing import List
 
-from spinn_utilities.config_holder import get_config_int
+from spinn_utilities.config_holder import get_config_int, get_config_bool,\
+    get_config_str
 from spinn_utilities.log import FormatAdapter
 from spinn_utilities.overrides import overrides
 
@@ -51,6 +52,24 @@ DEFAULT_MALLOCS_USED = 3
 CONFIG_SIZE_IN_BYTES = 2 * BYTES_PER_WORD
 
 
+def _get_config_int_or_timestep(
+        config_section: str, config_key: str, sample_frequency: int) -> int:
+    """ Get a configuration integer value, unless the value is @timestep,
+        at which point the number of samples per hardware timestep is returned
+        instead.
+
+    :param config_section: the section of the configuration file to read from
+    :param config_key: the key of the configuration value to read
+    :param sample_frequency: the sampling frequency to use in the calculation
+    :return: the configuration value, or the number of samples per timestep
+    """
+    value = get_config_str(config_section, config_key)
+    if value == "@timestep":
+        return int(FecDataView.get_hardware_time_step_us() / sample_frequency)
+    else:
+        return int(value)
+
+
 class ChipPowerMonitorMachineVertex(
         MachineVertex, AbstractHasAssociatedBinary,
         AbstractGeneratesDataSpecification, AbstractReceiveBuffersToHost):
@@ -79,10 +98,50 @@ class ChipPowerMonitorMachineVertex(
         """
         super().__init__(
             label=label, app_vertex=None, vertex_slice=None)
-        self.__sampling_frequency = get_config_int(
-            "EnergyMonitor", "sampling_frequency")
-        self.__n_samples_per_recording = get_config_int(
-            "EnergyMonitor", "n_samples_per_recording_entry")
+        energy_report = get_config_bool("Reports", "write_energy_report")
+        sample_report = get_config_bool(
+            "Reports", "write_sample_profile_report")
+        if energy_report and not sample_report:
+            self.__sampling_frequency = get_config_int(
+                "EnergyMonitor", "sampling_frequency")
+            self.__n_samples_per_recording = get_config_int(
+                "EnergyMonitor", "n_samples_per_recording_entry")
+        elif sample_report and not energy_report:
+            self.__sampling_frequency = get_config_int(
+                "SampleMonitor", "sampling_frequency")
+            self.__n_samples_per_recording = _get_config_int_or_timestep(
+                "SampleMonitor", "n_samples_per_recording_entry",
+                self.__sampling_frequency)
+        else:
+            # Sampling "frequency" is in microseconds, so the lower value is
+            # the higher frequency
+            self.__sampling_frequency = min(
+                get_config_int("EnergyMonitor", "sampling_frequency"),
+                get_config_int("SampleMonitor", "sampling_frequency"))
+            # The number of samples per recording entry is the lower value,
+            # so as to ensure detail is not missed when required
+            self.__n_samples_per_recording = min(
+                get_config_int("EnergyMonitor",
+                               "n_samples_per_recording_entry"),
+                get_config_int("SampleMonitor",
+                               "n_samples_per_recording_entry"))
+
+
+    @property
+    def sampling_frequency(self) -> int:
+        """ The frequency at which samples are taken, in microseconds.
+
+        :return: the sampling frequency
+        """
+        return self.__sampling_frequency
+
+    @property
+    def n_samples_per_recording(self) -> int:
+        """ The number of samples per recording entry.
+
+        :return: the number of samples per recording entry
+        """
+        return self.__n_samples_per_recording
 
     @property
     @overrides(MachineVertex.sdram_required)

--- a/spinn_front_end_common/utility_models/chip_power_monitor_machine_vertex.py
+++ b/spinn_front_end_common/utility_models/chip_power_monitor_machine_vertex.py
@@ -17,8 +17,8 @@ import logging
 from enum import IntEnum
 from typing import List
 
-from spinn_utilities.config_holder import get_config_int, get_config_bool,\
-    get_config_str
+from spinn_utilities.config_holder import (
+    get_config_int, get_config_bool, get_config_str)
 from spinn_utilities.log import FormatAdapter
 from spinn_utilities.overrides import overrides
 
@@ -125,7 +125,6 @@ class ChipPowerMonitorMachineVertex(
                                "n_samples_per_recording_entry"),
                 get_config_int("SampleMonitor",
                                "n_samples_per_recording_entry"))
-
 
     @property
     def sampling_frequency(self) -> int:


### PR DESCRIPTION
Add a report that can "profile" code using the energy reporting mechanism of sampling core activity.  This samples at as high a rate as possible without running out of time.  The report generated then indicates for each core what percentage of time it is active.  This can be useful for determining code efficiency without having to fully instrument the code with full profiling.