### PR TITLE
fix skipping on memory map reports

### DIFF
--- a/spinn_front_end_common/interface/abstract_spinnaker_base.py
+++ b/spinn_front_end_common/interface/abstract_spinnaker_base.py
@@ -1611,7 +1611,7 @@ class AbstractSpinnakerBase(ConfigHandler):
         """
         Runs, times and logs MemoryMapOnHostReport if requested.
         """
-        with FecTimer("Memory report", TimerWork.REPORT) as timer:
+        with FecTimer("Memory report sumary", TimerWork.REPORT) as timer:
             if timer.skip_if_virtual_board():
                 return
             if timer.skip_if_cfg_false(
@@ -1623,7 +1623,7 @@ class AbstractSpinnakerBase(ConfigHandler):
         """
         Runs, times and logs MemoryMapOnHostChipReport if requested.
         """
-        with FecTimer("Memory report", TimerWork.REPORT) as timer:
+        with FecTimer("Memory report detailed", TimerWork.REPORT) as timer:
             if timer.skip_if_virtual_board():
                 return
             if timer.skip_if_cfg_false(

--- a/spinn_front_end_common/interface/config_setup.py
+++ b/spinn_front_end_common/interface/config_setup.py
@@ -88,7 +88,8 @@ def fec_cfg_paths_skipped() -> Set[str]:
         skipped.add(optionxform("path_java_log"))
         skipped.add(optionxform("path_json_java_placements"))
         skipped.add(optionxform("path_memory_map_report_map"))
-        skipped.add(optionxform("path_memory_map_reports"))
+        skipped.add(optionxform("path_memory_map_report_detailed"))
+        skipped.add(optionxform("path_memory_map_report_summary"))
         skipped.add(optionxform("path_tag_allocation_reports_machine"))
 
     if not get_config_bool("Machine", "enable_advanced_monitor_support"):


### PR DESCRIPTION
fixes bug from https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1360

changes the reports not done on virtual machines

needed for 
https://github.com/SpiNNakerManchester/sPyNNaker/blob/master/unittests/test_using_virtual_board/test_debug_mode/test_debug.py

tested with paraller sPyNNaker branch
https://github.com/SpiNNakerManchester/sPyNNaker/actions/runs/31017868032