### PR TITLE
Fix make problems

### DIFF
--- a/c_common/front_end_common_lib/make/fec.mk
+++ b/c_common/front_end_common_lib/make/fec.mk
@@ -69,7 +69,7 @@ get_path = $(abspath $(word $2, $(subst :, ,$1)))/
 # The argument src_dir is a colon separated source directory and modified source
 # directory pair
 define add_source_dir#(src_dir)
-$(call get_path,$(1),2): $(wildcard $(call get_path,$(1),1)/**/*)
+$(call get_path,$(1),2): $(wildcard $(call get_path,$(1),1)/**/%)
 	python3 -m spinn_utilities.make_tools.converter $(call get_path,$(1),1) $(call get_path,$(1),2) $(APP_OUTPUT_DIR) $(DATABASE_KEY)
 
 $(call get_path,$(1), 2)%.c: $(call get_path,$(1), 1)%.c


### PR DESCRIPTION
This fixes the problems in sPyNNakerNewModelTemplate C build by making the modified_src only dependent on files within folders, not the folders themselves.  This then avoids an odd built-in rule from activating.